### PR TITLE
fix: Pause points no longer expire before await-pause-point can observe them

### DIFF
--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -251,6 +251,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void ExtendExpiryForAwait_WhenRequestedMinimumExceedsRemaining_PushesExpiryForward()
+        {
+            // Verifies await-pause-point can extend a marker's countdown to at least its own
+            // deadline, so a slow multi-step CLI round trip does not expire the marker mid-wait.
+            UloopPausePointRegistry.Enable("jump", 10);
+            _nowUtc = _nowUtc.AddSeconds(5);
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.ExtendExpiryForAwait("jump", 30);
+
+            Assert.That(snapshot.RemainingMilliseconds, Is.EqualTo(30000));
+        }
+
+        [Test]
+        public void ExtendExpiryForAwait_WhenRemainingAlreadyExceedsRequestedMinimum_DoesNotShrinkExpiry()
+        {
+            // Verifies extension only ever moves the deadline forward, never backward.
+            UloopPausePointRegistry.Enable("jump", 60);
+            _nowUtc = _nowUtc.AddSeconds(5);
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.ExtendExpiryForAwait("jump", 10);
+
+            Assert.That(snapshot.RemainingMilliseconds, Is.EqualTo(55000));
+        }
+
+        [Test]
+        public void ExtendExpiryForAwait_WhenMarkerIsNotEnabled_ReturnsNotEnabledWithoutThrowing()
+        {
+            // Verifies extending an unknown/not-yet-enabled id is a safe no-op status query.
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.ExtendExpiryForAwait("jump", 30);
+
+            Assert.That(snapshot.Status, Is.EqualTo(UloopPausePointStatus.NotEnabled));
+        }
+
+        [Test]
+        public void ExtendExpiryForAwait_WhenMarkerAlreadyExpired_DoesNotResurrectIt()
+        {
+            // Verifies extension cannot bring an already-expired marker back to life.
+            UloopPausePointRegistry.Enable("jump", 1);
+            _nowUtc = _nowUtc.AddSeconds(2);
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.ExtendExpiryForAwait("jump", 30);
+
+            Assert.That(snapshot.Status, Is.EqualTo(UloopPausePointStatus.Expired));
+            Assert.That(snapshot.RemainingMilliseconds, Is.EqualTo(0));
+        }
+
+        [Test]
         public void Enable_WhenMarkerIsReenabled_IncrementsGeneration()
         {
             // Verifies callers can distinguish a fresh marker from stale status or log evidence with the same id.
@@ -592,6 +639,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.CapturedVariablesTruncated, Is.True);
             Assert.That(response.CapturedVariables.Select(v => v.Name), Is.EquivalentTo(new[] { "speed" }));
             Assert.That(response.CapturedVariables[0].Value, Is.EqualTo("5"));
+        }
+
+        [Test]
+        public void PausePointStatusBridge_Extend_PushesExpiryToRequestedMinimumRemaining()
+        {
+            // Verifies the internal extend-pause-point-status bridge command reaches the registry
+            // extension so a slow await-pause-point round trip can push a marker's deadline out.
+            UloopPausePointRegistry.Enable("jump", 10);
+            _nowUtc = _nowUtc.AddSeconds(5);
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["minimumRemainingSeconds"] = 30
+            };
+
+            PausePointStatusResponse response = PausePointStatusBridgeCommand.Extend(parameters);
+
+            Assert.That(response.RemainingMilliseconds, Is.EqualTo(30000));
         }
 
         [Test]

--- a/Packages/src/Editor/Infrastructure/Api/InternalBridgeCommandRouter.cs
+++ b/Packages/src/Editor/Infrastructure/Api/InternalBridgeCommandRouter.cs
@@ -18,6 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                    methodName == UnityCliLoopConstants.COMMAND_NAME_GET_COMPILE_STATUS ||
                    methodName == UnityCliLoopConstants.COMMAND_NAME_GET_PAUSE_POINT_STATUS ||
                    methodName == UnityCliLoopConstants.COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS ||
+                   methodName == UnityCliLoopConstants.COMMAND_NAME_EXTEND_PAUSE_POINT_STATUS ||
                    methodName == UnityCliLoopConstants.COMMAND_NAME_GET_TOOL_DETAILS;
         }
 
@@ -52,6 +53,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             if (methodName == UnityCliLoopConstants.COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS)
             {
                 return PausePointStatusBridgeCommand.Clear(paramsToken);
+            }
+
+            if (methodName == UnityCliLoopConstants.COMMAND_NAME_EXTEND_PAUSE_POINT_STATUS)
+            {
+                return PausePointStatusBridgeCommand.Extend(paramsToken);
             }
 
             throw new ArgumentException($"Unknown internal bridge command: {methodName}", nameof(methodName));

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -14,11 +14,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     internal static class PausePointStatusBridgeCommand
     {
         private const string IdParamName = "Id";
+        private const string MinimumRemainingSecondsParamName = "MinimumRemainingSeconds";
 
         public static PausePointStatusResponse Execute(JToken paramsToken)
         {
             string id = ReadId(paramsToken);
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus(id);
+            return PausePointStatusResponse.FromSnapshot(snapshot);
+        }
+
+        // Called once when await-pause-point starts waiting, so a marker enabled well before a
+        // slow multi-step CLI round trip does not expire before the await itself observes a hit.
+        public static PausePointStatusResponse Extend(JToken paramsToken)
+        {
+            string id = ReadId(paramsToken);
+            int minimumRemainingSeconds = ReadMinimumRemainingSeconds(paramsToken);
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.ExtendExpiryForAwait(id, minimumRemainingSeconds);
             return PausePointStatusResponse.FromSnapshot(snapshot);
         }
 
@@ -42,6 +53,17 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             JToken idToken = paramsObject.GetValue(IdParamName, StringComparison.OrdinalIgnoreCase);
             return idToken?.ToString() ?? string.Empty;
+        }
+
+        private static int ReadMinimumRemainingSeconds(JToken paramsToken)
+        {
+            if (paramsToken is not JObject paramsObject)
+            {
+                return 0;
+            }
+
+            JToken valueToken = paramsObject.GetValue(MinimumRemainingSecondsParamName, StringComparison.OrdinalIgnoreCase);
+            return valueToken?.ToObject<int>() ?? 0;
         }
     }
 

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -78,6 +78,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string COMMAND_NAME_PAUSE_POINT_STATUS = "pause-point-status";
         public const string COMMAND_NAME_GET_PAUSE_POINT_STATUS = "get-pause-point-status";
         public const string COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS = "clear-pause-point-status";
+        public const string COMMAND_NAME_EXTEND_PAUSE_POINT_STATUS = "extend-pause-point-status";
 
         // Optional package names
         public const string PACKAGE_NAME_TEST_FRAMEWORK = "com.unity.test-framework";

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -103,6 +103,23 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             ExpiresAtUtc += pauseWindowEndUtc - effectiveStart;
         }
 
+        // Called once when await-pause-point starts waiting, so a marker enabled well before a
+        // slow multi-step CLI round trip (enable -> seed state -> await) does not expire before
+        // the await itself even gets a chance to observe a hit. Only ever moves ExpiresAtUtc
+        // forward: it cannot un-expire a marker or shorten a window an earlier call already set.
+        public void ExtendExpiryToAtLeast(DateTime minimumExpiresAtUtc)
+        {
+            if (Status == UloopPausePointStatus.Cleared || Status == UloopPausePointStatus.Expired)
+            {
+                return;
+            }
+
+            if (minimumExpiresAtUtc > ExpiresAtUtc)
+            {
+                ExpiresAtUtc = minimumExpiresAtUtc;
+            }
+        }
+
         public void MarkCleared(string clearedReason, string message = "Pause point cleared.")
         {
             // Why: a second clear must not erase the first reason (e.g. RunTestsAutoClear).

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -159,6 +159,34 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             return entry.ToSnapshot(now, _pauseController);
         }
 
+        /// <summary>
+        /// Extends a marker's capture window to at least minimumRemainingSeconds from now, so a
+        /// slow multi-step CLI round trip (enable -&gt; seed state -&gt; await) does not let the marker
+        /// expire before await-pause-point even starts observing it. Called once when the wait
+        /// begins. A no-op for markers that are already Cleared/Expired or unknown.
+        /// </summary>
+        public static UloopPausePointSnapshot ExtendExpiryForAwait(string id, int minimumRemainingSeconds)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(id), "id must not be null or empty");
+            Debug.Assert(minimumRemainingSeconds > 0, "minimumRemainingSeconds must be greater than zero");
+
+            DateTime now = NowUtc();
+            if (!Entries.ContainsKey(id))
+            {
+                return UloopPausePointSnapshot.NotEnabled(id, _pauseController);
+            }
+
+            UloopPausePointEntry entry = Entries[id];
+            if (TryExpire(entry, now))
+            {
+                ResumeEditorPause();
+                return entry.ToSnapshot(now, _pauseController);
+            }
+
+            entry.ExtendExpiryToAtLeast(now.AddSeconds(minimumRemainingSeconds));
+            return entry.ToSnapshot(now, _pauseController);
+        }
+
         public static UloopPausePointSnapshot Hit(string id)
         {
             return HitCore(id, null, Array.Empty<UloopCapturedVariable>(), false);

--- a/cli/project-runner/internal/projectrunner/pause_point_ipc.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_ipc.go
@@ -1,0 +1,88 @@
+package projectrunner
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hatayama/unity-cli-loop/common/clicontract"
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+func queryPausePointStatusFromUnity(
+	ctx context.Context,
+	connection unityipc.Connection,
+	id string,
+) (pausePointStatusResponse, error) {
+	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
+	defer cancel()
+
+	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
+		probeContext,
+		pausePointStatusCommandName,
+		map[string]any{"Id": id},
+	)
+	if err != nil {
+		return pausePointStatusResponse{}, err
+	}
+
+	response := pausePointStatusResponse{}
+	if err := json.Unmarshal(result, &response); err != nil {
+		return pausePointStatusResponse{}, err
+	}
+	return response, nil
+}
+
+func clearPausePointStatusFromUnity(
+	ctx context.Context,
+	connection unityipc.Connection,
+	id string,
+) (pausePointStatusResponse, error) {
+	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
+	defer cancel()
+
+	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
+		probeContext,
+		pausePointClearStatusCommandName,
+		map[string]any{"Id": id},
+	)
+	if err != nil {
+		return pausePointStatusResponse{}, err
+	}
+
+	response := pausePointStatusResponse{}
+	if err := json.Unmarshal(result, &response); err != nil {
+		return pausePointStatusResponse{}, err
+	}
+	return response, nil
+}
+
+func extendPausePointExpiryFromUnity(
+	ctx context.Context,
+	connection unityipc.Connection,
+	id string,
+	minimumRemainingSeconds int,
+) (pausePointStatusResponse, error) {
+	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
+	defer cancel()
+
+	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
+		probeContext,
+		pausePointExtendStatusCommandName,
+		map[string]any{"Id": id, "MinimumRemainingSeconds": minimumRemainingSeconds},
+	)
+	if err != nil {
+		return pausePointStatusResponse{}, err
+	}
+
+	response := pausePointStatusResponse{}
+	if err := json.Unmarshal(result, &response); err != nil {
+		return pausePointStatusResponse{}, err
+	}
+	return response, nil
+}
+
+func clearPausePointAfterWaitTimeout(ctx context.Context, connection unityipc.Connection, id string) {
+	clearContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
+	defer cancel()
+	_, _ = clearPausePointStatus(clearContext, connection, id)
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_ipc.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_ipc.go
@@ -8,18 +8,19 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
-func queryPausePointStatusFromUnity(
+func sendPausePointStatusCommand(
 	ctx context.Context,
 	connection unityipc.Connection,
-	id string,
+	commandName string,
+	params map[string]any,
 ) (pausePointStatusResponse, error) {
 	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
 	defer cancel()
 
 	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
 		probeContext,
-		pausePointStatusCommandName,
-		map[string]any{"Id": id},
+		commandName,
+		params,
 	)
 	if err != nil {
 		return pausePointStatusResponse{}, err
@@ -32,28 +33,20 @@ func queryPausePointStatusFromUnity(
 	return response, nil
 }
 
+func queryPausePointStatusFromUnity(
+	ctx context.Context,
+	connection unityipc.Connection,
+	id string,
+) (pausePointStatusResponse, error) {
+	return sendPausePointStatusCommand(ctx, connection, pausePointStatusCommandName, map[string]any{"Id": id})
+}
+
 func clearPausePointStatusFromUnity(
 	ctx context.Context,
 	connection unityipc.Connection,
 	id string,
 ) (pausePointStatusResponse, error) {
-	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
-	defer cancel()
-
-	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
-		probeContext,
-		pausePointClearStatusCommandName,
-		map[string]any{"Id": id},
-	)
-	if err != nil {
-		return pausePointStatusResponse{}, err
-	}
-
-	response := pausePointStatusResponse{}
-	if err := json.Unmarshal(result, &response); err != nil {
-		return pausePointStatusResponse{}, err
-	}
-	return response, nil
+	return sendPausePointStatusCommand(ctx, connection, pausePointClearStatusCommandName, map[string]any{"Id": id})
 }
 
 func extendPausePointExpiryFromUnity(
@@ -62,23 +55,10 @@ func extendPausePointExpiryFromUnity(
 	id string,
 	minimumRemainingSeconds int,
 ) (pausePointStatusResponse, error) {
-	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
-	defer cancel()
-
-	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
-		probeContext,
-		pausePointExtendStatusCommandName,
-		map[string]any{"Id": id, "MinimumRemainingSeconds": minimumRemainingSeconds},
-	)
-	if err != nil {
-		return pausePointStatusResponse{}, err
-	}
-
-	response := pausePointStatusResponse{}
-	if err := json.Unmarshal(result, &response); err != nil {
-		return pausePointStatusResponse{}, err
-	}
-	return response, nil
+	return sendPausePointStatusCommand(ctx, connection, pausePointExtendStatusCommandName, map[string]any{
+		"Id":                      id,
+		"MinimumRemainingSeconds": minimumRemainingSeconds,
+	})
 }
 
 func clearPausePointAfterWaitTimeout(ctx context.Context, connection unityipc.Connection, id string) {

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -18,6 +18,7 @@ import (
 const (
 	pausePointStatusCommandName       = "get-pause-point-status"
 	pausePointClearStatusCommandName  = "clear-pause-point-status"
+	pausePointExtendStatusCommandName = "extend-pause-point-status"
 	pausePointDefaultTimeoutSeconds   = 30
 	pausePointStatusProbeTimeout      = 5 * time.Second
 	pausePointStatusEnabled           = "Enabled"
@@ -29,9 +30,10 @@ const (
 )
 
 var (
-	pausePointStatusPoll  = 50 * time.Millisecond
-	queryPausePointStatus = queryPausePointStatusFromUnity
-	clearPausePointStatus = clearPausePointStatusFromUnity
+	pausePointStatusPoll   = 50 * time.Millisecond
+	queryPausePointStatus  = queryPausePointStatusFromUnity
+	clearPausePointStatus  = clearPausePointStatusFromUnity
+	extendPausePointExpiry = extendPausePointExpiryFromUnity
 )
 
 type waitForPausePointOptions struct {
@@ -113,7 +115,28 @@ func runWaitForPausePointCommand(
 		return 1
 	}
 
+	extendPausePointExpiryBeforeWait(ctx, connection, options, stderr)
+
 	return runWaitForPausePoint(ctx, connection, options, stdout, stderr)
+}
+
+// A marker enabled well before a slow multi-step CLI round trip (enable -> seed state via
+// execute-dynamic-code -> await) can otherwise expire before this wait ever gets a chance to
+// observe a hit, since the marker's countdown starts at enable time, not at await time. Best
+// effort: an older Unity package without this bridge command, or a transient IPC failure, must
+// not fail the whole await-pause-point call over a lifetime extension it can still work without.
+func extendPausePointExpiryBeforeWait(
+	ctx context.Context,
+	connection unityipc.Connection,
+	options waitForPausePointOptions,
+	stderr io.Writer,
+) {
+	if _, err := extendPausePointExpiry(ctx, connection, options.id, options.timeoutSeconds); err != nil {
+		_, _ = fmt.Fprintf(
+			stderr,
+			"warning: could not extend pause point %q expiry before waiting: %v\n",
+			options.id, err)
+	}
 }
 
 func runPausePointStatusCommand(
@@ -465,6 +488,31 @@ func clearPausePointStatusFromUnity(
 		probeContext,
 		pausePointClearStatusCommandName,
 		map[string]any{"Id": id},
+	)
+	if err != nil {
+		return pausePointStatusResponse{}, err
+	}
+
+	response := pausePointStatusResponse{}
+	if err := json.Unmarshal(result, &response); err != nil {
+		return pausePointStatusResponse{}, err
+	}
+	return response, nil
+}
+
+func extendPausePointExpiryFromUnity(
+	ctx context.Context,
+	connection unityipc.Connection,
+	id string,
+	minimumRemainingSeconds int,
+) (pausePointStatusResponse, error) {
+	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
+	defer cancel()
+
+	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
+		probeContext,
+		pausePointExtendStatusCommandName,
+		map[string]any{"Id": id, "MinimumRemainingSeconds": minimumRemainingSeconds},
 	)
 	if err != nil {
 		return pausePointStatusResponse{}, err

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -10,7 +10,6 @@ import (
 
 	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 
-	"github.com/hatayama/unity-cli-loop/common/clicontract"
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
@@ -450,83 +449,4 @@ func pausePointWaitStateForStatus(status string) pausePointWaitState {
 	default:
 		return ""
 	}
-}
-
-func queryPausePointStatusFromUnity(
-	ctx context.Context,
-	connection unityipc.Connection,
-	id string,
-) (pausePointStatusResponse, error) {
-	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
-	defer cancel()
-
-	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
-		probeContext,
-		pausePointStatusCommandName,
-		map[string]any{"Id": id},
-	)
-	if err != nil {
-		return pausePointStatusResponse{}, err
-	}
-
-	response := pausePointStatusResponse{}
-	if err := json.Unmarshal(result, &response); err != nil {
-		return pausePointStatusResponse{}, err
-	}
-	return response, nil
-}
-
-func clearPausePointStatusFromUnity(
-	ctx context.Context,
-	connection unityipc.Connection,
-	id string,
-) (pausePointStatusResponse, error) {
-	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
-	defer cancel()
-
-	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
-		probeContext,
-		pausePointClearStatusCommandName,
-		map[string]any{"Id": id},
-	)
-	if err != nil {
-		return pausePointStatusResponse{}, err
-	}
-
-	response := pausePointStatusResponse{}
-	if err := json.Unmarshal(result, &response); err != nil {
-		return pausePointStatusResponse{}, err
-	}
-	return response, nil
-}
-
-func extendPausePointExpiryFromUnity(
-	ctx context.Context,
-	connection unityipc.Connection,
-	id string,
-	minimumRemainingSeconds int,
-) (pausePointStatusResponse, error) {
-	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
-	defer cancel()
-
-	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
-		probeContext,
-		pausePointExtendStatusCommandName,
-		map[string]any{"Id": id, "MinimumRemainingSeconds": minimumRemainingSeconds},
-	)
-	if err != nil {
-		return pausePointStatusResponse{}, err
-	}
-
-	response := pausePointStatusResponse{}
-	if err := json.Unmarshal(result, &response); err != nil {
-		return pausePointStatusResponse{}, err
-	}
-	return response, nil
-}
-
-func clearPausePointAfterWaitTimeout(ctx context.Context, connection unityipc.Connection, id string) {
-	clearContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
-	defer cancel()
-	_, _ = clearPausePointStatus(clearContext, connection, id)
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -16,6 +17,120 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
+
+// Verifies a successful extend request writes no warning to stderr.
+func TestExtendPausePointExpiryBeforeWaitWritesNothingOnSuccess(t *testing.T) {
+	originalExtend := extendPausePointExpiry
+	defer func() { extendPausePointExpiry = originalExtend }()
+
+	extendPausePointExpiry = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+		minimumRemainingSeconds int,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{Id: id, Status: pausePointStatusEnabled}, nil
+	}
+
+	var stderr bytes.Buffer
+	extendPausePointExpiryBeforeWait(
+		context.Background(),
+		unityipc.Connection{},
+		waitForPausePointOptions{id: "jump", timeoutSeconds: 30},
+		&stderr)
+
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no warning, got: %s", stderr.String())
+	}
+}
+
+// Verifies a failed extend request is best-effort: it writes a warning but never blocks the wait.
+func TestExtendPausePointExpiryBeforeWaitWritesWarningOnFailure(t *testing.T) {
+	originalExtend := extendPausePointExpiry
+	defer func() { extendPausePointExpiry = originalExtend }()
+
+	extendPausePointExpiry = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+		minimumRemainingSeconds int,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{}, errors.New("unknown internal bridge command")
+	}
+
+	var stderr bytes.Buffer
+	extendPausePointExpiryBeforeWait(
+		context.Background(),
+		unityipc.Connection{},
+		waitForPausePointOptions{id: "jump", timeoutSeconds: 30},
+		&stderr)
+
+	if !strings.Contains(stderr.String(), "jump") || !strings.Contains(stderr.String(), "unknown internal bridge command") {
+		t.Fatalf("expected a warning mentioning the id and cause, got: %s", stderr.String())
+	}
+}
+
+// Verifies the await-pause-point command extends the marker's expiry to its own timeout before
+// the first status poll, so a slow multi-step CLI round trip cannot let the marker expire first.
+func TestRunWaitForPausePointCommandExtendsExpiryBeforePolling(t *testing.T) {
+	originalExtend := extendPausePointExpiry
+	originalQuery := queryPausePointStatus
+	defer func() {
+		extendPausePointExpiry = originalExtend
+		queryPausePointStatus = originalQuery
+	}()
+
+	var callOrder []string
+	var extendedID string
+	var extendedMinimumRemainingSeconds int
+	extendPausePointExpiry = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+		minimumRemainingSeconds int,
+	) (pausePointStatusResponse, error) {
+		callOrder = append(callOrder, "extend")
+		extendedID = id
+		extendedMinimumRemainingSeconds = minimumRemainingSeconds
+		return pausePointStatusResponse{Id: id, Status: pausePointStatusEnabled}, nil
+	}
+	queryPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		callOrder = append(callOrder, "query")
+		return pausePointStatusResponse{
+			Id:          id,
+			Status:      pausePointStatusHit,
+			IsHit:       true,
+			HitCount:    1,
+			EditorState: pausePointEditorState{IsPlaying: true, IsPaused: true, CapturedAt: "PausePointHit"},
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runWaitForPausePointCommand(
+		context.Background(),
+		unityipc.Connection{},
+		[]string{"--id", "jump", "--timeout-seconds", "7"},
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+	if len(callOrder) == 0 || callOrder[0] != "extend" {
+		t.Fatalf("expected extend to run before the first status query, got order: %v", callOrder)
+	}
+	if extendedID != "jump" {
+		t.Fatalf("extended id mismatch: %s", extendedID)
+	}
+	if extendedMinimumRemainingSeconds != 7 {
+		t.Fatalf("extended minimum remaining seconds mismatch: %d", extendedMinimumRemainingSeconds)
+	}
+}
 
 // Verifies await-pause-point polls until Unity reports the marker hit.
 func TestWaitForPausePointReturnsHitAfterEnabledStatus(t *testing.T) {


### PR DESCRIPTION
## Summary
- `await-pause-point` no longer reports a pause point as cleared/expired just because a slow multi-step CLI sequence used up its timeout before the wait itself started polling.

## User Impact
- Before: a marker's countdown started at `enable` time, so a sequence like enable -> seed state via `execute-dynamic-code` -> `await-pause-point` could consume most of the timeout before the wait ever began observing status, causing a spurious `PAUSE_POINT_CLEARED`/expired result even though the intended pause never had a real chance to be hit.
- After: `await-pause-point` extends the marker's expiry to at least its own remaining timeout right before it starts polling, so the wait window is no longer eaten by setup steps that ran earlier.

## Changes
- Added an internal bridge command (`extend-pause-point-status`) that pushes a marker's `ExpiresAtUtc` forward to a requested minimum remaining duration, never shrinking it and never resurrecting an already-cleared or expired marker.
- `await-pause-point` calls this once before polling begins. The call is best-effort: an older Unity package without this bridge command, or a transient IPC failure, only logs a warning and does not fail the wait.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo>` -> 0 errors, 0 warnings.
- `dist/darwin-arm64/uloop run-tests --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.PausePointTests"` -> 68/68 passed.
- `sh scripts/check-go-cli.sh` -> 0 lint issues across all Go modules, all tests passing (including 3 new tests covering the extend-before-wait behavior and call ordering).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

