### PR TITLE
fix: pause points now flag likely JIT-inlined methods and show capture timing

### DIFF
--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -594,6 +594,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.RemainingMilliseconds, Is.EqualTo(30000));
             Assert.That(response.Generation, Is.EqualTo(1));
             Assert.That(response.Expired, Is.False);
+            // An id-only marker has no resolved source line, so no pre-line timing note applies.
+            Assert.That(response.SnapshotTiming, Is.Empty);
             Assert.That(response.EditorState.CapturedAt, Is.EqualTo(UloopPausePointEditorStateCapturedAt.Current));
             Assert.That(response.RecommendedNextAction, Is.Empty);
         }
@@ -987,6 +989,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.ResolvedLine, Is.EqualTo(FixtureLine));
             Assert.That(response.ResolvedLineText, Is.EqualTo("return sum;"));
             Assert.That(response.ResolvedMethod, Does.Contain("Add"));
+            Assert.That(response.SnapshotTiming, Is.EqualTo(SourcePausePointConstants.PreLineSnapshotTimingNote));
 
             EnableBySourceLocationFixture fixture = new();
             int sum = fixture.Add(2, 3);

--- a/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherAggressiveInliningMethodFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherAggressiveInliningMethodFixture.cs
@@ -1,0 +1,29 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointPatcherTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointPatcherFixtures
+{
+    internal static class PatcherAggressiveInliningMethodFixture
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Classify(int value)
+        {
+            int result;
+            if (value > 100)
+            {
+                result = value * 2;
+            }
+            else if (value > 10)
+            {
+                result = value + 5;
+            }
+            else
+            {
+                result = value - 1;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherAggressiveInliningMethodFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherAggressiveInliningMethodFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58327c02ce6da452aa68743f64911393
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherLargeMethodFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherLargeMethodFixture.cs
@@ -1,0 +1,26 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointPatcherTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointPatcherFixtures
+{
+    internal static class PatcherLargeMethodFixture
+    {
+        public static int Classify(int value)
+        {
+            int result;
+            if (value > 100)
+            {
+                result = value * 2;
+            }
+            else if (value > 10)
+            {
+                result = value + 5;
+            }
+            else
+            {
+                result = value - 1;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherLargeMethodFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherLargeMethodFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 360c530c3d7184de9ba24bab69769e92
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
@@ -145,7 +145,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies OnCollisionEnter2D on a MonoBehaviour-derived type reports the informational
             // warning about Unity's physics message dispatch caching its call path independently of
             // this patch (see To-Do 2 investigation: an already-existing GameObject's collision
-            // callback can miss the pause point even though the method body runs).
+            // callback can miss the pause point even though the method body runs). This fixture's
+            // body is also small enough to additionally trigger the inlining-risk warning (see
+            // Patch_PhysicsMessageMethodOnMonoBehaviour_AlsoTriggersInliningWarning for the exact
+            // joined string), so this test only pins the physical-callback warning's presence.
             const string id = "patcher-physical-callback-method";
             SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(
                 FixturesDirectory + "PatcherPhysicalCallbackMethodFixture.cs", 13);
@@ -155,7 +158,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
 
             Assert.That(patchResult.Success, Is.True);
-            Assert.That(patchResult.Warning, Is.EqualTo(SourcePausePointConstants.PhysicalCallbackMayMissExistingInstanceWarning));
+            Assert.That(patchResult.Warning, Does.Contain(SourcePausePointConstants.PhysicalCallbackMayMissExistingInstanceWarning));
+        }
+
+        [Test]
+        public void Patch_PhysicsMessageMethodOnMonoBehaviour_AlsoTriggersInliningWarning()
+        {
+            // Verifies that when both the physical-callback warning and the small-body
+            // inlining-risk warning apply to the same method (OnCollisionEnter2D's body is only
+            // 16 IL bytes, well under SmallMethodInliningRiskThresholdBytes), BuildPatchWarning
+            // joins them in the same order as the checks appear in its source (physical-callback
+            // first, then inlining-risk), space-separated.
+            const string id = "patcher-physical-callback-method-dual-warning";
+            SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "PatcherPhysicalCallbackMethodFixture.cs", 13);
+            Assert.That(resolveResult.Success, Is.True);
+
+            UloopPausePointRegistry.Enable(id, 30);
+            SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
+
+            Assert.That(patchResult.Success, Is.True);
+            Assert.That(patchResult.Warning, Is.EqualTo(
+                SourcePausePointConstants.PhysicalCallbackMayMissExistingInstanceWarning + " "
+                + SourcePausePointConstants.SmallMethodInliningRiskWarning));
         }
 
         [Test]
@@ -163,6 +188,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies Update() on the same MonoBehaviour fixture does not trigger the
             // physics-message warning, since only physics message methods carry the caching risk.
+            // Update()'s body is also small (16 IL bytes), so the inlining-risk warning is still
+            // present; this test only asserts the physical-callback warning's absence.
             const string id = "patcher-ordinary-message-method";
             SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(
                 FixturesDirectory + "PatcherPhysicalCallbackMethodFixture.cs", 18);
@@ -172,7 +199,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
 
             Assert.That(patchResult.Success, Is.True);
-            Assert.That(patchResult.Warning, Is.Empty);
+            Assert.That(patchResult.Warning, Does.Not.Contain(SourcePausePointConstants.PhysicalCallbackMayMissExistingInstanceWarning));
         }
 
         [Test]
@@ -180,7 +207,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies the warning requires both a matching method name AND a MonoBehaviour-derived
             // declaring type, so an unrelated plain class that happens to name a method
-            // "OnTriggerEnter2D" does not produce a false positive.
+            // "OnTriggerEnter2D" does not produce a false positive. This fixture's body is also
+            // small (16 IL bytes), so the inlining-risk warning is still present; this test only
+            // asserts the physical-callback warning's absence.
             const string id = "patcher-physics-named-method-plain-class";
             SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(
                 FixturesDirectory + "PatcherPhysicsNamedMethodOnPlainClassFixture.cs", 9);
@@ -190,7 +219,77 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
 
             Assert.That(patchResult.Success, Is.True);
+            Assert.That(patchResult.Warning, Does.Not.Contain(SourcePausePointConstants.PhysicalCallbackMayMissExistingInstanceWarning));
+        }
+
+        [Test]
+        public void Patch_SmallMethodBody_ReturnsInliningRiskWarning()
+        {
+            // Verifies a method whose IL body is at or under SmallMethodInliningRiskThresholdBytes
+            // triggers the inlining-risk warning. The precondition assert guards against C# compiler
+            // version drift silently moving this fixture's IL size to the wrong side of the threshold.
+            byte[] ilBytes = typeof(PatcherStaticMethodFixture).GetMethod(nameof(PatcherStaticMethodFixture.Add))
+                .GetMethodBody().GetILAsByteArray();
+            Assert.That(ilBytes.Length, Is.LessThanOrEqualTo(SourcePausePointConstants.SmallMethodInliningRiskThresholdBytes),
+                "Fixture precondition failed: PatcherStaticMethodFixture.Add must stay at or under the inlining-risk threshold.");
+
+            const string id = "patcher-small-method-body";
+            SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "PatcherStaticMethodFixture.cs", 10);
+            Assert.That(resolveResult.Success, Is.True);
+
+            UloopPausePointRegistry.Enable(id, 30);
+            SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
+
+            Assert.That(patchResult.Success, Is.True);
+            Assert.That(patchResult.Warning, Is.EqualTo(SourcePausePointConstants.SmallMethodInliningRiskWarning));
+        }
+
+        [Test]
+        public void Patch_LargeMethodBody_DoesNotReturnInliningRiskWarning()
+        {
+            // Verifies a method whose IL body clearly exceeds SmallMethodInliningRiskThresholdBytes
+            // (with a safety margin against compiler version drift, rather than sizing the fixture
+            // to land just past the boundary) does not trigger the inlining-risk warning.
+            byte[] ilBytes = typeof(PatcherLargeMethodFixture).GetMethod(nameof(PatcherLargeMethodFixture.Classify))
+                .GetMethodBody().GetILAsByteArray();
+            Assert.That(ilBytes.Length, Is.GreaterThan(SourcePausePointConstants.SmallMethodInliningRiskThresholdBytes + 8),
+                "Fixture precondition failed: PatcherLargeMethodFixture.Classify must clearly exceed the inlining-risk threshold.");
+
+            const string id = "patcher-large-method-body";
+            SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "PatcherLargeMethodFixture.cs", 23);
+            Assert.That(resolveResult.Success, Is.True);
+
+            UloopPausePointRegistry.Enable(id, 30);
+            SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
+
+            Assert.That(patchResult.Success, Is.True);
             Assert.That(patchResult.Warning, Is.Empty);
+        }
+
+        [Test]
+        public void Patch_AggressiveInliningMethod_ReturnsInliningRiskWarningRegardlessOfSize()
+        {
+            // Verifies [MethodImpl(MethodImplOptions.AggressiveInlining)] triggers the inlining-risk
+            // warning independent of IL body size: this fixture's body is identical in shape to
+            // PatcherLargeMethodFixture (clearly over the threshold), so the warning here can only
+            // come from the attribute check, not the size check.
+            byte[] ilBytes = typeof(PatcherAggressiveInliningMethodFixture).GetMethod(nameof(PatcherAggressiveInliningMethodFixture.Classify))
+                .GetMethodBody().GetILAsByteArray();
+            Assert.That(ilBytes.Length, Is.GreaterThan(SourcePausePointConstants.SmallMethodInliningRiskThresholdBytes + 8),
+                "Fixture precondition failed: PatcherAggressiveInliningMethodFixture.Classify must clearly exceed the inlining-risk threshold so this test isolates the attribute check.");
+
+            const string id = "patcher-aggressive-inlining-method";
+            SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "PatcherAggressiveInliningMethodFixture.cs", 26);
+            Assert.That(resolveResult.Success, Is.True);
+
+            UloopPausePointRegistry.Enable(id, 30);
+            SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
+
+            Assert.That(patchResult.Success, Is.True);
+            Assert.That(patchResult.Warning, Is.EqualTo(SourcePausePointConstants.SmallMethodInliningRiskWarning));
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -51,6 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public int ResolvedLine { get; set; }
         public string ResolvedLineText { get; set; } = string.Empty;
         public string ResolvedMethod { get; set; } = string.Empty;
+        public string SnapshotTiming { get; set; } = string.Empty;
         public string Status { get; set; } = string.Empty;
         public bool IsEnabled { get; set; }
         public bool IsHit { get; set; }
@@ -358,6 +359,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             response.ResolvedLine = resolveResult.Resolution.ResolvedLine;
             response.ResolvedLineText = ReadResolvedLineText(parameters.File, resolveResult.Resolution.ResolvedLine);
             response.ResolvedMethod = resolveResult.Resolution.MethodDisplayName;
+            response.SnapshotTiming = SourcePausePointConstants.PreLineSnapshotTimingNote;
             response.Warning = MergeWarnings(CreateEnableWarning(), patchResult.Warning);
             return response;
         }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -21,6 +21,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string HarmonyId = "io.github.hatayama.uloop.source-pause-point";
         public const string BurstCompileAttributeFullName = "Unity.Burst.BurstCompileAttribute";
 
+        // A heuristic threshold, not a guarantee: Mono's JIT inlining decision depends on far more
+        // than IL byte count (call-site count, caller size, tiering), so this only flags methods
+        // small enough that inlining is plausible, to explain a HitCount=0 symptom after the fact.
+        public const int SmallMethodInliningRiskThresholdBytes = 32;
+
         // The only escape hatch a caller has when a method cannot be patched by file:line: the
         // hand-written marker path still works and does not depend on IL patching at all.
         public const string ManualMarkerFallbackHint =
@@ -59,6 +64,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             + "hit even though the method body runs. Workarounds: destroy and recreate the GameObject "
             + "after enabling this pause point, or embed UloopPausePoint.Pause(\"id\") directly in the "
             + "method body and arm it with enable-pause-point --id instead.";
+
+        // Surfaces the same JIT-inlining risk documented under Requirements & Safety in the skill,
+        // but at enable time instead of only after a confusing HitCount=0 timeout.
+        public const string SmallMethodInliningRiskWarning =
+            "The target method body is very small and may be inlined by Mono's JIT into its callers; "
+            + "if HitCount stays 0 while the line demonstrably runs, move the pause point into the calling method.";
 
         // Release code optimization strips most sequence points and hoists/elides locals, so the
         // Resolver's PDB-driven lookup cannot reliably find a patch location; rejecting up front

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -71,6 +71,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "The target method body is very small and may be inlined by Mono's JIT into its callers; "
             + "if HitCount stays 0 while the line demonstrably runs, move the pause point into the calling method.";
 
+        // Callers have observed captured values that look like they belong to the line after
+        // ResolvedLine; this makes the pre-line snapshot timing explicit in the response itself
+        // instead of leaving it documented only in the skill.
+        public const string PreLineSnapshotTimingNote =
+            "pre-line: variables are captured before ResolvedLine executes";
+
         // Release code optimization strips most sequence points and hoists/elides locals, so the
         // Resolver's PDB-driven lookup cannot reliably find a patch location; rejecting up front
         // avoids patching the wrong instruction instead of failing later in a confusing way.

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -266,6 +266,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings.Add(SourcePausePointConstants.PhysicalCallbackMayMissExistingInstanceWarning);
             }
 
+            if (IsLikelyJitInlined(method))
+            {
+                warnings.Add(SourcePausePointConstants.SmallMethodInliningRiskWarning);
+            }
+
             return string.Join(" ", warnings);
         }
 
@@ -280,6 +285,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return false;
+        }
+
+        // Heuristic, not a guarantee: [AggressiveInlining] is only a hint the JIT may ignore, and
+        // IL body size alone cannot predict Mono's actual inlining decision (call-site count, caller
+        // size, and tiering all matter too). Both false positives (flagged but never inlined) and
+        // false negatives (inlined despite exceeding the threshold) are possible; this exists solely
+        // to explain a HitCount=0 symptom, not to predict it precisely.
+        // Harmony detours the JIT-compiled native code and never rewrites the metadata IL, so
+        // measuring after Patch still reads the original method body size.
+        internal static bool IsLikelyJitInlined(MethodBase method)
+        {
+            if ((method.GetMethodImplementationFlags() & MethodImplAttributes.AggressiveInlining) != 0)
+            {
+                return true;
+            }
+
+            byte[] ilBytes = method.GetMethodBody()?.GetILAsByteArray();
+            return ilBytes != null && ilBytes.Length <= SourcePausePointConstants.SmallMethodInliningRiskThresholdBytes;
         }
 
         private static IEnumerable<CodeInstruction> Transpiler(

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -294,7 +294,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // to explain a HitCount=0 symptom, not to predict it precisely.
         // Harmony detours the JIT-compiled native code and never rewrites the metadata IL, so
         // measuring after Patch still reads the original method body size.
-        internal static bool IsLikelyJitInlined(MethodBase method)
+        private static bool IsLikelyJitInlined(MethodBase method)
         {
             if ((method.GetMethodImplementationFlags() & MethodImplAttributes.AggressiveInlining) != 0)
             {

--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -79,7 +79,8 @@ func pausePointTimeoutHint(response pausePointStatusResponse) string {
 	}
 	if response.HitCount == 0 && response.Status == pausePointStatusEnabled {
 		return "Marker was enabled but never hit. Confirm the id matches UloopPausePoint.Pause(\"<id>\") and that the code path was executed. In fast-progressing games the state may have already moved past the marker (for example back to Ready or GameOver), so re-trigger the code path and wait again. " +
-			"If the marker targets a Unity message method such as OnCollisionEnter2D/OnTriggerEnter2D, check whether `enable-pause-point`'s response carried a Warning about cached message dispatch: Unity can resolve a GameObject's message dispatch before the marker patch is installed, so a GameObject that already existed at enable time may never reach the marker even though the method body runs. Recreating the GameObject after enabling, or embedding UloopPausePoint.Pause(\"id\") directly in the method body, avoids this."
+			"If the marker targets a Unity message method such as OnCollisionEnter2D/OnTriggerEnter2D, check whether `enable-pause-point`'s response carried a Warning about cached message dispatch: Unity can resolve a GameObject's message dispatch before the marker patch is installed, so a GameObject that already existed at enable time may never reach the marker even though the method body runs. Recreating the GameObject after enabling, or embedding UloopPausePoint.Pause(\"id\") directly in the method body, avoids this. " +
+			"If the target line is inside a very small method, Mono's JIT may have inlined it into callers and the pause point never fires; move the pause point into the calling method."
 	}
 	return ""
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -917,7 +917,8 @@ func TestPausePointTimeoutErrorIncludesDiagnosisHint(t *testing.T) {
 				HitCount:    0,
 			},
 			wantHint: "Marker was enabled but never hit. Confirm the id matches UloopPausePoint.Pause(\"<id>\") and that the code path was executed. In fast-progressing games the state may have already moved past the marker (for example back to Ready or GameOver), so re-trigger the code path and wait again. " +
-				"If the marker targets a Unity message method such as OnCollisionEnter2D/OnTriggerEnter2D, check whether `enable-pause-point`'s response carried a Warning about cached message dispatch: Unity can resolve a GameObject's message dispatch before the marker patch is installed, so a GameObject that already existed at enable time may never reach the marker even though the method body runs. Recreating the GameObject after enabling, or embedding UloopPausePoint.Pause(\"id\") directly in the method body, avoids this.",
+				"If the marker targets a Unity message method such as OnCollisionEnter2D/OnTriggerEnter2D, check whether `enable-pause-point`'s response carried a Warning about cached message dispatch: Unity can resolve a GameObject's message dispatch before the marker patch is installed, so a GameObject that already existed at enable time may never reach the marker even though the method body runs. Recreating the GameObject after enabling, or embedding UloopPausePoint.Pause(\"id\") directly in the method body, avoids this. " +
+				"If the target line is inside a very small method, Mono's JIT may have inlined it into callers and the pause point never fires; move the pause point into the calling method.",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Pause points now warn you at enable time when the target method is small enough (or marked `AggressiveInlining`) that Mono's JIT may inline it away, instead of only leaving you to guess after a confusing `HitCount=0` timeout.
- The same JIT-inlining possibility is now called out directly in the `await-pause-point` timeout hint text.
- `enable-pause-point` responses for file:line markers now carry an explicit `SnapshotTiming` note stating that captured variables reflect state *before* the resolved line executes (pre-line, like an IDE breakpoint), so this is discoverable from the response itself rather than only from docs.

## User Impact
- Before: a pause point on a small/inlined method could silently never fire, and nothing in the response or timeout message pointed at JIT inlining as the cause — users had to already know about the possibility to suspect it.
- After: `enable-pause-point` proactively warns when a target method looks inlining-prone, and the `await-pause-point` timeout hint mentions it too, so the diagnosis is much faster.
- Before: the pre-line timing of captured variables was documented only in the skill file, easy to miss.
- After: every file:line `enable-pause-point` response includes a `SnapshotTiming` field stating this directly.

## Changes
- `SourcePausePointPatcher.BuildPatchWarning` gains a new check (`IsLikelyJitInlined`): true if the method has `[MethodImpl(MethodImplOptions.AggressiveInlining)]`, or if its IL body size is at or under a new heuristic threshold constant (`SourcePausePointConstants.SmallMethodInliningRiskThresholdBytes`, 32 bytes). New warning message constant `SmallMethodInliningRiskWarning`.
- `pausePointTimeoutHint` (Go, `pause_point_errors.go`) appends a sentence pointing at JIT inlining in the `HitCount==0 && Enabled` branch.
- `PausePointResponse` gains an additive `SnapshotTiming` field (new constant `PreLineSnapshotTimingNote`), populated only when a pause point is enabled via file:line (`EnableBySourceLocation`); id-only markers leave it empty since they have no resolved source line. This is a wire-compatible additive change, so no IPC `protocolVersion` bump is needed.
- Existing physical-callback-warning tests (`OnCollisionEnter2D`/`Update`/`OnTriggerEnter2D` fixtures) are loosened from exact-match to `Contains`/`Does.Not.Contain`, since those fixture bodies are also small enough to independently trigger the new inlining warning. New tests cover below-threshold, above-threshold, and `AggressiveInlining`-regardless-of-size cases, plus the two-warning joined-string ordering.

## Verification
- `dist/darwin-arm64/uloop compile`: 0 errors, 0 warnings (checked after each commit).
- `dist/darwin-arm64/uloop run-tests` (EditMode, filter `SourcePausePointPatcherTests`): 25/25 passed.
- `dist/darwin-arm64/uloop run-tests` (EditMode, filter `PausePointTests`): 68/68 passed.
- `scripts/check-go-cli.sh`: all packages `ok`, 0 lint issues.
- Manual: enabled a real file:line pause point via `uloop enable-pause-point` against the running Unity Editor and confirmed both the `SnapshotTiming` field and the inlining warning appear correctly in the JSON response, then cleared it.
- This PR targets the integration branch `feature/pause-point-feedback-round3-integration`, not `main`/`v3-beta`. Repo CI workflows filter `pull_request.branches` to `[main, v3-beta]`, so no repository CI runs on this PR — that's expected, not a gap. The checks above are local-equivalent verification; full repo CI will run on the final integration → `v3-beta` PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

