### PR TITLE
fix: Distinguish resume-from-pause from a fresh Play start in control-play-mode

### DIFF
--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -314,6 +314,166 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Message, Does.Contain("Prefab Stage: Assets/Prefabs/Hud.prefab"));
         }
 
+        [Test]
+        public async Task ExecuteAsync_WhenPlayResumesFromPause_OnlyClearsPauseAndReportsResumed()
+        {
+            // Verifies a true resume (paused while still playing) only clears isPaused, never
+            // reassigns isPlaying or triggers a scene save, and reports ResumedFromPause with no warning.
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: true);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: System.Array.Empty<string>());
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver,
+                editorState);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.Message, Is.EqualTo("Play mode resumed"));
+            Assert.That(response.ResumedFromPause, Is.True);
+            Assert.That(response.Warning, Is.Empty);
+            Assert.That(editorState.IsPaused, Is.False);
+            Assert.That(editorState.IsPlayingSetCount, Is.EqualTo(0));
+            Assert.That(quietSaver.SaveCallCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenPlayStartsFreshSession_SetsPlayingAndReportsWarning()
+        {
+            // Verifies a fresh Play start (not a resume) sets isPlaying and surfaces the
+            // fresh-start warning so callers expecting a resume notice their state was lost.
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: false, isPaused: false);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: System.Array.Empty<string>());
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver,
+                editorState);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.Message, Is.EqualTo("Play mode started"));
+            Assert.That(response.ResumedFromPause, Is.False);
+            Assert.That(response.Warning, Is.EqualTo(ControlPlayModeUseCase.FreshPlayStartFromNewSessionWarning));
+            Assert.That(editorState.IsPlaying, Is.True);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenPause_SetsPausedWithoutTouchingPlayingOrStep()
+        {
+            // Regression: Pause must only flip isPaused, leaving isPlaying and Step untouched.
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: false);
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                editorStateService: editorState);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Pause,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.Message, Is.EqualTo("Play mode paused"));
+            Assert.That(response.Changed, Is.True);
+            Assert.That(editorState.IsPaused, Is.True);
+            Assert.That(editorState.IsPlayingSetCount, Is.EqualTo(0));
+            Assert.That(editorState.StepCallCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenStop_ClearsPlayingAndPausedAndReportsChanged()
+        {
+            // Regression: Stop from a playing+paused state must clear both flags and report Changed.
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: true);
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                editorStateService: editorState);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Stop,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.Message, Is.EqualTo("Play mode stopped"));
+            Assert.That(response.Changed, Is.True);
+            Assert.That(response.WasAlreadyStopped, Is.False);
+            Assert.That(editorState.IsPlaying, Is.False);
+            Assert.That(editorState.IsPaused, Is.False);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenStepDuringPlayMode_AdvancesOneFrame()
+        {
+            // Regression: Step while playing must call through to the editor state service once.
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: false);
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                editorStateService: editorState);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Step,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.Message, Is.EqualTo("Stepped one frame; play mode is paused."));
+            Assert.That(response.Changed, Is.True);
+            Assert.That(editorState.StepCallCount, Is.EqualTo(1));
+        }
+
+        private sealed class FakeControlPlayModeEditorStateService : IControlPlayModeEditorStateService
+        {
+            private bool _isPlaying;
+            private bool _isPaused;
+
+            // Constructor sets initial state directly (bypassing the counting setters below), so
+            // IsPlayingSetCount/IsPausedSetCount only reflect writes the use case makes during the test.
+            public FakeControlPlayModeEditorStateService(bool isPlaying, bool isPaused)
+            {
+                _isPlaying = isPlaying;
+                _isPaused = isPaused;
+            }
+
+            public bool IsPlaying
+            {
+                get => _isPlaying;
+                set
+                {
+                    _isPlaying = value;
+                    IsPlayingSetCount++;
+                }
+            }
+
+            public bool IsPaused
+            {
+                get => _isPaused;
+                set
+                {
+                    _isPaused = value;
+                    IsPausedSetCount++;
+                }
+            }
+
+            public int IsPlayingSetCount { get; private set; }
+            public int IsPausedSetCount { get; private set; }
+            public int StepCallCount { get; private set; }
+
+            public void Step()
+            {
+                StepCallCount++;
+            }
+        }
+
         private sealed class StubCompilationFailureProvider : IControlPlayModeCompilationFailureProvider
         {
             private readonly ControlPlayModeCompileError[] _errors;

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeEditorStateService.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeEditorStateService.cs
@@ -1,0 +1,37 @@
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reads and writes Unity's Play Mode state for the Control Play Mode use case.
+    /// </summary>
+    public interface IControlPlayModeEditorStateService
+    {
+        bool IsPlaying { get; set; }
+        bool IsPaused { get; set; }
+        void Step();
+    }
+
+    /// <summary>
+    /// Forwards Play Mode state reads/writes to the real EditorApplication API.
+    /// </summary>
+    internal sealed class ControlPlayModeEditorStateService : IControlPlayModeEditorStateService
+    {
+        public bool IsPlaying
+        {
+            get => EditorApplication.isPlaying;
+            set => EditorApplication.isPlaying = value;
+        }
+
+        public bool IsPaused
+        {
+            get => EditorApplication.isPaused;
+            set => EditorApplication.isPaused = value;
+        }
+
+        public void Step()
+        {
+            EditorApplication.Step();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeEditorStateService.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeEditorStateService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 601708678c9874f6fbaad1ff3d181e2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeResponse.cs
@@ -11,9 +11,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool IsPaused { get; set; }
         public bool Changed { get; set; }
         public bool WasAlreadyStopped { get; set; }
+        public bool ResumedFromPause { get; set; }
         public bool BlockedByCompileErrors { get; set; }
         public int CompileErrorCount { get; set; }
         public ControlPlayModeCompileError[] CompileErrors { get; set; }
         public string Message { get; set; }
+        public string Warning { get; set; } = string.Empty;
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeServices.cs
@@ -7,6 +7,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         internal ControlPlayModeCompilationFailureService CompilationFailureService { get; } = new();
         internal ControlPlayModeCompilationFailureGate CompilationFailureGate { get; } = new();
+        internal ControlPlayModeEditorStateService EditorStateService { get; } = new();
 
         internal CliPlayModeRunInBackgroundService RunInBackgroundService { get; } =
             new CliPlayModeRunInBackgroundService(
@@ -31,6 +32,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static IControlPlayModeCompilationFailureGate CompilationFailureGate =>
             RegistryValue.CompilationFailureGate;
+
+        internal static IControlPlayModeEditorStateService EditorStateService =>
+            RegistryValue.EditorStateService;
 
         internal static CliPlayModeRunInBackgroundService RunInBackgroundService =>
             RegistryValue.RunInBackgroundService;

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using UnityEditor;
 using UnityEngine;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -18,14 +17,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const string UnsavedEditorChangesRemainingFailureMessage =
             "Play mode could not start while the editor has unsaved scene or prefab changes.";
 
+        // A fresh Play start looks identical to a resume in the response's "changed"/"message"
+        // fields unless callers already know they expected a resume; this makes the distinction
+        // explicit so a caller that expected to resume a paused session notices its state was lost.
+        internal const string FreshPlayStartFromNewSessionWarning =
+            "Play mode started a new session from Edit-time scene state. If you expected to resume "
+            + "a paused session, that session had already ended (for example, a recompile with "
+            + "\"Script Changes While Playing = Stop Playing And Recompile\" stops Play Mode); "
+            + "re-establish your runtime state before continuing verification.";
+
         private readonly IControlPlayModeCompilationFailureProvider _compilationFailureProvider;
         private readonly IControlPlayModeCompilationFailureGate _compilationFailureGate;
         private readonly IEditorUnsavedChangesQuietSaver _unsavedChangesQuietSaver;
+        private readonly IControlPlayModeEditorStateService _editorStateService;
 
         public ControlPlayModeUseCase(
             IControlPlayModeCompilationFailureProvider compilationFailureProvider = null,
             IControlPlayModeCompilationFailureGate compilationFailureGate = null,
-            IEditorUnsavedChangesQuietSaver unsavedChangesQuietSaver = null)
+            IEditorUnsavedChangesQuietSaver unsavedChangesQuietSaver = null,
+            IControlPlayModeEditorStateService editorStateService = null)
         {
             _compilationFailureProvider =
                 compilationFailureProvider ?? ControlPlayModeServices.CompilationFailureProvider;
@@ -33,6 +43,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 compilationFailureGate ?? ControlPlayModeServices.CompilationFailureGate;
             _unsavedChangesQuietSaver =
                 unsavedChangesQuietSaver ?? new EditorUnsavedChangesQuietSaver();
+            _editorStateService =
+                editorStateService ?? ControlPlayModeServices.EditorStateService;
         }
 
         public Task<ControlPlayModeResponse> ExecuteAsync(ControlPlayModeSchema parameters, CancellationToken ct)
@@ -58,12 +70,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return Task.FromResult(CreateResponse(
                 actionResult.Message,
                 actionResult.Changed,
-                actionResult.WasAlreadyStopped));
+                actionResult.WasAlreadyStopped,
+                actionResult.ResumedFromPause,
+                actionResult.Warning));
         }
 
         private ControlPlayModeResponse CreateStatusOnlyResponse(ControlPlayModeSchema parameters)
         {
-            if (ShouldBlockPlayForCompileErrors(parameters.Action, EditorApplication.isPlaying))
+            if (ShouldBlockPlayForCompileErrors(parameters.Action, _editorStateService.IsPlaying))
             {
                 ControlPlayModeCompileError[] compileErrors =
                     _compilationFailureProvider.GetLastFailedErrors();
@@ -76,8 +90,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private ControlPlayModeActionResult ExecuteRequestedPlayModeAction(PlayModeAction action)
         {
             string message;
-            bool wasPaused = EditorApplication.isPaused;
-            bool wasPlaying = EditorApplication.isPlaying;
+            bool wasPaused = _editorStateService.IsPaused;
+            bool wasPlaying = _editorStateService.IsPlaying;
 
             switch (action)
             {
@@ -88,7 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return ExecutePlayModeStop(wasPaused, wasPlaying);
 
                 case PlayModeAction.Pause:
-                    EditorApplication.isPaused = true;
+                    _editorStateService.IsPaused = true;
                     return ControlPlayModeActionResult.FromState("Play mode paused", !wasPaused, false);
 
                 case PlayModeAction.Step:
@@ -131,18 +145,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (wasPaused)
             {
-                EditorApplication.isPaused = false;
+                _editorStateService.IsPaused = false;
             }
-            if (!EditorApplication.isPlaying)
+            if (!_editorStateService.IsPlaying)
             {
                 // Why: only CLI-started Play owns the override; manual Editor Play must keep project defaults.
                 ControlPlayModeServices.RunInBackgroundService.EnableForCliPlayStart();
-                EditorApplication.isPlaying = true;
+                _editorStateService.IsPlaying = true;
             }
 
             bool changed = wasPaused || !wasPlaying;
+            bool resumedFromPause = wasPaused && wasPlaying;
             string message = wasPaused ? "Play mode resumed" : "Play mode started";
-            return ControlPlayModeActionResult.FromState(message, changed, false);
+            string warning = wasPlaying ? string.Empty : FreshPlayStartFromNewSessionWarning;
+            return ControlPlayModeActionResult.FromState(message, changed, false, resumedFromPause, warning);
         }
 
         private ControlPlayModeActionResult SaveDirtyEditorChangesBeforePlayStart()
@@ -168,16 +184,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return ControlPlayModeActionResult.FromState(string.Empty, false, false);
         }
 
-        private static ControlPlayModeActionResult ExecutePlayModeStop(bool wasPaused, bool wasPlaying)
+        private ControlPlayModeActionResult ExecutePlayModeStop(bool wasPaused, bool wasPlaying)
         {
             bool wasAlreadyStopped = !wasPlaying;
             if (wasPaused)
             {
-                EditorApplication.isPaused = false;
+                _editorStateService.IsPaused = false;
             }
-            if (EditorApplication.isPlaying)
+            if (_editorStateService.IsPlaying)
             {
-                EditorApplication.isPlaying = false;
+                _editorStateService.IsPlaying = false;
             }
 
             bool changed = wasPaused || wasPlaying;
@@ -185,7 +201,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return ControlPlayModeActionResult.FromState(message, changed, wasAlreadyStopped);
         }
 
-        private static ControlPlayModeActionResult ExecutePlayModeStep(bool wasPlaying)
+        private ControlPlayModeActionResult ExecutePlayModeStep(bool wasPlaying)
         {
             // Same API as the Editor's Next Frame button: advances one frame and
             // leaves the player paused, independent of Time.timeScale.
@@ -197,26 +213,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     false);
             }
 
-            EditorApplication.Step();
+            _editorStateService.Step();
             return ControlPlayModeActionResult.FromState("Stepped one frame; play mode is paused.", true, false);
         }
 
-        private static ControlPlayModeResponse CreateResponse(string message, bool changed, bool wasAlreadyStopped)
+        private ControlPlayModeResponse CreateResponse(
+            string message,
+            bool changed,
+            bool wasAlreadyStopped,
+            bool resumedFromPause = false,
+            string warning = "")
         {
             ControlPlayModeResponse response = new()
             {
-                IsPlaying = EditorApplication.isPlaying,
-                IsPaused = EditorApplication.isPaused,
+                IsPlaying = _editorStateService.IsPlaying,
+                IsPaused = _editorStateService.IsPaused,
                 Changed = changed,
                 WasAlreadyStopped = wasAlreadyStopped,
+                ResumedFromPause = resumedFromPause,
                 CompileErrors = Array.Empty<ControlPlayModeCompileError>(),
-                Message = message
+                Message = message,
+                Warning = warning
             };
 
             return response;
         }
 
-        private static ControlPlayModeResponse CreateSaveFailedResponse(string messagePrefix, string[] failedChanges)
+        private ControlPlayModeResponse CreateSaveFailedResponse(string messagePrefix, string[] failedChanges)
         {
             Debug.Assert(!string.IsNullOrEmpty(messagePrefix), "messagePrefix must not be null or empty");
             Debug.Assert(failedChanges != null, "failedChanges must not be null");
@@ -226,7 +249,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return CreateResponse(message, false, false);
         }
 
-        private static ControlPlayModeResponse CreateCompileErrorBlockedResponse(
+        private ControlPlayModeResponse CreateCompileErrorBlockedResponse(
             ControlPlayModeCompileError[] compileErrors)
         {
             ControlPlayModeCompileError[] errors = compileErrors ?? Array.Empty<ControlPlayModeCompileError>();
@@ -248,26 +271,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 bool changed,
                 bool wasAlreadyStopped,
                 ControlPlayModeResponse response,
-                bool hasResponse)
+                bool hasResponse,
+                bool resumedFromPause,
+                string warning)
             {
                 Message = message;
                 Changed = changed;
                 WasAlreadyStopped = wasAlreadyStopped;
                 Response = response;
                 HasResponse = hasResponse;
+                ResumedFromPause = resumedFromPause;
+                Warning = warning;
             }
 
             public static ControlPlayModeActionResult FromState(
                 string message,
                 bool changed,
-                bool wasAlreadyStopped)
+                bool wasAlreadyStopped,
+                bool resumedFromPause = false,
+                string warning = "")
             {
                 return new ControlPlayModeActionResult(
                     message,
                     changed,
                     wasAlreadyStopped,
                     null,
-                    false);
+                    false,
+                    resumedFromPause,
+                    warning);
             }
 
             public static ControlPlayModeActionResult FromResponse(
@@ -279,7 +310,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     changed,
                     response.WasAlreadyStopped,
                     response,
-                    true);
+                    true,
+                    false,
+                    string.Empty);
             }
 
             public string Message { get; }
@@ -287,6 +320,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public bool WasAlreadyStopped { get; }
             public ControlPlayModeResponse Response { get; }
             public bool HasResponse { get; }
+            public bool ResumedFromPause { get; }
+            public string Warning { get; }
         }
     }
 }

--- a/cli/project-runner/internal/projectrunner/control_play_mode_wait.go
+++ b/cli/project-runner/internal/projectrunner/control_play_mode_wait.go
@@ -32,10 +32,12 @@ type controlPlayModeResponse struct {
 	IsPaused               bool                          `json:"IsPaused"`
 	Changed                bool                          `json:"Changed"`
 	WasAlreadyStopped      bool                          `json:"WasAlreadyStopped"`
+	ResumedFromPause       bool                          `json:"ResumedFromPause"`
 	BlockedByCompileErrors bool                          `json:"BlockedByCompileErrors"`
 	CompileErrorCount      int                           `json:"CompileErrorCount"`
 	CompileErrors          []controlPlayModeCompileError `json:"CompileErrors"`
 	Message                string                        `json:"Message"`
+	Warning                string                        `json:"Warning"`
 }
 
 type controlPlayModeCompileError struct {
@@ -134,6 +136,8 @@ func runControlPlayModeWithStateWait(
 	if hasInitialResponse {
 		response.Changed = initialResponse.Changed
 		response.WasAlreadyStopped = initialResponse.WasAlreadyStopped
+		response.ResumedFromPause = initialResponse.ResumedFromPause
+		response.Warning = initialResponse.Warning
 	}
 	result, marshalErr := json.Marshal(response)
 	if marshalErr != nil {

--- a/cli/project-runner/internal/projectrunner/control_play_mode_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/control_play_mode_wait_test.go
@@ -154,6 +154,72 @@ func TestRunControlPlayModeWithStateWaitPreservesStopChangeFields(t *testing.T) 
 	}
 }
 
+// Verifies that ResumedFromPause and Warning from the initial Play response survive the
+// wait-and-remarshal path instead of being dropped by the Go-side response struct.
+func TestRunControlPlayModeWithStateWaitPreservesResumeAndWarningFields(t *testing.T) {
+	originalPoll := controlPlayModeStatePoll
+	controlPlayModeStatePoll = time.Millisecond
+	t.Cleanup(func() {
+		controlPlayModeStatePoll = originalPoll
+	})
+
+	listener := newLoopbackIpcListener(t)
+
+	serverErr := make(chan error, 1)
+	go serveControlPlayModeResponses(
+		listener,
+		make(chan map[string]any, 2),
+		serverErr,
+		[]string{
+			`{"IsPlaying":true,"IsPaused":true,"Changed":true,"ResumedFromPause":true,"Warning":"","Message":"Play mode resumed"}`,
+			`{"IsPlaying":true,"IsPaused":false,"Message":"Play mode status"}`,
+		})
+
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: listener.Addr().Network(),
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runControlPlayModeWithStateWait(
+		context.Background(),
+		connection,
+		map[string]any{
+			controlPlayModeActionParam:  "Play",
+			controlPlayModeTimeoutParam: 1,
+		},
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("runControlPlayModeWithStateWait failed with %d: %s", code, stderr.String())
+	}
+
+	response := controlPlayModeResponse{}
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode stdout: %v\n%s", err, stdout.String())
+	}
+	if !response.ResumedFromPause {
+		t.Fatalf("response should preserve ResumedFromPause=true: %#v", response)
+	}
+	if response.Warning != "" {
+		t.Fatalf("response should preserve empty Warning: %#v", response)
+	}
+	if response.Message != "Play mode resumed" {
+		t.Fatalf("response message mismatch: %s", response.Message)
+	}
+
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed: %v", err)
+	default:
+	}
+}
+
 // Verifies that dispatched PlayMode disconnects are treated as post-reload waits.
 func TestShouldWaitForControlPlayModeDisconnectWaitsAfterDispatchedTransportLoss(t *testing.T) {
 	outcome := unityipc.UnitySendOutcome{RequestDispatched: true}

--- a/cli/project-runner/internal/projectrunner/control_play_mode_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/control_play_mode_wait_test.go
@@ -166,12 +166,16 @@ func TestRunControlPlayModeWithStateWaitPreservesResumeAndWarningFields(t *testi
 	listener := newLoopbackIpcListener(t)
 
 	serverErr := make(chan error, 1)
+	// ResumedFromPause=true paired with a non-empty Warning never happens in production
+	// (Warning is only set on a fresh Play start); the sentinel text here only exists to
+	// prove the JSON round trip preserves a non-zero-value Warning string, not to assert
+	// a real response shape.
 	go serveControlPlayModeResponses(
 		listener,
 		make(chan map[string]any, 2),
 		serverErr,
 		[]string{
-			`{"IsPlaying":true,"IsPaused":true,"Changed":true,"ResumedFromPause":true,"Warning":"","Message":"Play mode resumed"}`,
+			`{"IsPlaying":true,"IsPaused":true,"Changed":true,"ResumedFromPause":true,"Warning":"warning sentinel from initial response","Message":"Play mode resumed"}`,
 			`{"IsPlaying":true,"IsPaused":false,"Message":"Play mode status"}`,
 		})
 
@@ -206,8 +210,8 @@ func TestRunControlPlayModeWithStateWaitPreservesResumeAndWarningFields(t *testi
 	if !response.ResumedFromPause {
 		t.Fatalf("response should preserve ResumedFromPause=true: %#v", response)
 	}
-	if response.Warning != "" {
-		t.Fatalf("response should preserve empty Warning: %#v", response)
+	if response.Warning != "warning sentinel from initial response" {
+		t.Fatalf("response should preserve non-empty Warning: %#v", response)
 	}
 	if response.Message != "Play mode resumed" {
 		t.Fatalf("response message mismatch: %s", response.Message)


### PR DESCRIPTION
## Summary
- `control-play-mode --action Play` now tells callers whether it resumed a paused session or started a brand-new one, instead of both cases looking identical in the response.
- When a Play call silently starts a new session (because the previously paused session had already ended, e.g. a recompile stopped Play Mode), the response carries a warning explaining that runtime state needs to be re-established.

## User Impact
- Before: a caller that expected `--action Play` to resume a paused session had no reliable way to detect that Unity actually started a fresh session instead (both cases returned `"Play mode started"`-shaped responses).
- After: the response includes `ResumedFromPause` (bool) and, on a fresh start following an unexpected session loss, a `Warning` field with the specific reason and remediation guidance.

## Changes
- `ControlPlayModeResponse` gains `ResumedFromPause` and `Warning` fields.
- `ControlPlayModeUseCase` computes `ResumedFromPause` (`wasPaused && wasPlaying`) and attaches a constant warning message when a Play call starts a new session from Edit-time state (`wasPlaying == false`).
- Play Mode state reads/writes are abstracted behind a new `IControlPlayModeEditorStateService`, following the existing `ControlPlayModeServices` registry pattern, so `ControlPlayModeUseCase` can be unit tested without touching `EditorApplication` directly.
- Fixed a Go-side bug where the CLI's wait/poll response struct silently dropped any field not explicitly declared on it (including the new `ResumedFromPause`/`Warning`, and previously also `Success`) whenever a `control-play-mode` call went through the wait-for-state-match path rather than the immediate-match passthrough. Added the missing fields and propagation, mirroring the existing `Changed`/`WasAlreadyStopped` handling.

## Verification
- `dist/darwin-arm64/uloop compile`: 0 errors, 0 warnings.
- `dist/darwin-arm64/uloop run-tests` (EditMode, filter `ControlPlayModeUseCaseTests`): 18/18 passed.
- `sh scripts/check-go-cli.sh`: all packages ok, 0 lint issues (project-runner package test run, not cached).
- `go test ./internal/projectrunner/... -run TestRunControlPlayModeWithStateWaitPreservesResumeAndWarningFields -v`: new regression test passes.
- Manual empirical verification against the running Unity Editor via `dist/darwin-arm64/uloop control-play-mode`: ran Stop → Play (fresh start) → Pause → Play (resume) → Stop, and confirmed `ResumedFromPause`/`Warning` appear correctly at every step in the actual CLI JSON output (this is what caught the Go-side field-dropping bug above, which unit tests alone could not have caught).

This PR targets the `feature/pause-point-feedback-round3-integration` branch, not `main`/`v3-beta`, so repository CI workflows (which filter `pull_request.branches` to `[main, v3-beta]`) will not fire here — that is expected. The verification above is local/manual for this PR; full CI runs on the final integration PR into `v3-beta`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

