### PR TITLE
fix: CLI now rejects invalid enum option values before contacting Unity

### DIFF
--- a/cli/project-runner/internal/projectrunner/tool_params.go
+++ b/cli/project-runner/internal/projectrunner/tool_params.go
@@ -2,6 +2,7 @@ package projectrunner
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -142,8 +143,34 @@ func convertValue(value string, property clicore.ToolProperty, option string) (a
 		return convertArrayValue(value, option)
 	case "object":
 		return convertObjectValue(value, option)
+	case "string":
+		return convertStringValue(value, property, option)
 	default:
 		return value, nil
+	}
+}
+
+// The C# side matches enum values case-insensitively (CaseInsensitiveStringEnumConverter),
+// so rejecting an invalid value here must use the same comparison rule the receiving side
+// uses, or a value this check accepts could still be rejected on the Unity side.
+func convertStringValue(value string, property clicore.ToolProperty, option string) (any, error) {
+	if len(property.Enum) == 0 {
+		return value, nil
+	}
+
+	for _, candidate := range property.Enum {
+		if strings.EqualFold(candidate, value) {
+			return value, nil
+		}
+	}
+
+	validValues := strings.Join(property.Enum, ", ")
+	return nil, &clierrors.ArgumentError{
+		Message:      fmt.Sprintf("Invalid value for %s: %s (valid values: %s)", option, value, validValues),
+		Option:       option,
+		Received:     value,
+		ExpectedType: validValues,
+		NextActions:  []string{fmt.Sprintf("Pass one of: %s for `%s`.", validValues, option)},
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/tool_params_test.go
+++ b/cli/project-runner/internal/projectrunner/tool_params_test.go
@@ -1,0 +1,73 @@
+package projectrunner
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+)
+
+// Verifies that a string property with an enum accepts an exact-case valid value.
+func TestConvertValueAcceptsExactCaseEnumValue(t *testing.T) {
+	property := clicore.ToolProperty{Type: "string", Enum: []string{"Play", "Stop", "Pause"}}
+
+	converted, err := convertValue("Stop", property, "--action")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if converted != "Stop" {
+		t.Fatalf("expected converted value %q, got %q", "Stop", converted)
+	}
+}
+
+// Verifies that enum matching ignores case, mirroring the C# CaseInsensitiveStringEnumConverter.
+func TestConvertValueAcceptsCaseInsensitiveEnumValue(t *testing.T) {
+	property := clicore.ToolProperty{Type: "string", Enum: []string{"Play", "Stop", "Pause"}}
+
+	converted, err := convertValue("stop", property, "--action")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if converted != "stop" {
+		t.Fatalf("expected the original value to be passed through unchanged, got %q", converted)
+	}
+}
+
+// Verifies that a value outside the enum is rejected with the valid value list included.
+func TestConvertValueRejectsInvalidEnumValue(t *testing.T) {
+	property := clicore.ToolProperty{Type: "string", Enum: []string{"Play", "Stop", "Pause"}}
+
+	_, err := convertValue("bogus", property, "--action")
+
+	if err == nil {
+		t.Fatal("expected an error for a value outside the enum")
+	}
+	var argumentError *clierrors.ArgumentError
+	if !errors.As(err, &argumentError) {
+		t.Fatalf("expected an *ArgumentError, got %T: %v", err, err)
+	}
+	if argumentError.Received != "bogus" {
+		t.Fatalf("expected Received to be %q, got %q", "bogus", argumentError.Received)
+	}
+	for _, want := range property.Enum {
+		if !strings.Contains(argumentError.ExpectedType, want) {
+			t.Fatalf("expected error to list valid value %q, got: %s", want, argumentError.ExpectedType)
+		}
+	}
+}
+
+// Verifies that a string property without an enum passes any value through unchanged.
+func TestConvertValuePassesThroughStringWithoutEnum(t *testing.T) {
+	property := clicore.ToolProperty{Type: "string"}
+
+	converted, err := convertValue("anything", property, "--label")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if converted != "anything" {
+		t.Fatalf("expected converted value %q, got %q", "anything", converted)
+	}
+}


### PR DESCRIPTION
## Summary
- Invalid enum values on CLI options (e.g. `--capture-mode bogus`) are now rejected by the CLI itself, instead of being forwarded to Unity and showing up as an Editor Console error.

## User Impact
- Before: a typo'd or invalid string option value passed CLI-side parsing unchecked and reached Unity, where it failed with an error that also polluted the Unity Console log.
- After: the CLI validates the value against the option's declared enum (case-insensitively, matching the C# side's behavior) and returns an argument error listing the valid values, before ever contacting Unity.

## Changes
- `convertValue` now routes `string`-typed options through a new `convertStringValue`, which checks the value against `property.Enum` case-insensitively and returns a descriptive argument error (including the valid value list) on mismatch. Options without a declared enum pass through unchanged.
- Added table-driven tests covering: exact-case match, case-insensitive match, an invalid value, and a plain string property with no enum.

## Verification
- `sh scripts/check-go-cli.sh`: all packages pass, 0 lint issues.
- `go test` (new `tool_params_test.go`): 4/4 new tests pass.
- Manual: `dist/darwin-arm64/uloop screenshot --capture-mode bogus` against the running Unity Editor now returns a CLI-side `INVALID_ARGUMENT` error listing `window, rendering` as valid values, and `dist/darwin-arm64/uloop get-logs --log-type error` immediately after shows `TotalCount: 0` — confirming no new Console error was produced in Unity.

This PR targets the `feature/pause-point-feedback-round3-integration` branch, not `main`/`v3-beta`, so repository CI workflows (filtered to `[main, v3-beta]`) will not fire here — that is expected. Verification above is local/manual for this PR; full CI runs on the final integration PR into `v3-beta`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

