### PR TITLE
fix: Dynamic code can construct Color32 and similar byte-argument types

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/CompiledAssemblyBuilderTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CompiledAssemblyBuilderTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using NUnit.Framework;
+using UnityEditor.Compilation;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
@@ -20,6 +22,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(compilationName, Does.Not.Contain("/"));
             Assert.That(compilationName, Does.Not.Contain("\\"));
             Assert.That(compilationName, Does.Not.Contain(":"));
+        }
+
+        // What: CS1503 (argument type mismatch), which hoisting can cause by turning a
+        // narrowing literal argument into an int variable, must trigger the non-hoisted
+        // recompile fallback like the other hoisting-caused error codes.
+        [Test]
+        public void ShouldRetryWithoutLiteralHoisting_WhenDiagnosticsContainCS1503_ReturnsTrue()
+        {
+            PreparedDynamicCode preparedCode = new(
+                "// prepared source",
+                isScriptMode: true,
+                new List<HoistedLiteralBinding> { new("arg0", "int", 255) });
+            CompilerDiagnostics diagnostics = CompilerDiagnostics.FromMessages(new[]
+            {
+                new CompilerMessage
+                {
+                    message = "error CS1503: Argument 1: cannot convert from 'int' to 'byte'",
+                    type = CompilerMessageType.Error
+                }
+            });
+
+            bool shouldRetry = CompiledAssemblyBuilder.ShouldRetryWithoutLiteralHoisting(preparedCode, diagnostics);
+
+            Assert.That(shouldRetry, Is.True);
+        }
+
+        // What: without any hoisted literal bindings, a CS1503 error cannot be caused by
+        // hoisting, so the fallback must not be triggered.
+        [Test]
+        public void ShouldRetryWithoutLiteralHoisting_WhenNoLiteralsWereHoisted_ReturnsFalse()
+        {
+            PreparedDynamicCode preparedCode = new(
+                "// prepared source",
+                isScriptMode: true,
+                new List<HoistedLiteralBinding>());
+            CompilerDiagnostics diagnostics = CompilerDiagnostics.FromMessages(new[]
+            {
+                new CompilerMessage
+                {
+                    message = "error CS1503: Argument 1: cannot convert from 'int' to 'byte'",
+                    type = CompilerMessageType.Error
+                }
+            });
+
+            bool shouldRetry = CompiledAssemblyBuilder.ShouldRetryWithoutLiteralHoisting(preparedCode, diagnostics);
+
+            Assert.That(shouldRetry, Is.False);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/CompiledAssemblyBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/CompiledAssemblyBuilder.cs
@@ -16,7 +16,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal sealed class CompiledAssemblyBuilder : ICompiledAssemblyBuilder
     {
         private static int _compileCounter;
-        private static readonly string[] LiteralHoistingFallbackErrorCodes = { "CS0133", "CS0150", "CS0182", "CS1736" };
+        // Hoisting turns constant literals into variables, which loses implicit narrowing
+        // conversions (e.g. an int literal argument no longer converts to a byte parameter
+        // such as Color32's), so CS1503 needs the same non-hoisted recompile fallback as the
+        // other hoisting-caused error codes below.
+        private static readonly string[] LiteralHoistingFallbackErrorCodes =
+            { "CS0133", "CS0150", "CS0182", "CS1736", "CS1503" };
 
         private readonly ExternalCompilerPathResolutionService _externalCompilerPathResolver;
         private readonly DynamicReferenceSetBuilderService _referenceSetBuilder;
@@ -314,7 +319,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 externalCompilerPaths);
         }
 
-        private static bool ShouldRetryWithoutLiteralHoisting(
+        internal static bool ShouldRetryWithoutLiteralHoisting(
             PreparedDynamicCode preparedCode,
             CompilerDiagnostics diagnostics)
         {


### PR DESCRIPTION
## Summary
- Dynamic code that constructs Unity types with byte-typed constructor arguments (e.g. `new Color32(255, 255, 255, 255)`) now compiles successfully through `execute-dynamic-code`, instead of failing with a type-mismatch error.

## User Impact
- Before: literal hoisting (which lets `execute-dynamic-code` treat top-level statements as a script) turned integer literal arguments into `int` variables. This silently broke calls whose parameters expect a narrower type like `byte` (e.g. `Color32`'s constructor), because the implicit `int → byte` narrowing conversion no longer applied — producing a confusing `CS1503` failure for code that looks completely valid.
- After: a `CS1503` failure caused by hoisting now triggers the same non-hoisted recompile fallback already used for other hoisting-caused error codes, so the call succeeds.

## Changes
- Added `"CS1503"` to `CompiledAssemblyBuilder.LiteralHoistingFallbackErrorCodes`, with a why-comment explaining the narrowing-conversion loss.
- Made `ShouldRetryWithoutLiteralHoisting` internal so it can be unit tested directly (assembly already grants test visibility via `InternalsVisibleTo`).
- Added two unit tests: one confirming the fallback triggers for a hoisted CS1503, one confirming it does not trigger when no literals were hoisted.

## Verification
- `dist/darwin-arm64/uloop compile`: 0 errors, 0 warnings.
- `dist/darwin-arm64/uloop run-tests` (EditMode, filter `CompiledAssemblyBuilderTests`): 3/3 passed.
- Regression check: temporarily reverted the `CS1503` addition and reran both the unit tests and a real `execute-dynamic-code` call — the new unit test failed as expected, and `dist/darwin-arm64/uloop execute-dynamic-code --code 'UnityEngine.Debug.Log(new UnityEngine.Color32(255, 255, 255, 255));'` failed with the CS1503 errors this PR fixes. Restored the fix and confirmed both pass again.
- Manual (with the fix in place): `dist/darwin-arm64/uloop execute-dynamic-code --code 'UnityEngine.Debug.Log(new UnityEngine.Color32(255, 255, 255, 255));'` succeeds.

This PR targets the `feature/pause-point-feedback-round3-integration` branch, not `main`/`v3-beta`, so repository CI workflows (filtered to `[main, v3-beta]`) will not fire here — that is expected. Verification above is local/manual for this PR; full CI runs on the final integration PR into `v3-beta`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

