### PR TITLE
Replace macOS ps exec with in-process sysctl-based Unity process discovery

### DIFF
--- a/cli/common/go.mod
+++ b/cli/common/go.mod
@@ -4,4 +4,4 @@ go 1.26
 
 require github.com/Microsoft/go-winio v0.6.2
 
-require golang.org/x/sys v0.10.0 // indirect
+require golang.org/x/sys v0.10.0

--- a/cli/common/unityprocess/process.go
+++ b/cli/common/unityprocess/process.go
@@ -1,8 +1,10 @@
 package unityprocess
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -17,7 +19,6 @@ const windowsPowerShellCommand = "powershell"
 var (
 	macUnityExecutablePattern     = regexp.MustCompile(`(?i)Unity\.app/Contents/MacOS/Unity`)
 	windowsUnityExecutablePattern = regexp.MustCompile(`(?i)Unity\.exe`)
-	macProcessLinePattern         = regexp.MustCompile(`^\s*(\d+)\s+(.*)$`)
 	projectPathFlagPattern        = regexp.MustCompile(`(?i)-projectpath(?:=|\s+)(.+)$`)
 	nextUnityFlagPattern          = regexp.MustCompile(`\s-[A-Za-z][A-Za-z0-9-]*(?:=|\s|$)`)
 )
@@ -64,16 +65,6 @@ func listUnityProcesses(ctx context.Context) ([]UnityProcess, error) {
 	}
 }
 
-func listUnityProcessesMac(ctx context.Context) ([]UnityProcess, error) {
-	commandContext, cancel := withCommandTimeout(ctx, ProcessListCommandTimeout)
-	defer cancel()
-	output, err := exec.CommandContext(commandContext, "ps", "-axo", "pid=,command=", "-ww").Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve Unity process list: %w", err)
-	}
-	return parseMacUnityProcesses(string(output)), nil
-}
-
 func listUnityProcessesWindows(ctx context.Context) ([]UnityProcess, error) {
 	commandContext, cancel := withCommandTimeout(ctx, ProcessListCommandTimeout)
 	defer cancel()
@@ -103,31 +94,54 @@ func windowsUnityProcessListScript() string {
 	return strings.Join(scriptLines, "\n")
 }
 
-func parseMacUnityProcesses(output string) []UnityProcess {
-	processes := []UnityProcess{}
-	for _, line := range strings.Split(output, "\n") {
-		matches := macProcessLinePattern.FindStringSubmatch(line)
-		if len(matches) != 3 {
-			continue
-		}
-
-		pid, err := strconv.Atoi(matches[1])
-		if err != nil {
-			continue
-		}
-
-		command := matches[2]
-		if !isUnityEditorCommand(command, macUnityExecutablePattern) {
-			continue
-		}
-		projectPath := extractProjectPath(command)
-		if projectPath == "" {
-			continue
-		}
-
-		processes = append(processes, UnityProcess{Pid: pid, projectPath: projectPath})
+// matchMacUnityProcess checks a single process's (pid, space-joined argv) pair against
+// the same Unity-editor-command and project-path rules used for the ps-based command
+// text this replaced, so callers built from either a text source or a raw argv slice
+// share one matching implementation.
+func matchMacUnityProcess(pid int, command string) (UnityProcess, bool) {
+	if !isUnityEditorCommand(command, macUnityExecutablePattern) {
+		return UnityProcess{}, false
 	}
-	return processes
+	projectPath := extractProjectPath(command)
+	if projectPath == "" {
+		return UnityProcess{}, false
+	}
+	return UnityProcess{Pid: pid, projectPath: projectPath}, true
+}
+
+// parseMacProcArgs2 decodes the kern.procargs2 sysctl buffer layout: a leading int32
+// argc, followed by the exec path (NUL terminated), NUL padding, then argc consecutive
+// NUL-terminated argv strings. Darwin's supported architectures (amd64, arm64) are both
+// little-endian, so argc is read with binary.LittleEndian. This parser has no
+// darwin-specific dependency, only the sysctl call that supplies its input does, so it
+// stays in the shared, cross-platform-buildable file for CI coverage.
+func parseMacProcArgs2(buf []byte) ([]string, error) {
+	if len(buf) < 4 {
+		return nil, fmt.Errorf("procargs2 buffer too short: %d bytes", len(buf))
+	}
+
+	argc := int(binary.LittleEndian.Uint32(buf[:4]))
+	rest := buf[4:]
+
+	execPathEnd := bytes.IndexByte(rest, 0)
+	if execPathEnd < 0 {
+		return nil, fmt.Errorf("procargs2 missing exec path terminator")
+	}
+	rest = rest[execPathEnd:]
+	for len(rest) > 0 && rest[0] == 0 {
+		rest = rest[1:]
+	}
+
+	args := make([]string, 0, argc)
+	for len(rest) > 0 && len(args) < argc {
+		argEnd := bytes.IndexByte(rest, 0)
+		if argEnd < 0 {
+			break
+		}
+		args = append(args, string(rest[:argEnd]))
+		rest = rest[argEnd+1:]
+	}
+	return args, nil
 }
 
 func parseWindowsUnityProcesses(output string) []UnityProcess {

--- a/cli/common/unityprocess/process_darwin.go
+++ b/cli/common/unityprocess/process_darwin.go
@@ -33,8 +33,9 @@ func listUnityProcessesMac(ctx context.Context) ([]UnityProcess, error) {
 
 		args, err := macProcessArgs(pid)
 		if err != nil || len(args) == 0 {
-			// Reading another user's process args fails (EPERM); ps could not see
-			// those processes either, so skipping them preserves prior behavior.
+			// Reading another user's process args fails (EPERM). Non-root ps could
+			// not read those processes' arguments either, so they never matched
+			// before; skipping them preserves prior behavior.
 			continue
 		}
 

--- a/cli/common/unityprocess/process_darwin.go
+++ b/cli/common/unityprocess/process_darwin.go
@@ -1,0 +1,56 @@
+//go:build darwin
+
+package unityprocess
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// listUnityProcessesMac enumerates Unity Editor processes via the kern.proc.all and
+// kern.procargs2 sysctl nodes instead of exec'ing /bin/ps, so Unity process discovery
+// keeps working inside sandboxes that deny exec of external binaries (ps included) but
+// still permit process-info syscalls.
+func listUnityProcessesMac(ctx context.Context) ([]UnityProcess, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	kinfoProcs, err := unix.SysctlKinfoProcSlice("kern.proc.all")
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve Unity process list: %w", err)
+	}
+
+	processes := []UnityProcess{}
+	for _, kinfoProc := range kinfoProcs {
+		pid := int(kinfoProc.Proc.P_pid)
+		if pid <= 0 {
+			continue
+		}
+
+		args, err := macProcessArgs(pid)
+		if err != nil || len(args) == 0 {
+			// Reading another user's process args fails (EPERM); ps could not see
+			// those processes either, so skipping them preserves prior behavior.
+			continue
+		}
+
+		process, matched := matchMacUnityProcess(pid, strings.Join(args, " "))
+		if matched {
+			processes = append(processes, process)
+		}
+	}
+	return processes, nil
+}
+
+// macProcessArgs reads a process's argv via the kern.procargs2 sysctl node.
+func macProcessArgs(pid int) ([]string, error) {
+	buf, err := unix.SysctlRaw("kern.procargs2", pid)
+	if err != nil {
+		return nil, err
+	}
+	return parseMacProcArgs2(buf)
+}

--- a/cli/common/unityprocess/process_other.go
+++ b/cli/common/unityprocess/process_other.go
@@ -1,0 +1,16 @@
+//go:build !darwin
+
+package unityprocess
+
+import (
+	"context"
+	"errors"
+)
+
+// listUnityProcessesMac exists so the shared dispatcher in process.go compiles on
+// every target OS; the real sysctl-based implementation lives in process_darwin.go
+// and this stub is never reached at runtime because listUnityProcesses only calls it
+// when runtime.GOOS == "darwin".
+func listUnityProcessesMac(_ context.Context) ([]UnityProcess, error) {
+	return nil, errors.New("listUnityProcessesMac is unsupported on this platform")
+}

--- a/cli/common/unityprocess/process_test.go
+++ b/cli/common/unityprocess/process_test.go
@@ -2,30 +2,100 @@ package unityprocess
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 )
 
-// Verifies macOS Unity process parsing extracts project paths and skips batchmode workers.
-func TestParseMacUnityProcessesExtractsProjectPath(t *testing.T) {
-	output := `123 /Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app/Contents/MacOS/Unity -projectPath "/Users/<USER_NAME>/My Project" -useHub -hubIPC
-456 /Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app/Contents/MacOS/Unity -batchmode -projectPath "/Users/<USER_NAME>/Batch"
-789 /Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app/Contents/MacOS/Unity -projectPath /Users/<USER_NAME>/Other -logFile -
-`
+// Verifies macOS Unity process matching extracts project paths and skips batchmode workers,
+// using the same (pid, command) shape produced by joining a process's sysctl-read argv.
+func TestMatchMacUnityProcessExtractsProjectPath(t *testing.T) {
+	editorProcess, matched := matchMacUnityProcess(
+		123,
+		`/Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app/Contents/MacOS/Unity -projectPath "/Users/<USER_NAME>/My Project" -useHub -hubIPC`)
+	if !matched {
+		t.Fatal("expected the Unity editor process to match")
+	}
+	if editorProcess.Pid != 123 || editorProcess.projectPath != "/Users/<USER_NAME>/My Project" {
+		t.Fatalf("editor process mismatch: %#v", editorProcess)
+	}
 
-	processes := parseMacUnityProcesses(output)
+	_, batchmodeMatched := matchMacUnityProcess(
+		456,
+		`/Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app/Contents/MacOS/Unity -batchmode -projectPath "/Users/<USER_NAME>/Batch"`)
+	if batchmodeMatched {
+		t.Fatal("expected a -batchmode process to be skipped")
+	}
 
-	if len(processes) != 2 {
-		t.Fatalf("process count mismatch: %#v", processes)
+	unquotedProcess, unquotedMatched := matchMacUnityProcess(
+		789,
+		`/Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app/Contents/MacOS/Unity -projectPath /Users/<USER_NAME>/Other -logFile -`)
+	if !unquotedMatched {
+		t.Fatal("expected an unquoted project path process to match")
 	}
-	if processes[0].Pid != 123 || processes[0].projectPath != "/Users/<USER_NAME>/My Project" {
-		t.Fatalf("first process mismatch: %#v", processes[0])
+	if unquotedProcess.Pid != 789 || unquotedProcess.projectPath != "/Users/<USER_NAME>/Other" {
+		t.Fatalf("unquoted process mismatch: %#v", unquotedProcess)
 	}
-	if processes[1].Pid != 789 || processes[1].projectPath != "/Users/<USER_NAME>/Other" {
-		t.Fatalf("second process mismatch: %#v", processes[1])
+}
+
+// Verifies the kern.procargs2 buffer parser decodes argc, skips the exec path and NUL
+// padding, and stops after argc argv entries.
+func TestParseMacProcArgs2DecodesArgv(t *testing.T) {
+	buf := buildProcArgs2Fixture(t, "/usr/bin/execpath", []string{"/usr/bin/execpath", "-projectPath", "/tmp/proj"})
+
+	args, err := parseMacProcArgs2(buf)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
+	expected := []string{"/usr/bin/execpath", "-projectPath", "/tmp/proj"}
+	if len(args) != len(expected) {
+		t.Fatalf("argv length mismatch: %#v", args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Fatalf("argv[%d] mismatch: got %q, want %q", i, args[i], want)
+		}
+	}
+}
+
+// Verifies a buffer shorter than the leading argc field is rejected instead of panicking.
+func TestParseMacProcArgs2RejectsShortBuffer(t *testing.T) {
+	_, err := parseMacProcArgs2([]byte{1, 2})
+
+	if err == nil {
+		t.Fatal("expected an error for a too-short buffer")
+	}
+}
+
+// Verifies a buffer missing the NUL-terminated exec path is rejected instead of scanning past the end.
+func TestParseMacProcArgs2RejectsMissingExecPathTerminator(t *testing.T) {
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, 1)
+	buf = append(buf, []byte("/usr/bin/execpath-with-no-terminator")...)
+
+	_, err := parseMacProcArgs2(buf)
+
+	if err == nil {
+		t.Fatal("expected an error when the exec path has no NUL terminator")
+	}
+}
+
+// buildProcArgs2Fixture assembles a kern.procargs2-shaped buffer: argc, then the exec
+// path NUL terminated, one padding NUL, then each argv entry NUL terminated.
+func buildProcArgs2Fixture(t *testing.T, execPath string, argv []string) []byte {
+	t.Helper()
+
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, uint32(len(argv)))
+	buf = append(buf, []byte(execPath)...)
+	buf = append(buf, 0)
+	for _, arg := range argv {
+		buf = append(buf, []byte(arg)...)
+		buf = append(buf, 0)
+	}
+	return buf
 }
 
 // Verifies Windows Unity process parsing decodes Base64 command lines, extracts project paths, and skips batchmode workers.

--- a/cli/common/unityprocess/timeouts.go
+++ b/cli/common/unityprocess/timeouts.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	// ProcessListCommandTimeout bounds ps and PowerShell process-enumeration calls that can hang on WMI stalls.
+	// ProcessListCommandTimeout bounds the Windows PowerShell process-enumeration call that can hang on WMI stalls.
+	// macOS enumeration reads process info via sysctl instead of exec'ing an external command, so it does not use this.
 	ProcessListCommandTimeout = 10 * time.Second
 	// FocusCommandTimeout bounds osascript and PowerShell focus calls that can hang on permission dialogs.
 	FocusCommandTimeout = 10 * time.Second

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "9eed1894ac125f75cdbb2f5145977ecfa92095bf"
+  "sharedInputsHash": "ffe6879910a39cf2bfd41750d1004a74009bc166"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "5e974fe74190b43814743342f870ff27ded3b83c"
+  "sharedInputsHash": "365d004e1dd5b0ffd4da57aafb814466595cbf26"
 }


### PR DESCRIPTION
## Summary
- Unity Editor discovery on macOS no longer depends on exec'ing `/bin/ps`, so it now works inside sandboxed environments (e.g. Claude Code's default sandbox) that deny exec of external binaries.
- `uloop`'s plain `launch`, `get-logs`, `compile`, and other commands that need to detect an already-running Unity Editor for this project now succeed in such sandboxes; they previously failed outright because the `ps` invocation itself was denied.

## User Impact
- Before: any `uloop` command path that needed to check for a running Unity Editor on macOS shelled out to `ps`. In sandboxes that block exec of external binaries, this made Unity process discovery fail entirely with a permission error, even though the rest of the command logic could otherwise run.
- After: discovery reads process info directly via `sysctl` (`kern.proc.all` / `kern.procargs2`), which sandboxes that block `ps` still permit. Discovery now works in both sandboxed and normal environments with identical results.
- Residual limitation (out of scope for this PR): `launch -r`/`-q` still kill the found Unity process via `kill(2)` against a non-child PID. Sandboxes that deny process discovery also independently deny sending signals to processes they don't own, so `-r`/`-q` will still fail inside such a sandbox even though discovery itself now succeeds. This is a separate, pre-existing sandbox restriction that no process-discovery implementation can work around.

## Changes
- `cli/common/unityprocess/process.go`: removed the `ps -axo ... -ww` exec call and its output parser; kept the existing project-path/batchmode matching rules (`isUnityEditorCommand`, `extractProjectPath`) and exposed them through a new `matchMacUnityProcess(pid, command)` helper shared by both the old command-line-based tests and the new argv-based path. Added a build-tag-free `parseMacProcArgs2` buffer parser for the `kern.procargs2` sysctl layout (leading `int32` argc, NUL-terminated exec path, NUL padding, then argc NUL-terminated argv entries; both darwin architectures are little-endian).
- `cli/common/unityprocess/process_darwin.go` (new, `//go:build darwin`): the real sysctl-based `listUnityProcessesMac`, using `golang.org/x/sys/unix`'s `SysctlKinfoProcSlice("kern.proc.all")` for enumeration and `SysctlRaw("kern.procargs2", pid)` for argv. Processes whose argv can't be read (e.g. `EPERM` for another user's process) are skipped, matching `ps`'s own visibility limits.
- `cli/common/unityprocess/process_other.go` (new, `//go:build !darwin`): a stub so the shared dispatcher compiles on every target OS; never reached at runtime.
- `cli/common/unityprocess/timeouts.go`: corrected a comment now that macOS enumeration no longer uses the timed external-command path.
- `cli/common/unityprocess/process_test.go`: replaced the old ps-output-parsing test with `TestMatchMacUnityProcessExtractsProjectPath` (same coverage: quoted path, batchmode-skip, unquoted path) and added fixture-based tests for the buffer parser (`TestParseMacProcArgs2DecodesArgv`, `TestParseMacProcArgs2RejectsShortBuffer`, `TestParseMacProcArgs2RejectsMissingExecPathTerminator`).
- `cli/common/go.mod`: promoted `golang.org/x/sys` from an indirect to a direct dependency (`go mod tidy`).
- `cli/project-runner/shared-inputs-stamp.json`, `cli/dispatcher/shared-inputs-stamp.json`: refreshed via `scripts/stamp-release-inputs.sh` per this repo's shared release-input trigger convention, since non-test `cli/common/**/*.go` sources changed.

## Verification
- `sh scripts/check-go-cli.sh`: 0 lint issues, all packages pass (including `cli/common/unityprocess`, `cli/project-runner`, `cli/dispatcher`).
- `sh scripts/build-go-cli.sh`: rebuilt dev binaries successfully.
- Sandbox enumeration proof: a standalone Go probe calling `unityprocess.FindRunningUnityProcess` directly, run under Claude Code's **default sandbox** (no sandbox override), correctly found the actual running Unity Editor process for this repo. In the same sandbox, plain `ps`/`pgrep` both fail with "operation not permitted."
- Regression check: outside the sandbox, `dist/darwin-arm64/uloop launch -r --project-path <project root>` still succeeds end-to-end (finds the existing process, kills it, and relaunches), confirming no behavior change for the normal (non-sandboxed) path.
- This PR targets an integration branch, not `main`/`v3-beta`, so repository CI workflows (filtered to `[main, v3-beta]`) do not fire here; the checks above are the local equivalent.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

