### PR TITLE
ci: Cancel superseded approval-waiting publish runs on new pushes

### DIFF
--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -22,6 +22,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'
     permissions:
       contents: read
+      actions: write
     outputs:
       should_publish: ${{ steps.release.outputs.publish }}
       should_release: ${{ steps.release.outputs.release }}
@@ -122,6 +123,18 @@ jobs:
       - name: Dry run summary
         if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run == 'true'
         run: ls -lh dist/dispatcher-release
+
+      - name: Cancel superseded approval-waiting runs
+        if: (steps.release.outputs.publish == 'true' || steps.release.outputs.release == 'true') && steps.release.outputs.dry_run != 'true'
+        working-directory: cli/release-automation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          go run ./cmd/cancel-superseded-waiting-runs
+          --repo "${{ github.repository }}"
+          --workflow dispatcher-publish.yml
+          --branch "${{ github.ref_name }}"
+          --current-run-id "${{ github.run_id }}"
 
   publish:
     needs: build

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -18,6 +18,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'
     permissions:
       contents: read
+      actions: write
     outputs:
       should_publish: ${{ steps.release.outputs.publish }}
       should_release: ${{ steps.release.outputs.release }}
@@ -133,6 +134,18 @@ jobs:
       - name: Dry run summary
         if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run == 'true'
         run: ls -lh dist/release
+
+      - name: Cancel superseded approval-waiting runs
+        if: (steps.release.outputs.publish == 'true' || steps.release.outputs.release == 'true') && steps.release.outputs.dry_run != 'true'
+        working-directory: cli/release-automation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          go run ./cmd/cancel-superseded-waiting-runs
+          --repo "${{ github.repository }}"
+          --workflow native-cli-publish.yml
+          --branch "${{ github.ref_name }}"
+          --current-run-id "${{ github.run_id }}"
 
   publish:
     needs: build

--- a/cli/release-automation/cmd/cancel-superseded-waiting-runs/main.go
+++ b/cli/release-automation/cmd/cancel-superseded-waiting-runs/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/hatayama/unity-cli-loop/tools/release-automation/internal/automation"
+)
+
+func main() {
+	os.Exit(automation.RunCancelSupersededWaitingRuns(context.Background(), os.Stdout, os.Stderr, os.Args[1:]))
+}

--- a/cli/release-automation/internal/automation/cancel_superseded_waiting_runs.go
+++ b/cli/release-automation/internal/automation/cancel_superseded_waiting_runs.go
@@ -1,0 +1,154 @@
+package automation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// cancelSupersededWaitingRunsConfig holds the target workflow run selection for cancellation.
+type cancelSupersededWaitingRunsConfig struct {
+	repository   string
+	workflow     string
+	branch       string
+	currentRunID int64
+}
+
+type cancelSupersededWaitingRunsDeps struct {
+	runOutput func(context.Context, string, ...string) (string, error)
+}
+
+type waitingWorkflowRun struct {
+	DatabaseID int64  `json:"databaseId"`
+	CreatedAt  string `json:"createdAt"`
+}
+
+// RunCancelSupersededWaitingRuns cancels approval-waiting publish runs for the same workflow and
+// branch that are older than the currently running one, so approval-waiting runs never pile up
+// between a release-please release PR merge and the eventual manual publish approval.
+func RunCancelSupersededWaitingRuns(ctx context.Context, stdout io.Writer, stderr io.Writer, args []string) int {
+	config, err := parseCancelSupersededWaitingRunsFlags(args)
+	if err != nil {
+		writeCancelSupersededWaitingRunsLine(stderr, "cancel-superseded-waiting-runs:", err)
+		return 1
+	}
+	return runCancelSupersededWaitingRunsWithDeps(ctx, stdout, stderr, config, defaultCancelSupersededWaitingRunsDeps())
+}
+
+func defaultCancelSupersededWaitingRunsDeps() cancelSupersededWaitingRunsDeps {
+	return cancelSupersededWaitingRunsDeps{
+		runOutput: runCancelSupersededWaitingRunsCommandOutput,
+	}
+}
+
+func parseCancelSupersededWaitingRunsFlags(args []string) (cancelSupersededWaitingRunsConfig, error) {
+	flagSet := flag.NewFlagSet("cancel-superseded-waiting-runs", flag.ContinueOnError)
+	repository := flagSet.String("repo", "", "GitHub repository in owner/name form")
+	workflow := flagSet.String("workflow", "", "workflow file name to filter runs by")
+	branch := flagSet.String("branch", "", "branch name to filter runs by")
+	currentRunID := flagSet.Int64("current-run-id", 0, "database id of the run invoking this command")
+	err := flagSet.Parse(args)
+	if err != nil {
+		return cancelSupersededWaitingRunsConfig{}, err
+	}
+	if *repository == "" {
+		return cancelSupersededWaitingRunsConfig{}, fmt.Errorf("--repo is required")
+	}
+	if *workflow == "" {
+		return cancelSupersededWaitingRunsConfig{}, fmt.Errorf("--workflow is required")
+	}
+	if *branch == "" {
+		return cancelSupersededWaitingRunsConfig{}, fmt.Errorf("--branch is required")
+	}
+	if *currentRunID == 0 {
+		return cancelSupersededWaitingRunsConfig{}, fmt.Errorf("--current-run-id is required")
+	}
+	return cancelSupersededWaitingRunsConfig{
+		repository:   *repository,
+		workflow:     *workflow,
+		branch:       *branch,
+		currentRunID: *currentRunID,
+	}, nil
+}
+
+func runCancelSupersededWaitingRunsWithDeps(ctx context.Context, stdout io.Writer, stderr io.Writer, config cancelSupersededWaitingRunsConfig, deps cancelSupersededWaitingRunsDeps) int {
+	runs, err := listCancelSupersededWaitingRuns(ctx, config, deps)
+	if err != nil {
+		writeCancelSupersededWaitingRunsLine(stderr, "cancel-superseded-waiting-runs:", err)
+		return 1
+	}
+
+	for _, run := range runs {
+		if run.DatabaseID >= config.currentRunID {
+			continue
+		}
+		err = cancelSupersededWaitingRun(ctx, config, run.DatabaseID, deps)
+		if err != nil {
+			writeCancelSupersededWaitingRunsLine(stderr, fmt.Sprintf("cancel-superseded-waiting-runs: warning: failed to cancel waiting run %d: %v", run.DatabaseID, err))
+			continue
+		}
+		writeCancelSupersededWaitingRunsLine(stdout, fmt.Sprintf("Cancelled superseded waiting run %d.", run.DatabaseID))
+	}
+
+	return 0
+}
+
+func writeCancelSupersededWaitingRunsLine(writer io.Writer, values ...any) {
+	// CI status output failures cannot be recovered after the command outcome is known.
+	_, _ = fmt.Fprintln(writer, values...)
+}
+
+func listCancelSupersededWaitingRuns(ctx context.Context, config cancelSupersededWaitingRunsConfig, deps cancelSupersededWaitingRunsDeps) ([]waitingWorkflowRun, error) {
+	output, err := deps.runOutput(
+		ctx,
+		"gh",
+		"run",
+		"list",
+		"--repo",
+		config.repository,
+		"--workflow",
+		config.workflow,
+		"--branch",
+		config.branch,
+		"--status",
+		"waiting",
+		"--json",
+		"databaseId,createdAt",
+		"--limit",
+		"50",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	runs := []waitingWorkflowRun{}
+	err = json.Unmarshal([]byte(output), &runs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse waiting workflow runs: %w", err)
+	}
+	return runs, nil
+}
+
+func cancelSupersededWaitingRun(ctx context.Context, config cancelSupersededWaitingRunsConfig, runID int64, deps cancelSupersededWaitingRunsDeps) error {
+	_, err := deps.runOutput(ctx, "gh", "run", "cancel", strconv.FormatInt(runID, 10), "--repo", config.repository)
+	return err
+}
+
+func runCancelSupersededWaitingRunsCommandOutput(ctx context.Context, name string, args ...string) (string, error) {
+	command := exec.CommandContext(ctx, name, args...)
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err := command.Run()
+	if err != nil {
+		return "", fmt.Errorf("%s %s failed: %w\n%s%s", name, strings.Join(args, " "), err, stderr.String(), stdout.String())
+	}
+	return stdout.String(), nil
+}

--- a/cli/release-automation/internal/automation/cancel_superseded_waiting_runs_test.go
+++ b/cli/release-automation/internal/automation/cancel_superseded_waiting_runs_test.go
@@ -1,0 +1,187 @@
+package automation
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Verifies that only waiting runs with a databaseId older than the current run are cancelled,
+// while the current run itself and any newer waiting run are left untouched.
+func TestCancelSupersededWaitingRunsCancelsOlderRunsOnly(t *testing.T) {
+	commandLog := []string{}
+	deps := cancelSupersededWaitingRunsDeps{
+		runOutput: func(ctx context.Context, name string, args ...string) (string, error) {
+			commandLine := strings.Join(append([]string{name}, args...), " ")
+			commandLog = append(commandLog, commandLine)
+			if commandLine == "gh run list --repo owner/repository --workflow native-cli-publish.yml --branch v3-beta --status waiting --json databaseId,createdAt --limit 50" {
+				return `[{"databaseId":100,"createdAt":"2026-07-20T01:00:00Z"},{"databaseId":200,"createdAt":"2026-07-20T02:00:00Z"},{"databaseId":300,"createdAt":"2026-07-20T03:00:00Z"}]`, nil
+			}
+			if commandLine == "gh run cancel 100 --repo owner/repository" || commandLine == "gh run cancel 200 --repo owner/repository" {
+				return "", nil
+			}
+			return "", fmt.Errorf("unexpected command: %s", commandLine)
+		},
+	}
+	config := cancelSupersededWaitingRunsConfig{
+		repository:   "owner/repository",
+		workflow:     "native-cli-publish.yml",
+		branch:       "v3-beta",
+		currentRunID: 300,
+	}
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	exitCode := runCancelSupersededWaitingRunsWithDeps(context.Background(), &stdout, &stderr, config, deps)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", exitCode, stderr.String())
+	}
+	commandLogText := strings.Join(commandLog, "\n")
+	assertCancelSupersededWaitingRunsLogContainsLine(t, commandLogText, "gh run cancel 100 --repo owner/repository")
+	assertCancelSupersededWaitingRunsLogContainsLine(t, commandLogText, "gh run cancel 200 --repo owner/repository")
+	assertCancelSupersededWaitingRunsLogDoesNotContain(t, commandLogText, "gh run cancel 300")
+}
+
+// Verifies that no cancel command is issued when there are no waiting runs.
+func TestCancelSupersededWaitingRunsSkipsCancelWhenNoWaitingRuns(t *testing.T) {
+	commandLog := []string{}
+	deps := cancelSupersededWaitingRunsDeps{
+		runOutput: func(ctx context.Context, name string, args ...string) (string, error) {
+			commandLine := strings.Join(append([]string{name}, args...), " ")
+			commandLog = append(commandLog, commandLine)
+			if commandLine == "gh run list --repo owner/repository --workflow native-cli-publish.yml --branch v3-beta --status waiting --json databaseId,createdAt --limit 50" {
+				return `[]`, nil
+			}
+			return "", fmt.Errorf("unexpected command: %s", commandLine)
+		},
+	}
+	config := cancelSupersededWaitingRunsConfig{
+		repository:   "owner/repository",
+		workflow:     "native-cli-publish.yml",
+		branch:       "v3-beta",
+		currentRunID: 300,
+	}
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	exitCode := runCancelSupersededWaitingRunsWithDeps(context.Background(), &stdout, &stderr, config, deps)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", exitCode, stderr.String())
+	}
+	commandLogText := strings.Join(commandLog, "\n")
+	assertCancelSupersededWaitingRunsLogDoesNotContain(t, commandLogText, "gh run cancel")
+}
+
+// Verifies that a cancel failure on one run (e.g. it was approved between listing and cancelling)
+// is reported as a warning while the remaining older runs are still cancelled, and the process exits 0.
+func TestCancelSupersededWaitingRunsContinuesAfterCancelFailure(t *testing.T) {
+	commandLog := []string{}
+	deps := cancelSupersededWaitingRunsDeps{
+		runOutput: func(ctx context.Context, name string, args ...string) (string, error) {
+			commandLine := strings.Join(append([]string{name}, args...), " ")
+			commandLog = append(commandLog, commandLine)
+			if commandLine == "gh run list --repo owner/repository --workflow native-cli-publish.yml --branch v3-beta --status waiting --json databaseId,createdAt --limit 50" {
+				return `[{"databaseId":100,"createdAt":"2026-07-20T01:00:00Z"},{"databaseId":200,"createdAt":"2026-07-20T02:00:00Z"}]`, nil
+			}
+			if commandLine == "gh run cancel 100 --repo owner/repository" {
+				return "", fmt.Errorf("run has already been approved")
+			}
+			if commandLine == "gh run cancel 200 --repo owner/repository" {
+				return "", nil
+			}
+			return "", fmt.Errorf("unexpected command: %s", commandLine)
+		},
+	}
+	config := cancelSupersededWaitingRunsConfig{
+		repository:   "owner/repository",
+		workflow:     "native-cli-publish.yml",
+		branch:       "v3-beta",
+		currentRunID: 300,
+	}
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	exitCode := runCancelSupersededWaitingRunsWithDeps(context.Background(), &stdout, &stderr, config, deps)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0 even when an individual cancel fails, got %d", exitCode)
+	}
+	assertCancelSupersededWaitingRunsLogContains(t, stderr.String(), "100")
+	commandLogText := strings.Join(commandLog, "\n")
+	assertCancelSupersededWaitingRunsLogContainsLine(t, commandLogText, "gh run cancel 200 --repo owner/repository")
+}
+
+// Verifies that a gh run list failure aborts with a non-zero exit code instead of being swallowed.
+func TestCancelSupersededWaitingRunsFailsWhenRunListFails(t *testing.T) {
+	deps := cancelSupersededWaitingRunsDeps{
+		runOutput: func(ctx context.Context, name string, args ...string) (string, error) {
+			return "", fmt.Errorf("gh: authentication failed")
+		},
+	}
+	config := cancelSupersededWaitingRunsConfig{
+		repository:   "owner/repository",
+		workflow:     "native-cli-publish.yml",
+		branch:       "v3-beta",
+		currentRunID: 300,
+	}
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	exitCode := runCancelSupersededWaitingRunsWithDeps(context.Background(), &stdout, &stderr, config, deps)
+
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1 when gh run list fails, got %d", exitCode)
+	}
+	assertCancelSupersededWaitingRunsLogContains(t, stderr.String(), "authentication failed")
+}
+
+// Verifies that each required flag (--repo, --workflow, --branch, --current-run-id) is enforced,
+// and that the command errors instead of running with a partially specified configuration.
+func TestCancelSupersededWaitingRunsRequiresFlags(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing repo", args: []string{"--workflow", "native-cli-publish.yml", "--branch", "v3-beta", "--current-run-id", "300"}},
+		{name: "missing workflow", args: []string{"--repo", "owner/repository", "--branch", "v3-beta", "--current-run-id", "300"}},
+		{name: "missing branch", args: []string{"--repo", "owner/repository", "--workflow", "native-cli-publish.yml", "--current-run-id", "300"}},
+		{name: "missing current-run-id", args: []string{"--repo", "owner/repository", "--workflow", "native-cli-publish.yml", "--branch", "v3-beta"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := parseCancelSupersededWaitingRunsFlags(testCase.args)
+			if err == nil {
+				t.Fatalf("expected an error for %s, got none", testCase.name)
+			}
+		})
+	}
+}
+
+func assertCancelSupersededWaitingRunsLogContains(t *testing.T, actual string, expected string) {
+	t.Helper()
+	if !strings.Contains(actual, expected) {
+		t.Fatalf("expected log to contain %q, got:\n%s", expected, actual)
+	}
+}
+
+func assertCancelSupersededWaitingRunsLogDoesNotContain(t *testing.T, actual string, unexpected string) {
+	t.Helper()
+	if strings.Contains(actual, unexpected) {
+		t.Fatalf("expected log not to contain %q, got:\n%s", unexpected, actual)
+	}
+}
+
+func assertCancelSupersededWaitingRunsLogContainsLine(t *testing.T, actual string, expected string) {
+	t.Helper()
+	for _, line := range strings.Split(actual, "\n") {
+		if strings.TrimSuffix(line, "\r") == expected {
+			return
+		}
+	}
+	t.Fatalf("expected log to contain line %q, got:\n%s", expected, actual)
+}


### PR DESCRIPTION
## Summary
- Stops approval-waiting native CLI / dispatcher publish runs from piling up in the `cli-release` environment between a release-please release PR merge and the eventual manual approval.

## User Impact
- Previously, every ordinary `fix:`/`feat:` push merged while a release-please release PR's version was still unpublished would queue another approval-waiting publish run. Approving an old one later just failed with a release-tag mismatch, wasting reviewer time.
- Now, each new push automatically cancels its own workflow's older waiting runs (matched by workflow, branch, and run id), so the approval queue holds at most one waiting run per publish workflow.

## Changes
- Added a `cancel-superseded-waiting-runs` Go command (`cli/release-automation`) that lists `waiting` runs for a given repo/workflow/branch and cancels those with a database id older than the invoking run, warning (not failing) on individual cancel races and failing only when the run listing itself errors.
- Wired the new command into both `native-cli-publish.yml` and `dispatcher-publish.yml` build jobs as a final step, gated on the run actually reaching the publish/release path, with `actions: write` added to each build job's permissions.
- Left `dispatcher-publish.yml`'s existing `concurrency` block untouched; it does not address this problem, and `cancel-in-progress` remains unsafe for in-flight publish runs.

## Verification
- `sh scripts/check-go-cli.sh` — full pass (fmt, vet, lint, tests including the new `cancel_superseded_waiting_runs_test.go` cases, native binary rebuild).
- Not yet verified: the actual GitHub Actions behavior (cancelling a real waiting run on push). That requires merging and observing a live release-please approval window.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

