### PR TITLE
ci: Enforce conventional commit PR titles for squash merges

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,29 @@
+name: PR Title Conventional Commit Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: [main, v3-beta]
+
+permissions:
+  contents: read
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: cli/.go-version
+          cache: false
+
+      - name: Check PR title is a conventional commit header
+        working-directory: cli/release-automation
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: go run ./cmd/check-pr-title

--- a/cli/release-automation/cmd/check-pr-title/main.go
+++ b/cli/release-automation/cmd/check-pr-title/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hatayama/unity-cli-loop/tools/release-automation/internal/automation"
+)
+
+func main() {
+	prTitle, isSet := os.LookupEnv("PR_TITLE")
+	if !isSet || prTitle == "" {
+		fmt.Fprintln(os.Stderr, "PR_TITLE is not set")
+		os.Exit(1)
+	}
+
+	os.Exit(automation.RunPRTitleGuard(os.Stdout, os.Stderr, prTitle))
+}

--- a/cli/release-automation/internal/automation/pr_title_guard.go
+++ b/cli/release-automation/internal/automation/pr_title_guard.go
@@ -1,0 +1,66 @@
+package automation
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// allowedPRTitleTypes lists the conventional commit types release-please
+// recognizes when parsing squash-merge commit subjects into release notes.
+var allowedPRTitleTypes = []string{
+	"build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test",
+}
+
+// conventionalCommitTitlePattern matches "<type>(<scope>)?!?: <summary>" with
+// a single space after the colon and a non-empty summary. The type token is
+// captured loosely here; allowedPRTitleTypes is checked separately so the
+// error message can report the exact unmatched type when it exists.
+var conventionalCommitTitlePattern = regexp.MustCompile(`^([a-z]+)(\([^()]+\))?!?: (.+)$`)
+
+// CheckPRTitle reports whether title is a conventional commit header using
+// one of allowedPRTitleTypes, returning the user-facing violation message
+// when it is not. This repository squash-merges every PR, so the PR title
+// becomes the base branch commit subject that release-please parses; a
+// non-conventional title silently drops the change from releases and
+// changelogs (as happened for PR #1884). The message is returned as a plain
+// string rather than an error because it is a fixed, sentence-final
+// user-facing string, not a Go error to be wrapped or compared.
+func CheckPRTitle(title string) (bool, string) {
+	trimmedTitle := strings.TrimSpace(title)
+
+	matches := conventionalCommitTitlePattern.FindStringSubmatch(trimmedTitle)
+	if matches == nil || strings.TrimSpace(matches[3]) == "" {
+		return false, formatPRTitleViolation(title)
+	}
+
+	commitType := matches[1]
+	for _, allowedType := range allowedPRTitleTypes {
+		if commitType == allowedType {
+			return true, ""
+		}
+	}
+
+	return false, formatPRTitleViolation(title)
+}
+
+// RunPRTitleGuard validates prTitle and reports the outcome to stdout/stderr,
+// returning the process exit code the caller should use.
+func RunPRTitleGuard(stdout io.Writer, stderr io.Writer, prTitle string) int {
+	if isValid, violationMessage := CheckPRTitle(prTitle); !isValid {
+		_, _ = fmt.Fprintln(stderr, violationMessage)
+		return 1
+	}
+
+	_, _ = fmt.Fprintln(stdout, "PR title guard passed.")
+	return 0
+}
+
+func formatPRTitleViolation(title string) string {
+	return fmt.Sprintf(
+		"PR title %q is not a conventional commit header. This repository squash-merges, so the PR title becomes the commit subject that release-please parses; a non-conventional title silently drops the change from releases and changelogs. Retitle the PR as <type>(<scope>)?: <summary> using one of: %s.",
+		title,
+		strings.Join(allowedPRTitleTypes, ", "),
+	)
+}

--- a/cli/release-automation/internal/automation/pr_title_guard_test.go
+++ b/cli/release-automation/internal/automation/pr_title_guard_test.go
@@ -1,0 +1,66 @@
+package automation
+
+import "testing"
+
+// Verifies conventional commit titles with common types and forms pass validation.
+func TestCheckPRTitleAcceptsValidConventionalCommitTitles(t *testing.T) {
+	validTitles := []string{
+		"fix: x",
+		"feat(scope): x",
+		"chore!: x",
+		"ci: x",
+	}
+	for _, title := range validTitles {
+		if isValid, message := CheckPRTitle(title); !isValid {
+			t.Errorf("expected %q to be valid, got violation message: %q", title, message)
+		}
+	}
+}
+
+// Verifies a title without any conventional commit prefix is rejected, reproducing the PR #1884 incident.
+func TestCheckPRTitleRejectsTitleWithoutPrefix(t *testing.T) {
+	title := "Round-3 pause-point/dynamic-code usability and reliability fixes"
+	if isValid, _ := CheckPRTitle(title); isValid {
+		t.Fatalf("expected %q to be rejected", title)
+	}
+}
+
+// Verifies a title using an unknown conventional commit type is rejected.
+func TestCheckPRTitleRejectsUnknownType(t *testing.T) {
+	title := "foo: x"
+	if isValid, _ := CheckPRTitle(title); isValid {
+		t.Fatalf("expected %q to be rejected", title)
+	}
+}
+
+// Verifies a title missing the required space after the colon is rejected.
+func TestCheckPRTitleRejectsMissingSpaceAfterColon(t *testing.T) {
+	title := "fix:x"
+	if isValid, _ := CheckPRTitle(title); isValid {
+		t.Fatalf("expected %q to be rejected", title)
+	}
+}
+
+// Verifies a title with an empty summary after the colon is rejected.
+func TestCheckPRTitleRejectsEmptySummary(t *testing.T) {
+	title := "fix: "
+	if isValid, _ := CheckPRTitle(title); isValid {
+		t.Fatalf("expected %q to be rejected", title)
+	}
+}
+
+// Verifies an empty title is rejected.
+func TestCheckPRTitleRejectsEmptyString(t *testing.T) {
+	title := ""
+	if isValid, _ := CheckPRTitle(title); isValid {
+		t.Fatalf("expected empty title to be rejected")
+	}
+}
+
+// Verifies a title using an uppercase type token is rejected since types must be lowercase.
+func TestCheckPRTitleRejectsUppercaseType(t *testing.T) {
+	title := "Fix: x"
+	if isValid, _ := CheckPRTitle(title); isValid {
+		t.Fatalf("expected %q to be rejected", title)
+	}
+}


### PR DESCRIPTION
## Summary
- PR titles that don't follow the conventional commit format now fail CI, instead of silently passing through as an unreleased squash commit.

## User Impact
- This repository squash-merges every PR, so the PR title becomes the base branch commit subject that release-please parses into release notes. A PR merged without a conventional commit prefix previously landed silently: the change compiled and shipped, but release-please never saw it as a release input, so it was missing from the changelog and version bump until manually recovered.
- Now, a PR titled without a `<type>(<scope>)?: <summary>` prefix fails a dedicated, lightweight CI check before merge. Editing the title after opening the PR re-triggers the check, so a fix applied post-review is still verified.

## Changes
- Added `CheckPRTitle`/`RunPRTitleGuard` in `cli/release-automation/internal/automation`, validating the title against the conventional commit types release-please recognizes (`build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test`).
- Added `cmd/check-pr-title`, a thin CLI entry point reading the title from the `PR_TITLE` environment variable (kept out of the shell command line to avoid injection from arbitrary PR title content).
- Added `.github/workflows/pr-title.yml` as a separate, lightweight workflow (rather than folding it into `build-and-test.yml`) so a title-only edit doesn't re-trigger the full build/test suite. It runs on `opened`, `edited`, `reopened`, and `synchronize`.

## Verification
- `cd cli/release-automation && go test ./internal/automation/ -run PRTitle -v` — all 7 cases pass (valid titles, PR #1884's actual title with no prefix, unknown type, missing space after colon, empty summary, empty string, uppercase type).
- `scripts/check-go-cli.sh` — 0 issues (fmt/vet/lint/test across all Go modules).
- `PR_TITLE='fix: valid title' go run ./cmd/check-pr-title` → exit 0; `PR_TITLE='no prefix title' ...` → exit 1 with the guidance message; unset `PR_TITLE` → exit 1.
- This PR's own title (`ci: Enforce conventional commit PR titles for squash merges`) is expected to pass the new `pr-title.yml` check once CI runs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

