### PR TITLE
fix: Correct dispatcher version series back to the 3.0.0-beta line

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "Packages/src": "3.0.0-beta.56",
-  "cli/dispatcher": "3.1.0-beta.19",
+  "cli/dispatcher": "3.0.0-beta.19",
   "cli/project-runner": "3.0.0-beta.53"
 }

--- a/.uloop/project-runner-pin.json
+++ b/.uloop/project-runner-pin.json
@@ -1,6 +1,6 @@
 {
   "dispatcherArchiveManifest": "05bc50dfccd20956feeaaef53305b51ce08a2399d9afd269dea5f87b06f55b9c  uloop-dispatcher-windows-amd64.zip.sha256\n1b917ed4b9bdeba2fad58991bdc378cd1166040ba938e2251f9692f66b9bd8dd  uloop-dispatcher-darwin-arm64.tar.gz\n284b71ce14ba93de7482db315cd1e1c327d1e5043b5a5e2e57b419d9aeaa944b  install.sh\n71bac19a7a2bb53bb1f01adfd6ecbeab32cd286594d1c775e211dcd90d616e26  uloop-dispatcher-windows-amd64.zip\n975edb2fbf2f83e7b502c5da9d4313e745d089cc35af9c5c1d0efb9b7ebdf261  uloop-dispatcher-darwin-amd64.tar.gz\na1250c3067be192e5e75954c7f807239503aaae56acae0132f613432ebcd6ecf  install.ps1\nc23354e22e25e5fcdc3059aba3572fa4ed4d34b4f64438f4ec6ab057ff203c57  install.sh.sha256\neb79a00522cae84464553e4b13d92a20784ecad71b429af13e413063b987901b  uloop-dispatcher-darwin-arm64.tar.gz.sha256\nf7d9d29939ed678f50fa8127680b250a3614367a3aa053ef530c61f88c584889  install.ps1.sha256\nf93a0b90a2bc2319fab0a1b526b2abf9e834f80b9b68f676315cc70fd47e2c1f  uloop-dispatcher-darwin-amd64.tar.gz.sha256",
   "dispatcherReleaseTag": "dispatcher-v3.1.0-beta.16",
-  "minimumDispatcherVersion": "3.1.0-beta.16",
+  "minimumDispatcherVersion": "3.0.0-beta.19",
   "projectRunnerVersion": "3.0.0-beta.53"
 }

--- a/Packages/src/project-runner-pin.json
+++ b/Packages/src/project-runner-pin.json
@@ -1,6 +1,6 @@
 {
   "dispatcherArchiveManifest": "05bc50dfccd20956feeaaef53305b51ce08a2399d9afd269dea5f87b06f55b9c  uloop-dispatcher-windows-amd64.zip.sha256\n1b917ed4b9bdeba2fad58991bdc378cd1166040ba938e2251f9692f66b9bd8dd  uloop-dispatcher-darwin-arm64.tar.gz\n284b71ce14ba93de7482db315cd1e1c327d1e5043b5a5e2e57b419d9aeaa944b  install.sh\n71bac19a7a2bb53bb1f01adfd6ecbeab32cd286594d1c775e211dcd90d616e26  uloop-dispatcher-windows-amd64.zip\n975edb2fbf2f83e7b502c5da9d4313e745d089cc35af9c5c1d0efb9b7ebdf261  uloop-dispatcher-darwin-amd64.tar.gz\na1250c3067be192e5e75954c7f807239503aaae56acae0132f613432ebcd6ecf  install.ps1\nc23354e22e25e5fcdc3059aba3572fa4ed4d34b4f64438f4ec6ab057ff203c57  install.sh.sha256\neb79a00522cae84464553e4b13d92a20784ecad71b429af13e413063b987901b  uloop-dispatcher-darwin-arm64.tar.gz.sha256\nf7d9d29939ed678f50fa8127680b250a3614367a3aa053ef530c61f88c584889  install.ps1.sha256\nf93a0b90a2bc2319fab0a1b526b2abf9e834f80b9b68f676315cc70fd47e2c1f  uloop-dispatcher-darwin-amd64.tar.gz.sha256",
   "dispatcherReleaseTag": "dispatcher-v3.1.0-beta.16",
-  "minimumDispatcherVersion": "3.1.0-beta.16",
+  "minimumDispatcherVersion": "3.0.0-beta.19",
   "projectRunnerVersion": "3.0.0-beta.53"
 }

--- a/cli/dispatcher/CHANGELOG.md
+++ b/cli/dispatcher/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.0.0-beta.19](https://github.com/hatayama/unity-cli-loop/releases/tag/dispatcher-v3.0.0-beta.19) (2026-07-21)
+
+Version realignment: the dispatcher rejoins the 3.0.0-beta line. The 3.1.0-beta series existed only because an unintended dispatcher-v3.0.0 bootstrap release made release-please treat 3.0.0 as shipped. No functional changes.
+
 ## [3.1.0-beta.19](https://github.com/hatayama/unity-cli-loop/compare/dispatcher-v3.1.0-beta.18...dispatcher-v3.1.0-beta.19) (2026-07-20)
 
 

--- a/cli/dispatcher/dispatchercontract/dispatcher-contract.json
+++ b/cli/dispatcher/dispatchercontract/dispatcher-contract.json
@@ -1,3 +1,3 @@
 {
-  "dispatcherVersion": "3.1.0-beta.19"
+  "dispatcherVersion": "3.0.0-beta.19"
 }


### PR DESCRIPTION
## Summary
- Dispatcher's version series is corrected back to the intended `3.0.0-beta.x` line, matching the Unity package and project runner.

## User Impact
- The dispatcher component had drifted onto an unintended `3.1.0-beta.x` series (caused by a one-off bootstrap release that release-please treated as a shipped `3.0.0`), out of step with the other components on `3.0.0-beta.x`.
- After this change, the dispatcher version series is consistent with the rest of the project again, and subsequent beta releases continue from `3.0.0-beta.19` as intended. No functional changes to the dispatcher itself.

## Changes
- Roll back `.release-please-manifest.json` and `dispatcher-contract.json`'s `dispatcherVersion` to `3.0.0-beta.19`. Hand-editing `dispatcher-contract.json` is normally disallowed (release-please stamps it), but this is a one-time correction of an incorrect version series, called out explicitly in the commit message.
- Add a `3.0.0-beta.19` CHANGELOG entry in the same commit as the manifest change, matching the release-sync script's requirement that both land together.
- Update `minimumDispatcherVersion` in both `project-runner-pin.json` copies to `3.0.0-beta.19` so `dispatcher_minimum_version_guard` passes (pin minimum equals the in-tree `dispatcherVersion`).

## Verification
- `cd cli/release-automation && go build ./...` — success
- `go test ./internal/automation/ -run Dispatcher -v` — all tests pass
- `jq -r '.["cli/dispatcher"]' .release-please-manifest.json`, `jq -r .dispatcherVersion cli/dispatcher/dispatchercontract/dispatcher-contract.json`, `jq -r .minimumDispatcherVersion Packages/src/project-runner-pin.json` all return `3.0.0-beta.19`
- `diff Packages/src/project-runner-pin.json .uloop/project-runner-pin.json` — no difference


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

