### PR TITLE
docs: Promote frame-boundary pause and pause-before-setup guidance in pause-point skill

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -30,6 +30,10 @@ uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 5. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
 6. Clear the marker with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` or stop PlayMode before moving on. Use `uloop clear-pause-point --all` to clear every active marker at once, for example when resetting between E2E scenarios. Clearing also removes the underlying code patch, so the method runs untouched afterwards.
 
+A hit pauses Unity at the next frame boundary — the patched method and the rest of that frame still run to completion. Only `CapturedVariables` is evidence of the values at the patched line; state read after the pause (for example via `execute-dynamic-code`) may already have advanced past it.
+
+If the game progresses on its own (timers, gravity, spawners), run `control-play-mode` `Pause` before setting up scenario state and `Resume` only after `enable-pause-point` succeeds — otherwise the scenario can be consumed before your input arrives. See Fast-Progressing Games below.
+
 ## Capture Modes and History
 
 Choose the capture mode when enabling a pause point:

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -30,6 +30,10 @@ uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 5. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
 6. Clear the marker with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` or stop PlayMode before moving on. Use `uloop clear-pause-point --all` to clear every active marker at once, for example when resetting between E2E scenarios. Clearing also removes the underlying code patch, so the method runs untouched afterwards.
 
+A hit pauses Unity at the next frame boundary — the patched method and the rest of that frame still run to completion. Only `CapturedVariables` is evidence of the values at the patched line; state read after the pause (for example via `execute-dynamic-code`) may already have advanced past it.
+
+If the game progresses on its own (timers, gravity, spawners), run `control-play-mode` `Pause` before setting up scenario state and `Resume` only after `enable-pause-point` succeeds — otherwise the scenario can be consumed before your input arrives. See Fast-Progressing Games below.
+
 ## Capture Modes and History
 
 Choose the capture mode when enabling a pause point:

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -30,6 +30,10 @@ uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 5. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
 6. Clear the marker with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` or stop PlayMode before moving on. Use `uloop clear-pause-point --all` to clear every active marker at once, for example when resetting between E2E scenarios. Clearing also removes the underlying code patch, so the method runs untouched afterwards.
 
+A hit pauses Unity at the next frame boundary — the patched method and the rest of that frame still run to completion. Only `CapturedVariables` is evidence of the values at the patched line; state read after the pause (for example via `execute-dynamic-code`) may already have advanced past it.
+
+If the game progresses on its own (timers, gravity, spawners), run `control-play-mode` `Pause` before setting up scenario state and `Resume` only after `enable-pause-point` succeeds — otherwise the scenario can be consumed before your input arrives. See Fast-Progressing Games below.
+
 ## Capture Modes and History
 
 Choose the capture mode when enabling a pause point:


### PR DESCRIPTION
## Summary
- The pause-point skill's Quick Check Template now states, up front, that a hit pauses at the next frame boundary (not instantly) and that self-progressing games need to be paused before scenario setup.

## User Impact
- These two semantics were previously documented only in later, easy-to-miss sections (Fast-Progressing Games, captured-variables.md), so callers reading only the Quick Check Template misread a hit as an instantaneous stop and could lose a scenario to a self-progressing game consuming it before their setup input arrived.
- Both points now appear right where the workflow is first read, pointing to the existing detailed sections for more.

## Changes
- Added two sentences to the Quick Check Template in `SKILL.md`, right after the numbered workflow steps.
- Regenerated the `.claude`/`.agents` skill copies via `uloop skills install --claude --agents`.
- No wording changes to the existing Fast-Progressing Games section or `captured-variables.md`; this is purely additive.

## Verification
- Docs-only change: `diff` confirms the source `SKILL.md` and the two generated skill copies are byte-identical.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

