### PR TITLE
feat: Add timeout diagnostics and outdated-runner hint to pause-point CLI errors

### DIFF
--- a/cli/project-runner/internal/projectrunner/native_command_help.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help.go
@@ -1,8 +1,11 @@
 package projectrunner
 
 import (
+	"fmt"
 	"io"
 	"sort"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 	"github.com/hatayama/unity-cli-loop/common/tooldocs"
@@ -71,6 +74,22 @@ func printNativeCommandHelp(command string, stdout io.Writer) {
 	clicore.WriteLine(stdout, "")
 	clicore.WriteLine(stdout, "Global options:")
 	clicore.WriteFormat(stdout, "  --%s <path>   Run against a Unity project outside the current directory\n", tooldocs.ProjectPathFlagName)
+}
+
+// pausePointUnknownOptionError reports an unrecognized flag for a runner-owned native
+// command. The hint calls out an outdated installed project runner as the likely cause when
+// the flag is documented in the skill but this runner build predates it, rather than leaving
+// the caller to guess between a typo and a stale binary.
+func pausePointUnknownOptionError(command string, name string) *clierrors.ArgumentError {
+	return &clierrors.ArgumentError{
+		Message: fmt.Sprintf(
+			"Unknown option %q for %s. If the skill documentation mentions this option, the installed "+
+				"project runner may be older than the docs — check 'uloop --version' and update the CLI.",
+			"--"+name, command),
+		Option:      "--" + name,
+		Command:     command,
+		NextActions: []string{fmt.Sprintf("Run `uloop %s --help` to inspect supported options.", command)},
+	}
 }
 
 func sortedNativeCommandOptions(options []string) []string {

--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -80,7 +80,8 @@ func pausePointTimeoutHint(response pausePointStatusResponse) string {
 	if response.HitCount == 0 && response.Status == pausePointStatusEnabled {
 		return "Marker was enabled but never hit. Confirm the id matches UloopPausePoint.Pause(\"<id>\") and that the code path was executed. In fast-progressing games the state may have already moved past the marker (for example back to Ready or GameOver), so re-trigger the code path and wait again. " +
 			"If the marker targets a Unity message method such as OnCollisionEnter2D/OnTriggerEnter2D, check whether `enable-pause-point`'s response carried a Warning about cached message dispatch: Unity can resolve a GameObject's message dispatch before the marker patch is installed, so a GameObject that already existed at enable time may never reach the marker even though the method body runs. Recreating the GameObject after enabling, or embedding UloopPausePoint.Pause(\"id\") directly in the method body, avoids this. " +
-			"If the target line is inside a very small method, Mono's JIT may have inlined it into callers and the pause point never fires; move the pause point into the calling method."
+			"If the target line is inside a very small method, Mono's JIT may have inlined it into callers and the pause point never fires; move the pause point into the calling method. " +
+			"If PlayMode kept progressing on its own while you were arranging state (timers, gravity, spawners), the scenario may have already been consumed before this marker could fire; next time, run `control-play-mode --action Pause` before setup and only `Resume` after `enable-pause-point` succeeds."
 	}
 	return ""
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -81,7 +81,7 @@ func pausePointTimeoutHint(response pausePointStatusResponse) string {
 		return "Marker was enabled but never hit. Confirm the id matches UloopPausePoint.Pause(\"<id>\") and that the code path was executed. In fast-progressing games the state may have already moved past the marker (for example back to Ready or GameOver), so re-trigger the code path and wait again. " +
 			"If the marker targets a Unity message method such as OnCollisionEnter2D/OnTriggerEnter2D, check whether `enable-pause-point`'s response carried a Warning about cached message dispatch: Unity can resolve a GameObject's message dispatch before the marker patch is installed, so a GameObject that already existed at enable time may never reach the marker even though the method body runs. Recreating the GameObject after enabling, or embedding UloopPausePoint.Pause(\"id\") directly in the method body, avoids this. " +
 			"If the target line is inside a very small method, Mono's JIT may have inlined it into callers and the pause point never fires; move the pause point into the calling method. " +
-			"If PlayMode kept progressing on its own while you were arranging state (timers, gravity, spawners), the scenario may have already been consumed before this marker could fire; next time, run `control-play-mode --action Pause` before setup and only `Resume` after `enable-pause-point` succeeds."
+			"If PlayMode kept progressing on its own while you were arranging state (timers, gravity, spawners), the scenario may have already been consumed before this marker could fire; next time, run `control-play-mode --action Pause` before setup and resume with `control-play-mode --action Play` only after `enable-pause-point` succeeds."
 	}
 	return ""
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -291,12 +291,7 @@ func parseWaitForPausePointOptions(args []string) (waitForPausePointOptions, err
 		case PausePointCapturedVariableNamesFlagName:
 			options.capturedVariableNames = parsePausePointCapturedVariableNames(value)
 		default:
-			return waitForPausePointOptions{}, &clierrors.ArgumentError{
-				Message:     "Unknown option for await-pause-point: --" + name,
-				Option:      "--" + name,
-				Command:     clicore.PausePointAwaitCommandName,
-				NextActions: []string{"Run `uloop await-pause-point --help` to inspect supported options."},
-			}
+			return waitForPausePointOptions{}, pausePointUnknownOptionError(clicore.PausePointAwaitCommandName, name)
 		}
 
 		if consumedNext {
@@ -339,12 +334,7 @@ func parsePausePointStatusOptions(args []string) (pausePointStatusOptions, error
 		case PausePointCapturedVariableNamesFlagName:
 			options.capturedVariableNames = parsePausePointCapturedVariableNames(value)
 		default:
-			return pausePointStatusOptions{}, &clierrors.ArgumentError{
-				Message:     "Unknown option for pause-point-status: --" + name,
-				Option:      "--" + name,
-				Command:     clicore.PausePointStatusUserCommandName,
-				NextActions: []string{"Run `uloop pause-point-status --help` to inspect supported options."},
-			}
+			return pausePointStatusOptions{}, pausePointUnknownOptionError(clicore.PausePointStatusUserCommandName, name)
 		}
 
 		if consumedNext {

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -919,7 +919,7 @@ func TestPausePointTimeoutErrorIncludesDiagnosisHint(t *testing.T) {
 			wantHint: "Marker was enabled but never hit. Confirm the id matches UloopPausePoint.Pause(\"<id>\") and that the code path was executed. In fast-progressing games the state may have already moved past the marker (for example back to Ready or GameOver), so re-trigger the code path and wait again. " +
 				"If the marker targets a Unity message method such as OnCollisionEnter2D/OnTriggerEnter2D, check whether `enable-pause-point`'s response carried a Warning about cached message dispatch: Unity can resolve a GameObject's message dispatch before the marker patch is installed, so a GameObject that already existed at enable time may never reach the marker even though the method body runs. Recreating the GameObject after enabling, or embedding UloopPausePoint.Pause(\"id\") directly in the method body, avoids this. " +
 				"If the target line is inside a very small method, Mono's JIT may have inlined it into callers and the pause point never fires; move the pause point into the calling method. " +
-				"If PlayMode kept progressing on its own while you were arranging state (timers, gravity, spawners), the scenario may have already been consumed before this marker could fire; next time, run `control-play-mode --action Pause` before setup and only `Resume` after `enable-pause-point` succeeds.",
+				"If PlayMode kept progressing on its own while you were arranging state (timers, gravity, spawners), the scenario may have already been consumed before this marker could fire; next time, run `control-play-mode --action Pause` before setup and resume with `control-play-mode --action Play` only after `enable-pause-point` succeeds.",
 		},
 	}
 
@@ -1091,7 +1091,6 @@ func TestRunProjectLocalPausePointStatusRespectsToolSettings(t *testing.T) {
 	}
 }
 
-// Verifies await-pause-point requires a marker id.
 // Verifies an unrecognized flag on await-pause-point/pause-point-status carries a hint
 // that the installed project runner may be older than the skill docs.
 func TestParseUnknownOptionErrorsIncludeOutdatedRunnerHint(t *testing.T) {
@@ -1116,6 +1115,7 @@ func TestParseUnknownOptionErrorsIncludeOutdatedRunnerHint(t *testing.T) {
 	}
 }
 
+// Verifies await-pause-point requires a marker id.
 func TestParseWaitForPausePointOptionsRequiresID(t *testing.T) {
 	_, err := parseWaitForPausePointOptions([]string{"--timeout-seconds", "1"})
 

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -918,7 +918,8 @@ func TestPausePointTimeoutErrorIncludesDiagnosisHint(t *testing.T) {
 			},
 			wantHint: "Marker was enabled but never hit. Confirm the id matches UloopPausePoint.Pause(\"<id>\") and that the code path was executed. In fast-progressing games the state may have already moved past the marker (for example back to Ready or GameOver), so re-trigger the code path and wait again. " +
 				"If the marker targets a Unity message method such as OnCollisionEnter2D/OnTriggerEnter2D, check whether `enable-pause-point`'s response carried a Warning about cached message dispatch: Unity can resolve a GameObject's message dispatch before the marker patch is installed, so a GameObject that already existed at enable time may never reach the marker even though the method body runs. Recreating the GameObject after enabling, or embedding UloopPausePoint.Pause(\"id\") directly in the method body, avoids this. " +
-				"If the target line is inside a very small method, Mono's JIT may have inlined it into callers and the pause point never fires; move the pause point into the calling method.",
+				"If the target line is inside a very small method, Mono's JIT may have inlined it into callers and the pause point never fires; move the pause point into the calling method. " +
+				"If PlayMode kept progressing on its own while you were arranging state (timers, gravity, spawners), the scenario may have already been consumed before this marker could fire; next time, run `control-play-mode --action Pause` before setup and only `Resume` after `enable-pause-point` succeeds.",
 		},
 	}
 
@@ -1091,6 +1092,30 @@ func TestRunProjectLocalPausePointStatusRespectsToolSettings(t *testing.T) {
 }
 
 // Verifies await-pause-point requires a marker id.
+// Verifies an unrecognized flag on await-pause-point/pause-point-status carries a hint
+// that the installed project runner may be older than the skill docs.
+func TestParseUnknownOptionErrorsIncludeOutdatedRunnerHint(t *testing.T) {
+	wantHint := "Unknown option \"--bogus-flag\" for await-pause-point. If the skill documentation mentions this option, the installed project runner may be older than the docs — check 'uloop --version' and update the CLI."
+
+	_, err := parseWaitForPausePointOptions([]string{"--id", "jump", "--bogus-flag", "value"})
+	if err == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+	if err.Error() != wantHint {
+		t.Fatalf("await-pause-point hint mismatch: %v", err)
+	}
+
+	wantStatusHint := "Unknown option \"--bogus-flag\" for pause-point-status. If the skill documentation mentions this option, the installed project runner may be older than the docs — check 'uloop --version' and update the CLI."
+
+	_, statusErr := parsePausePointStatusOptions([]string{"--id", "jump", "--bogus-flag", "value"})
+	if statusErr == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+	if statusErr.Error() != wantStatusHint {
+		t.Fatalf("pause-point-status hint mismatch: %v", statusErr)
+	}
+}
+
 func TestParseWaitForPausePointOptionsRequiresID(t *testing.T) {
 	_, err := parseWaitForPausePointOptions([]string{"--timeout-seconds", "1"})
 


### PR DESCRIPTION
## Summary
- A `HitCount=0` `await-pause-point` timeout now suggests pausing PlayMode before scenario setup, not just re-triggering the code path.
- An unrecognized flag on `await-pause-point`/`pause-point-status` now names an outdated installed project runner as a likely cause, alongside the existing typo/help pointer.

## User Impact
- Previously, a timeout with no hits only advised re-triggering the code path, which does not help when a self-progressing game (timers, gravity, spawners) consumed the scenario before the marker could fire. The hint now also points at `control-play-mode --action Pause` as the preventive fix for next time.
- Previously, an unrecognized flag read as a plain typo, even when the actual cause was an installed project runner older than the flag's documentation. The error now suggests checking `uloop --version` and updating the CLI as an alternative explanation.

## Changes
- Extended the existing `HitCount=0` timeout hint in `pausePointTimeoutHint` with one additional sentence; no other diagnostic fields changed.
- Added a shared `pausePointUnknownOptionError` helper used by both `await-pause-point` and `pause-point-status` option parsing, replacing their near-duplicate inline error construction.
- No IPC or response-shape changes; both errors are CLI-side argument/diagnostic text only.

## Verification
- `scripts/check-go-cli.sh`: all packages pass (fmt/vet/lint/test/build)
- `dist/darwin-arm64/uloop await-pause-point --id jump --bogus-flag value`: confirmed the new hint text in the response


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

