### PR TITLE
feat: Warn on Play Mode compiles with active pause points

### DIFF
--- a/Assets/Editor/CompileCheckWindow/CompileCheckerExample.cs
+++ b/Assets/Editor/CompileCheckWindow/CompileCheckerExample.cs
@@ -30,6 +30,7 @@ namespace io.github.hatayama.UnityCliLoop.Dev
 
                 CompileResult result = await compileController.TryCompileAsync(
                     forceRecompile: false,
+                    pausePointWarning: null,
                     ct: CancellationToken.None);
                 CompilerMessage[] err = result.Errors;
                 CompilerMessage[] warning = result.Warnings;
@@ -71,6 +72,7 @@ namespace io.github.hatayama.UnityCliLoop.Dev
                 // Example of forced re-compilation
                 CompileResult result = await compileController.TryCompileAsync(
                     forceRecompile: true,
+                    pausePointWarning: null,
                     ct: CancellationToken.None);
                 CompilerMessage[] err = result.Errors;
                 CompilerMessage[] warning = result.Warnings;

--- a/Assets/Editor/CompileCheckWindow/CompileEditorWindow.cs
+++ b/Assets/Editor/CompileCheckWindow/CompileEditorWindow.cs
@@ -135,7 +135,7 @@ namespace io.github.hatayama.UnityCliLoop.Dev
                 return;
             }
 
-            CompileResult result = await _compileController.TryCompileAsync(_forceRecompile, CancellationToken.None);
+            CompileResult result = await _compileController.TryCompileAsync(_forceRecompile, pausePointWarning: null, CancellationToken.None);
             if (ShouldRunExecuteDynamicCodeReadinessAfterCompile(result))
             {
                 _isPostCompileReadinessRunning = true;

--- a/Assets/Tests/Editor/CompilePausePointWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/CompilePausePointWarningBuilderTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies the compile Warning text only appears when Play Mode was active with at least
+    /// one enabled pause point, and states the domain-reload loss when it does.
+    /// </summary>
+    [TestFixture]
+    public sealed class CompilePausePointWarningBuilderTests
+    {
+        [Test]
+        public void BuildWarning_WhenNotPlayingAtRequestStart_ReturnsNull()
+        {
+            // Verifies no warning is produced when Play Mode was not active, regardless of marker count.
+            string warning = CompilePausePointWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                activePausePointCount: 3);
+
+            Assert.That(warning, Is.Null);
+        }
+
+        [Test]
+        public void BuildWarning_WhenPlayingButNoActivePausePoints_ReturnsNull()
+        {
+            // Verifies no warning is produced when Play Mode was active but no pause point is enabled.
+            string warning = CompilePausePointWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: true,
+                activePausePointCount: 0);
+
+            Assert.That(warning, Is.Null);
+        }
+
+        [Test]
+        public void BuildWarning_WhenPlayingWithActivePausePoints_MentionsCountAndDomainReloadLoss()
+        {
+            // Verifies the warning names the active count and explains what the domain reload discards.
+            string warning = CompilePausePointWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: true,
+                activePausePointCount: 2);
+
+            Assert.That(warning, Does.Contain("2 enabled pause point"));
+            Assert.That(warning, Does.Contain("Play session state"));
+            Assert.That(warning, Does.Contain("pause point patches"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/CompilePausePointWarningBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/CompilePausePointWarningBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b619b8f058fc54c9d855b5ae93c5d746
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CompileResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/CompileResponseFactoryTests.cs
@@ -42,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 warnings: new[] { warning });
 
             CompileResponse response =
-                CompileResponseFactory.CreateResponse(result, forceRecompile: false);
+                CompileResponseFactory.CreateResponse(result, forceRecompile: false, pausePointWarning: null);
 
             Assert.That(response.Success, Is.False);
             Assert.That(response.ErrorCount, Is.EqualTo(1));
@@ -75,7 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 message: null);
 
             CompileResponse response =
-                CompileResponseFactory.CreateResponse(result, forceRecompile: true);
+                CompileResponseFactory.CreateResponse(result, forceRecompile: true, pausePointWarning: null);
 
             Assert.That(response.Success, Is.False);
             Assert.That(response.ErrorCount, Is.Null);
@@ -102,7 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 message: "Internal force compile status message.");
 
             CompileResponse response =
-                CompileResponseFactory.CreateResponse(result, forceRecompile: true);
+                CompileResponseFactory.CreateResponse(result, forceRecompile: true, pausePointWarning: null);
 
             Assert.That(response.Success, Is.False);
             Assert.That(response.ErrorCount, Is.Null);
@@ -144,7 +144,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 message: null);
 
             CompileResponse response =
-                CompileResponseFactory.CreateResponse(result, forceRecompile: false);
+                CompileResponseFactory.CreateResponse(result, forceRecompile: false, pausePointWarning: null);
 
             Assert.That(response.Success, Is.False);
             Assert.That(response.ErrorCount, Is.EqualTo(1));
@@ -179,7 +179,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 preserveDetailsWhenForceRecompile: true);
 
             CompileResponse response =
-                CompileResponseFactory.CreateResponse(result, forceRecompile: true);
+                CompileResponseFactory.CreateResponse(result, forceRecompile: true, pausePointWarning: null);
 
             Assert.That(response.Success, Is.False);
             Assert.That(response.ErrorCount, Is.EqualTo(1));
@@ -210,7 +210,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 message: error.message);
 
             CompileResponse response =
-                CompileResponseFactory.CreateResponse(result, forceRecompile: false);
+                CompileResponseFactory.CreateResponse(result, forceRecompile: false, pausePointWarning: null);
 
             Assert.That(response.NextActions, Is.Not.Null);
             Assert.That(response.NextActions, Has.Length.EqualTo(2));
@@ -245,7 +245,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 message: error.message);
 
             CompileResponse response =
-                CompileResponseFactory.CreateResponse(result, forceRecompile: false);
+                CompileResponseFactory.CreateResponse(result, forceRecompile: false, pausePointWarning: null);
 
             Assert.That(response.NextActions, Is.Not.Null);
             Assert.That(response.NextActions, Has.Length.EqualTo(2));
@@ -275,7 +275,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 message: error.message);
 
             CompileResponse response =
-                CompileResponseFactory.CreateResponse(result, forceRecompile: false);
+                CompileResponseFactory.CreateResponse(result, forceRecompile: false, pausePointWarning: null);
 
             Assert.That(response.NextActions, Is.Null);
         }
@@ -301,7 +301,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 warnings: Array.Empty<CompilerMessage>());
 
             CompileResponse response =
-                CompileResponseFactory.CreateResponse(result, forceRecompile: false);
+                CompileResponseFactory.CreateResponse(result, forceRecompile: false, pausePointWarning: null);
 
             Assert.That(response.Message, Does.Contain("TestAssemblies"));
             Assert.That(response.Message, Does.Contain("com.unity.test-framework"));

--- a/Assets/Tests/Editor/CompileSessionResultStoreTests.cs
+++ b/Assets/Tests/Editor/CompileSessionResultStoreTests.cs
@@ -97,9 +97,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     errors: Array.Empty<CompilerMessage>(),
                     warnings: new[] { warning });
                 CompileResponse firstResponse =
-                    CompileResponseFactory.CreateResponse(result, forceRecompile: false);
+                    CompileResponseFactory.CreateResponse(result, forceRecompile: false, pausePointWarning: null);
                 CompileResponse secondResponse =
-                    CompileResponseFactory.CreateResponse(result, forceRecompile: false);
+                    CompileResponseFactory.CreateResponse(result, forceRecompile: false, pausePointWarning: null);
 
                 CompileSessionResultStore.StoreCompileResult(
                     compileResultSessionRepository,

--- a/Assets/Tests/Editor/CompileUseCaseTests.cs
+++ b/Assets/Tests/Editor/CompileUseCaseTests.cs
@@ -67,6 +67,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Assert.That(compileResultSessionRepository.StoreCount, Is.EqualTo(1));
                 Assert.That(response.Success, Is.True);
                 Assert.That(response.ProjectRoot, Is.Not.Empty);
+                // Verifies no pause-point Warning appears outside Play Mode (the only state an EditMode test can exercise).
+                Assert.That(response.Warning, Is.Null);
                 UnityCliLoopStoredCompileResult storedResult =
                     compileResultSessionRepository.GetCompileResult("compile_test_request");
                 Assert.That(storedResult.ResultJson, Does.Contain("\"ProjectRoot\":"));

--- a/Assets/Tests/Editor/CompileUseCaseTests.cs
+++ b/Assets/Tests/Editor/CompileUseCaseTests.cs
@@ -49,7 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     compileSessionLifecycleService,
                     compileResultSessionRepository,
                     pendingCompileSessionRepository);
-                useCase.SetCompilationExecutionForTesting((compileRequest, ct) =>
+                useCase.SetCompilationExecutionForTesting((compileRequest, pausePointWarning, ct) =>
                 {
                     ct.ThrowIfCancellationRequested();
                     CompileResultSessionRecorder.RecordCompileResult(

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompilationExecutionService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompilationExecutionService.cs
@@ -34,8 +34,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Execute compilation asynchronously
         /// </summary>
         /// <param name="request">Compile request with force and delayed-result settings.</param>
+        /// <param name="pausePointWarning">Optional Warning to carry onto the shaped response, e.g. when Play Mode was active with enabled pause points.</param>
         /// <returns>Compilation result</returns>
-        public async Task<CompileResult> ExecuteCompilationAsync(CompileSchema request, CancellationToken ct)
+        public async Task<CompileResult> ExecuteCompilationAsync(CompileSchema request, string pausePointWarning, CancellationToken ct)
         {
             if (request == null)
             {
@@ -47,7 +48,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _pendingCompileSessionRepository);
             compileController.SetResultRecordingContext(CompileResultRecordingContext.Create(request));
             compileController.SetExternalSceneChangePolicy(request.ReloadExternalSceneChanges);
-            return await compileController.TryCompileAsync(request.ForceRecompile, ct).ConfigureAwait(false);
+            return await compileController.TryCompileAsync(request.ForceRecompile, pausePointWarning, ct).ConfigureAwait(false);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -22,6 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private List<CompilerMessage> _compileMessages = new();
         private TaskCompletionSource<CompileResult> _currentCompileTask;
         private bool _isForceCompile = false;
+        private string _pendingPausePointWarning;
         private bool _reloadExternalSceneChanges = true;
         private CompileResultRecordingContext _resultRecordingContext = CompileResultRecordingContext.Disabled();
         private DateTime _compileStartedAtUtc = DateTime.MinValue;
@@ -96,6 +97,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Executes compilation asynchronously.
         /// </summary>
         /// <param name="forceRecompile">Whether to force a recompile.</param>
+        /// <param name="pausePointWarning">Optional Warning to carry onto the shaped response, e.g. when Play Mode was active with enabled pause points.</param>
         /// <param name="ct">Cancellation token for the compile execution.</param>
         /// <returns>The compilation result.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the task is not found during compilation.</exception>
@@ -103,8 +105,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Callers must validate editor compilation state before invoking compile execution;
         /// the production pipeline does this in CompileUseCase.
         /// </remarks>
-        public async Task<CompileResult> TryCompileAsync(bool forceRecompile, CancellationToken ct)
+        public async Task<CompileResult> TryCompileAsync(bool forceRecompile, string pausePointWarning, CancellationToken ct)
         {
+            _pendingPausePointWarning = pausePointWarning;
+
             if (_isCompiling)
             {
                 // If compilation is already in progress, wait for the current task.
@@ -136,7 +140,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     });
                 CompileResult result =
                     CompileResultFactory.CreateExternalSceneChangeFailureResult(sceneChangeResult);
-                RecordCompileResultIfNeeded(result);
+                RecordCompileResultIfNeeded(result, pausePointWarning: null);
                 return result;
             }
 
@@ -321,7 +325,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Completion subscribers are outside this controller, so state cleanup cannot depend on them returning.
             try
             {
-                RecordCompileResultIfNeeded(result);
+                RecordCompileResultIfNeeded(result, _pendingPausePointWarning);
 
                 if (unregisterEvents)
                 {
@@ -341,13 +345,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     _isForceCompile = false;
                     _resultRecordingContext = CompileResultRecordingContext.Disabled();
                     _compileStartedAtUtc = DateTime.MinValue;
+                    _pendingPausePointWarning = null;
                 }
 
                 task?.TrySetResult(result);
             }
         }
 
-        private void RecordCompileResultIfNeeded(CompileResult result)
+        private void RecordCompileResultIfNeeded(CompileResult result, string pausePointWarning)
         {
             UnityEngine.Debug.Assert(result != null, "result must not be null");
 
@@ -362,7 +367,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _resultRecordingContext.RequestId,
                 _resultRecordingContext.ForceRecompile,
                 result,
-                _resultRecordingContext.RequestId);
+                _resultRecordingContext.RequestId,
+                pausePointWarning);
         }
 
         /// <summary>
@@ -462,6 +468,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _reloadExternalSceneChanges = true;
             _resultRecordingContext = CompileResultRecordingContext.Disabled();
             _compileStartedAtUtc = DateTime.MinValue;
+            _pendingPausePointWarning = null;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompilePausePointWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompilePausePointWarningBuilder.cs
@@ -1,0 +1,22 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds the compile Warning text for the case where Play Mode was active with enabled
+    /// pause points at the moment compile was requested: the domain reload that follows discards
+    /// both the Play session state and every pause-point Harmony patch.
+    /// </summary>
+    internal static class CompilePausePointWarningBuilder
+    {
+        public static string BuildWarning(bool wasPlayingAtRequestStart, int activePausePointCount)
+        {
+            if (!wasPlayingAtRequestStart || activePausePointCount <= 0)
+            {
+                return null;
+            }
+
+            return "Play Mode was active with " + activePausePointCount + " enabled pause point(s). "
+                + "The compile stops Play Mode and the domain reload discards the Play session state "
+                + "and all pause point patches — re-enable pause points after the compile completes.";
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompilePausePointWarningBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompilePausePointWarningBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fd68b00b4e134f7bbd52a920ebea900
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileResponse.cs
@@ -74,6 +74,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string ProjectRoot { get; set; }
 
         /// <summary>
+        /// Optional warning about a condition compile does not block on, e.g. Play Mode being
+        /// active with enabled pause points whose patches the domain reload will discard.
+        /// </summary>
+        public string Warning { get; set; }
+
+        /// <summary>
         /// Create a new CompileResponse
         /// </summary>
         public CompileResponse(

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
@@ -27,24 +27,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static CompileResponse CreateResponse(
             CompileResult result,
-            bool forceRecompile)
+            bool forceRecompile,
+            string pausePointWarning)
         {
             Debug.Assert(result != null, "result must not be null");
 
             if (forceRecompile && !result.PreserveDetailsWhenForceRecompile)
             {
-                return CreateForceCompileResult(result);
+                return CreateForceCompileResult(result, pausePointWarning);
             }
 
             if (result.IsIndeterminate)
             {
-                return new CompileResponse(
+                CompileResponse indeterminateResponse = new CompileResponse(
                     success: result.Success == true,
                     errorCount: result.ErrorCount,
                     warningCount: result.WarningCount,
                     errors: null,
                     warnings: null,
                     message: result.Message ?? "Compilation status is unknown. Use get-logs to inspect the compiler output.");
+                indeterminateResponse.Warning = pausePointWarning;
+                return indeterminateResponse;
             }
 
             CompileResponse response = new CompileResponse(
@@ -55,6 +58,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings: ToIssues(result.Warnings),
                 message: AddMissingTestFrameworkReferenceHint(result.Message, result.Errors));
             response.NextActions = CreateExternalSceneChangeNextActions(result.Message);
+            response.Warning = pausePointWarning;
             return response;
         }
 
@@ -73,7 +77,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return ExternalSceneChangeNextActions;
         }
 
-        private static CompileResponse CreateForceCompileResult(CompileResult result)
+        private static CompileResponse CreateForceCompileResult(CompileResult result, string pausePointWarning)
         {
             ForceCompileUnknownResult unknownResult = ForceCompileUnknownResult.Create();
             CompileResponse response = new CompileResponse(
@@ -85,6 +89,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 message: unknownResult.Message);
             response.ErrorCode = ForceCompileUnknownResult.ErrorCodeText;
             response.NextActions = new[] { ForceCompileUnknownResult.NextActionText };
+            response.Warning = pausePointWarning;
             return response;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileResultSessionRecorder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileResultSessionRecorder.cs
@@ -16,14 +16,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string requestId,
             bool forceRecompile,
             CompileResult result,
-            string correlationId)
+            string correlationId,
+            string pausePointWarning = null)
         {
             Debug.Assert(compileResultSessionRepository != null, "compileResultSessionRepository must not be null");
             Debug.Assert(pendingCompileSessionRepository != null, "pendingCompileSessionRepository must not be null");
             Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
             Debug.Assert(result != null, "result must not be null");
 
-            CompileResponse response = CompileResponseFactory.CreateResponse(result, forceRecompile);
+            CompileResponse response = CompileResponseFactory.CreateResponse(result, forceRecompile, pausePointWarning);
             return RecordCompileResponse(
                 compileResultSessionRepository,
                 pendingCompileSessionRepository,

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
@@ -5,6 +5,7 @@ using UnityEditor;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -67,6 +68,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             PrepareResultStorage(request);
             string correlationId = ResolveCorrelationId(request);
             LogCompileRequestReceived(request, correlationId);
+
+            // Captured before PlayMode preparation can stop Play Mode, so the warning reflects
+            // the state compile was actually requested in, not the state after this method mutates it.
+            bool wasPlayingAtRequestStart = EditorApplication.isPlaying;
+            int activePausePointCountAtRequestStart = UloopPausePointRegistry.GetActiveCount();
 
             DateTime utcNow = DateTime.UtcNow;
             _compileSessionLifecycleService.ClearExpiredCompileResult(utcNow);
@@ -159,6 +165,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // 4. Result formatting
             CompileResponse successResponse =
                 CompileResponseFactory.CreateResponse(result, request.ForceRecompile);
+            successResponse.Warning = CompilePausePointWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart,
+                activePausePointCountAtRequestStart);
             StampProjectRootForDelayedResponseIfNeeded(request, successResponse);
             return successResponse;
         }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
@@ -22,7 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly UnityCliLoopCompileSessionLifecycleService _compileSessionLifecycleService;
         private readonly ICompileResultSessionRepository _compileResultSessionRepository;
         private readonly IPendingCompileSessionRepository _pendingCompileSessionRepository;
-        private Func<CompileSchema, CancellationToken, Task<CompileResult>> _executeCompilationAsync;
+        private Func<CompileSchema, string, CancellationToken, Task<CompileResult>> _executeCompilationAsync;
 
         public CompileUseCase(
             UnityCliLoopCompileSessionLifecycleService compileSessionLifecycleService,
@@ -45,7 +45,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>
         /// Replaces compilation execution for tests that must not start Unity's real compilation pipeline.
         /// </summary>
-        internal void SetCompilationExecutionForTesting(Func<CompileSchema, CancellationToken, Task<CompileResult>> executeCompilationAsync)
+        internal void SetCompilationExecutionForTesting(Func<CompileSchema, string, CancellationToken, Task<CompileResult>> executeCompilationAsync)
         {
             Debug.Assert(executeCompilationAsync != null, "executeCompilationAsync must not be null");
             _executeCompilationAsync = executeCompilationAsync ??
@@ -159,15 +159,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             // 3. Compilation execution
+            string pausePointWarning = CompilePausePointWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart,
+                activePausePointCountAtRequestStart);
             ct.ThrowIfCancellationRequested();
-            CompileResult result = await _executeCompilationAsync(request, ct).ConfigureAwait(false);
+            CompileResult result = await _executeCompilationAsync(request, pausePointWarning, ct).ConfigureAwait(false);
 
             // 4. Result formatting
             CompileResponse successResponse =
-                CompileResponseFactory.CreateResponse(result, request.ForceRecompile);
-            successResponse.Warning = CompilePausePointWarningBuilder.BuildWarning(
-                wasPlayingAtRequestStart,
-                activePausePointCountAtRequestStart);
+                CompileResponseFactory.CreateResponse(result, request.ForceRecompile, pausePointWarning);
             StampProjectRootForDelayedResponseIfNeeded(request, successResponse);
             return successResponse;
         }
@@ -356,14 +356,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return $"compile_{unixTimeMilliseconds}_{correlationId}";
         }
 
-        private Task<CompileResult> ExecuteCompilationWithDefaultServiceAsync(CompileSchema request, CancellationToken ct)
+        private Task<CompileResult> ExecuteCompilationWithDefaultServiceAsync(CompileSchema request, string pausePointWarning, CancellationToken ct)
         {
             Debug.Assert(request != null, "request must not be null");
 
             CompilationExecutionService executionService = new(
                 _compileResultSessionRepository,
                 _pendingCompileSessionRepository);
-            return executionService.ExecuteCompilationAsync(request, ct);
+            return executionService.ExecuteCompilationAsync(request, pausePointWarning, ct);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/UnityCLILoop.FirstPartyTools.Compile.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Compile/UnityCLILoop.FirstPartyTools.Compile.Editor.asmdef
@@ -5,7 +5,8 @@
         "GUID:5c4588558a3624eacbce0f50007cf1eb",
         "GUID:e5952ef560e1641f68b2687e6045bf5b",
         "GUID:d427b32aad9cb44fc8e962437c9dbcd8",
-        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b",
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
+++ b/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Common.Preflight.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Compile.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Infrastructure")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -224,6 +224,23 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             return Entries.TryGetValue(id, out UloopPausePointEntry entry) && entry.IsEnabled;
         }
 
+        /// <summary>
+        /// Counts entries still armed (IsEnabled), i.e. markers whose Harmony patch is currently
+        /// installed and would be lost on the next domain reload.
+        /// </summary>
+        public static int GetActiveCount()
+        {
+            int count = 0;
+            foreach (UloopPausePointEntry entry in Entries.Values)
+            {
+                if (entry.IsEnabled)
+                {
+                    count++;
+                }
+            }
+            return count;
+        }
+
         private static UloopPausePointSnapshot HitCore(
             string id,
             UloopPausePointCapturedVariableFrame capturedFrame,

--- a/tests/contracts/compile_status_response_contract.json
+++ b/tests/contracts/compile_status_response_contract.json
@@ -14,7 +14,8 @@
     "Message": "Compile result is available.",
     "ErrorCode": null,
     "NextActions": null,
-    "ProjectRoot": null
+    "ProjectRoot": null,
+    "Warning": null
   },
   "Message": "Compile result is available."
 }


### PR DESCRIPTION
## Summary
- `uloop compile` now warns when it compiles while Play Mode is active and pause points are still enabled, since the domain reload that follows discards both the Play session state and every pause-point patch.
- Verified the existing physical/message-callback pause-point warning (`OnCollisionEnter`, `OnTriggerEnter`, etc.) already covers this case fully — no new implementation was needed there.

## User Impact
- Before: compiling during Play Mode silently dropped the Play session and any enabled pause points, with no indication anything was lost. Users only noticed later when a pause point stopped firing.
- After: the compile response includes a `Warning` field naming how many pause points were active and explaining that they need to be re-enabled after the compile completes.

## Changes
- `CompileResponse` gains an additive `Warning: string` field.
- `CompileUseCase` captures whether Play Mode was active and the number of enabled pause points before Play Mode gets stopped for compilation, then attaches the warning text on the path where compilation actually runs.
- `UloopPausePointRegistry` gains `GetActiveCount()`.
- `Compile.Editor` is wired to the PausePoints runtime assembly using the same `InternalsVisibleTo` + asmdef-reference pattern already used by several other first-party tool assemblies.
- The warning-decision logic lives in a small pure `CompilePausePointWarningBuilder`, unit-tested directly (avoids needing a real Play Mode session inside an EditMode test).
- Shared `compile_status_response_contract.json` fixture updated additively for the new field; both the C# and Go contract tests were re-verified.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo>` → 0 errors / 0 warnings.
- `dist/darwin-arm64/uloop run-tests --filter-type all` → 2240/2250 passed, 3 pre-existing failures unrelated to this change (dispatcher pin version drift, an unrelated schema-attribute test), 7 skipped.
- `cd cli/project-runner && go test ./internal/projectrunner/... -run TestCompileStatusResponseMatchesSharedContract` → pass.
- `sh scripts/check-go-cli.sh` → all Go modules pass (format, vet, lint, tests, build).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

