### PR TITLE
feat: Report the resolved camera in raycast responses

### DIFF
--- a/Assets/Tests/Editor/RaycastToolTests.cs
+++ b/Assets/Tests/Editor/RaycastToolTests.cs
@@ -78,6 +78,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Success, Is.True);
             Assert.That(response.Hit, Is.True);
             Assert.That(response.HitGameObjectName, Is.EqualTo("RaycastToolTestsCube"));
+            Assert.That(response.CameraName, Is.EqualTo("RaycastToolTestsCamera"));
+            Assert.That(response.CameraPath, Does.Contain("RaycastToolTestsCamera"));
             Assert.That(response.InputCoordinateSystem, Is.EqualTo(UnityCliLoopConstants.COORDINATE_SYSTEM_TOP_LEFT_GAME_VIEW));
             Assert.That(response.UnityCoordinateSystem, Is.EqualTo(UnityCliLoopConstants.COORDINATE_SYSTEM_BOTTOM_LEFT_GAME_VIEW));
             Assert.That(response.CoordinateConversionFormula, Is.EqualTo(UnityCliLoopConstants.COORDINATE_CONVERSION_FORMULA_GAME_VIEW_INPUT_TO_UNITY));
@@ -99,6 +101,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Success, Is.True);
             Assert.That(response.Hit, Is.False);
             Assert.That(response.HitGameObjectName, Is.Null);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenCoordinateMissesCollider_ShouldStillReportResolvedCamera()
+        {
+            // Tests that the resolved Camera.main is reported even on a "No physics hit" response, so an
+            // agent can tell which camera the ray actually came from instead of assuming Camera.main.
+            CreateRaycastScene();
+            Vector2 inputPosition = new Vector2(0f, 0f);
+
+            RaycastResponse response = await ExecuteRaycast(inputPosition);
+
+            Assert.That(response.Hit, Is.False);
+            Assert.That(response.CameraName, Is.EqualTo("RaycastToolTestsCamera"));
+            Assert.That(response.CameraPath, Does.Contain("RaycastToolTestsCamera"));
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/Common/GameView/GameViewRaycastUtility.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/GameView/GameViewRaycastUtility.cs
@@ -20,7 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Camera mainCamera = Camera.main;
             if (mainCamera == null)
             {
-                return new GameViewRaycastResult(false, conversion, new RaycastHit[0]);
+                return new GameViewRaycastResult(false, conversion, new RaycastHit[0], null);
             }
 
             Ray ray = mainCamera.ScreenPointToRay(conversion.InjectedUnityPosition);
@@ -34,7 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             RaycastHit[] hits = Physics.RaycastAll(ray, maxDistance, visibleLayerMask);
             System.Array.Sort(hits, CompareHitsByDistance);
 
-            return new GameViewRaycastResult(true, conversion, hits);
+            return new GameViewRaycastResult(true, conversion, hits, mainCamera);
         }
 
         private static int CompareHitsByDistance(RaycastHit left, RaycastHit right)
@@ -51,15 +51,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public readonly bool CameraFound;
         public readonly GameViewCoordinateConversion Conversion;
         public readonly RaycastHit[] Hits;
+        public readonly Camera Camera;
 
         public GameViewRaycastResult(
             bool cameraFound,
             GameViewCoordinateConversion conversion,
-            RaycastHit[] hits)
+            RaycastHit[] hits,
+            Camera camera)
         {
             CameraFound = cameraFound;
             Conversion = conversion;
             Hits = hits;
+            Camera = camera;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Raycast/RaycastResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/Raycast/RaycastResponse.cs
@@ -10,6 +10,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class RaycastResponse : UnityCliLoopToolResponse
     {
         public string Message { get; set; } = "";
+        public string? CameraName { get; set; }
+        public string? CameraPath { get; set; }
         public bool Hit { get; set; }
         public string? HitGameObjectName { get; set; }
         public string? HitGameObjectPath { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/Raycast/RaycastTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/Raycast/RaycastTool.cs
@@ -49,6 +49,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 noHitResponse.Success = true;
                 noHitResponse.Hit = false;
                 noHitResponse.Message = $"No physics hit at ({inputPosition.x:F1}, {inputPosition.y:F1}).";
+                noHitResponse.CameraName = raycastResult.Camera.name;
+                noHitResponse.CameraPath = GameObjectPathUtility.GetFullPath(raycastResult.Camera.gameObject);
                 return Task.FromResult(noHitResponse);
             }
 
@@ -57,6 +59,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             response.Success = true;
             response.Hit = true;
             response.Message = $"Hit {nearestHit.collider.gameObject.name} at ({inputPosition.x:F1}, {inputPosition.y:F1}).";
+            response.CameraName = raycastResult.Camera.name;
+            response.CameraPath = GameObjectPathUtility.GetFullPath(raycastResult.Camera.gameObject);
             response.HitGameObjectName = nearestHit.collider.gameObject.name;
             response.HitGameObjectPath = GameObjectPathUtility.GetFullPath(nearestHit.collider.gameObject);
             response.HitLayer = nearestHit.collider.gameObject.layer;


### PR DESCRIPTION
## Summary
- `raycast` now reports which camera the ray was actually cast from, on every response (hit and no-hit alike).

## User Impact
- Before: when a scene had more than one `MainCamera`-tagged camera, `Camera.main` could resolve to a camera the agent didn't expect, and a "No physics hit" response gave no way to tell which camera was actually used. A round5 dogfooding session got stuck on exactly this.
- After: every raycast response includes `CameraName` and `CameraPath` for the resolved camera, so a surprising "no hit" can be diagnosed immediately instead of assuming the intended camera was used.

## Changes
- Add `CameraName`/`CameraPath` to `RaycastResponse` (additive, existing fields unchanged).
- Thread the resolved `Camera.main` through `GameViewRaycastUtility`'s result so `RaycastTool` can report it on both the hit and no-hit paths.

## Verification
- `dist/darwin-arm64/uloop compile --project-path .` — 0 errors, 0 warnings.
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value RaycastToolTests --test-mode EditMode` — 6/6 passed.
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value Raycast --test-mode EditMode` — 54/54 passed (full regression across raycast-related tests).
- Confirmed Red→Green: ran the new tests before the implementation (compile errors for missing `CameraName`/`CameraPath`), then implemented and re-ran to green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

