### PR TITLE
docs: Document the resolved-camera fields in the raycast skill

### DIFF
--- a/.agents/skills/uloop-raycast/SKILL.md
+++ b/.agents/skills/uloop-raycast/SKILL.md
@@ -50,6 +50,7 @@ uloop raycast --x 960 --y 540 --layer-mask 1
 Returns JSON with:
 - `Success`: Whether the command completed
 - `Message`: Status message
+- `CameraName` / `CameraPath`: The camera that `Camera.main` resolved to and that the ray was cast from, reported on both hit and no-hit responses. When a `No physics hit` result looks wrong, check these first — another camera in the scene carrying the `MainCamera` tag can silently win the `Camera.main` resolution, so the ray may not come from the viewpoint you expect
 - `Hit`: Whether physics hit anything
 - `HitGameObjectName` / `HitGameObjectPath`: Hit object identity when `Hit` is true
 - `HitLayer` / `HitLayerName`: Hit object layer when `Hit` is true

--- a/.claude/skills/uloop-raycast/SKILL.md
+++ b/.claude/skills/uloop-raycast/SKILL.md
@@ -50,6 +50,7 @@ uloop raycast --x 960 --y 540 --layer-mask 1
 Returns JSON with:
 - `Success`: Whether the command completed
 - `Message`: Status message
+- `CameraName` / `CameraPath`: The camera that `Camera.main` resolved to and that the ray was cast from, reported on both hit and no-hit responses. When a `No physics hit` result looks wrong, check these first — another camera in the scene carrying the `MainCamera` tag can silently win the `Camera.main` resolution, so the ray may not come from the viewpoint you expect
 - `Hit`: Whether physics hit anything
 - `HitGameObjectName` / `HitGameObjectPath`: Hit object identity when `Hit` is true
 - `HitLayer` / `HitLayerName`: Hit object layer when `Hit` is true

--- a/Packages/src/Editor/FirstPartyTools/Raycast/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Raycast/Skill/SKILL.md
@@ -50,6 +50,7 @@ uloop raycast --x 960 --y 540 --layer-mask 1
 Returns JSON with:
 - `Success`: Whether the command completed
 - `Message`: Status message
+- `CameraName` / `CameraPath`: The camera that `Camera.main` resolved to and that the ray was cast from, reported on both hit and no-hit responses. When a `No physics hit` result looks wrong, check these first — another camera in the scene carrying the `MainCamera` tag can silently win the `Camera.main` resolution, so the ray may not come from the viewpoint you expect
 - `Hit`: Whether physics hit anything
 - `HitGameObjectName` / `HitGameObjectPath`: Hit object identity when `Hit` is true
 - `HitLayer` / `HitLayerName`: Hit object layer when `Hit` is true


### PR DESCRIPTION
## Summary

Follow-up to PR #1904 (resolved-camera fields in raycast responses). Docs only.

- `Packages/src/Editor/FirstPartyTools/Raycast/Skill/SKILL.md`: document `CameraName` / `CameraPath` in the Output list, and tell agents to check them first when a `No physics hit` result looks wrong (a stray `MainCamera`-tagged camera can silently win the `Camera.main` resolution — the exact Round-5 dogfooding failure).
- Regenerated `.claude/` and `.agents/` copies via `uloop skills install --claude --agents`; verified the generated diff matches the source.

## Verification

- Docs-only change; source SKILL.md and generated copies are byte-consistent.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

