### PR TITLE
feat: Record pause-point and raycast activity in the diagnostics log

### DIFF
--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -14,6 +14,7 @@ using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.Tests.PausePointToolsFixtures;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -598,6 +599,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.SnapshotTiming, Is.Empty);
             Assert.That(response.EditorState.CapturedAt, Is.EqualTo(UloopPausePointEditorStateCapturedAt.Current));
             Assert.That(response.RecommendedNextAction, Is.Empty);
+        }
+
+        [Test]
+        public async Task Enable_WhenMarkerCreated_EmitsPausePointEnableVibeLog()
+        {
+            // Verifies enable-pause-point records a pause_point_enable observability event.
+            VibeLogger.ClearMemoryLogs();
+
+            await EnablePausePointAsync("jump");
+
+            string logs = VibeLogger.GetLogsForAi("pause_point_enable");
+            Assert.That(logs, Does.Contain("pause_point_enable"));
+            Assert.That(logs, Does.Contain("\"Id\": \"jump\""));
+        }
+
+        [Test]
+        public async Task Clear_WhenMarkerCleared_EmitsPausePointClearedVibeLog()
+        {
+            // Verifies clear-pause-point records a pause_point_cleared observability event.
+            await EnablePausePointAsync("jump");
+            VibeLogger.ClearMemoryLogs();
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["id"] = "jump" };
+            await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            string logs = VibeLogger.GetLogsForAi("pause_point_cleared");
+            Assert.That(logs, Does.Contain("pause_point_cleared"));
+            Assert.That(logs, Does.Contain("\"Target\": \"jump\""));
+        }
+
+        [Test]
+        public async Task Clear_WhenMarkerExpired_EmitsPausePointExpiredVibeLog()
+        {
+            // Verifies clear-pause-point on an already-expired marker records a pause_point_expired
+            // observability event alongside pause_point_cleared.
+            await EnablePausePointAsync("jump");
+            _nowUtc = _nowUtc.AddSeconds(31);
+            VibeLogger.ClearMemoryLogs();
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["id"] = "jump" };
+            await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            string logs = VibeLogger.GetLogsForAi("pause_point_expired");
+            Assert.That(logs, Does.Contain("pause_point_expired"));
+            Assert.That(logs, Does.Contain("\"Id\": \"jump\""));
         }
 
         [Test]

--- a/Assets/Tests/Editor/RaycastToolTests.cs
+++ b/Assets/Tests/Editor/RaycastToolTests.cs
@@ -119,6 +119,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task ExecuteAsync_WhenCoordinateIntersectsCollider_EmitsRaycastExecutedVibeLog()
+        {
+            // Verifies a raycast records a raycast_executed observability event with camera/hit context.
+            CreateRaycastScene();
+            Vector2 gameViewSize = GameViewCoordinateUtility.GetMainGameViewSize();
+            Vector2 inputPosition = new Vector2(gameViewSize.x / 2f, gameViewSize.y / 2f);
+            VibeLogger.ClearMemoryLogs();
+
+            await ExecuteRaycast(inputPosition);
+
+            string logs = VibeLogger.GetLogsForAi("raycast_executed");
+            Assert.That(logs, Does.Contain("raycast_executed"));
+            Assert.That(logs, Does.Contain("\"CameraName\": \"RaycastToolTestsCamera\""));
+            Assert.That(logs, Does.Contain("\"Hit\": true"));
+            Assert.That(logs, Does.Contain("\"HitGameObjectName\": \"RaycastToolTestsCube\""));
+        }
+
+        [Test]
         public async Task ExecuteAsync_WhenCameraIsMissing_ShouldReturnConversionMetadata()
         {
             // Tests that a missing Camera.main fails the raycast but still returns coordinate conversion metadata.

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
@@ -12,6 +12,7 @@ using UnityEngine.TestTools;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -52,6 +53,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(snapshot.CapturedVariables.Select(v => v.Name), Is.EquivalentTo(new[] { "speed", "damage" }));
             Assert.That(snapshot.CapturedVariablesTruncated, Is.False);
             Assert.That(_pauseController.PauseCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Capture_WhenPausePointIsEnabled_EmitsPausePointHitVibeLog()
+        {
+            // Verifies a source-capture hit records a pause_point_hit observability event.
+            UloopPausePointRegistry.Enable("jump", 30);
+            VibeLogger.ClearMemoryLogs();
+
+            SourcePausePointCapture.Capture("jump", null, Array.Empty<object>(), Array.Empty<object>());
+
+            string logs = VibeLogger.GetLogsForAi("pause_point_hit");
+            Assert.That(logs, Does.Contain("pause_point_hit"));
+            Assert.That(logs, Does.Contain("\"Id\": \"jump\""));
+            Assert.That(logs, Does.Contain("\"HitCount\": 1"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/SourcePausePointCapture/UnityCLILoop.Tests.Editor.SourcePausePointCapture.asmdef
+++ b/Assets/Tests/Editor/SourcePausePointCapture/UnityCLILoop.Tests.Editor.SourcePausePointCapture.asmdef
@@ -5,7 +5,8 @@
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:94d8abc693f543a691a4645a5ff42e5c",
-        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d",
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -331,6 +331,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return PausePointResponse.FromSnapshot(snapshot);
         }
 
+        // Why: PausePointStatusBridgeCommand duplicates this instead of sharing it, since that
+        // bridge must not reference this Editor-only tool assembly. Keep both in sync if the
+        // log shape or wording changes.
         private static void LogCleared(string target, string statusBeforeClear)
         {
             VibeLogger.LogInfo(
@@ -339,6 +342,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 new { Target = target, StatusBeforeClear = statusBeforeClear });
         }
 
+        // Why: PausePointStatusBridgeCommand duplicates this instead of sharing it, since that
+        // bridge must not reference this Editor-only tool assembly. Keep both in sync if the
+        // log shape or wording changes.
         private static void LogExpired(string id, long elapsedSinceEnabledMilliseconds)
         {
             VibeLogger.LogInfo(

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -299,6 +299,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters.MaxHistory);
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
             response.Warning = CreateEnableWarning();
+            LogEnable(response.Id, resolvedMethod: string.Empty, fileLine: string.Empty, response.Mode, response.Warning);
             return response;
         }
 
@@ -310,6 +311,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // SourcePausePointPatcher wires into it; this use case never references the
                 // Patcher directly.
                 UloopPausePointClearAllResult clearAllResult = UloopPausePointRegistry.ClearAll();
+                LogCleared("all", string.Empty);
                 return PausePointResponse.FromClearAll(clearAllResult);
             }
 
@@ -320,7 +322,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(parameters.Id);
+            LogCleared(snapshot.Id, snapshot.StatusBeforeClear);
+            if (snapshot.StatusBeforeClear == UloopPausePointStatus.Expired)
+            {
+                LogExpired(snapshot.Id, snapshot.ElapsedSinceEnabledMilliseconds);
+            }
+
             return PausePointResponse.FromSnapshot(snapshot);
+        }
+
+        private static void LogCleared(string target, string statusBeforeClear)
+        {
+            VibeLogger.LogInfo(
+                "pause_point_cleared",
+                $"Pause point cleared: {target}",
+                new { Target = target, StatusBeforeClear = statusBeforeClear });
+        }
+
+        private static void LogExpired(string id, long elapsedSinceEnabledMilliseconds)
+        {
+            VibeLogger.LogInfo(
+                "pause_point_expired",
+                $"Pause point expired before being cleared: {id}",
+                new { Id = id, ElapsedSinceEnabledMilliseconds = elapsedSinceEnabledMilliseconds });
         }
 
         // Resolves File:Line to a patch location via the Resolver, patches it via Harmony, then
@@ -361,7 +385,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             response.ResolvedMethod = resolveResult.Resolution.MethodDisplayName;
             response.SnapshotTiming = SourcePausePointConstants.PreLineSnapshotTimingNote;
             response.Warning = MergeWarnings(CreateEnableWarning(), patchResult.Warning);
+            LogEnable(response.Id, response.ResolvedMethod, $"{parameters.File}:{response.ResolvedLine}", response.Mode, response.Warning);
             return response;
+        }
+
+        private static void LogEnable(string id, string resolvedMethod, string fileLine, string mode, string warning)
+        {
+            VibeLogger.LogInfo(
+                "pause_point_enable",
+                $"Pause point enabled: {id}",
+                new { Id = id, ResolvedMethod = resolvedMethod, FileLine = fileLine, Mode = mode, HasWarning = !string.IsNullOrEmpty(warning) });
         }
 
         // The resolved line can be rounded forward from the requested line (the Resolver picks

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCapture.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCapture.cs
@@ -30,7 +30,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (MainThreadSwitcher.IsMainThread)
             {
-                UloopPausePointRegistry.HitWithCapturedFrame(id, frame, variables, truncated);
+                UloopPausePointSnapshot snapshot = UloopPausePointRegistry.HitWithCapturedFrame(id, frame, variables, truncated);
+                LogHit(snapshot, truncated);
                 return;
             }
 
@@ -38,8 +39,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // touched from the main thread, so an off-thread hit is recorded on the next
             // main-thread tick instead of inline. HitCore re-checks IsEnabled at that point, so a
             // marker that already got disarmed by a faster hit safely no-ops there.
-            MainThreadSwitcher.AddContinuation(
-                () => UloopPausePointRegistry.HitWithCapturedFrame(id, frame, variables, truncated));
+            MainThreadSwitcher.AddContinuation(() =>
+            {
+                UloopPausePointSnapshot snapshot = UloopPausePointRegistry.HitWithCapturedFrame(id, frame, variables, truncated);
+                LogHit(snapshot, truncated);
+            });
+        }
+
+        private static void LogHit(UloopPausePointSnapshot snapshot, bool truncated)
+        {
+            VibeLogger.LogInfo(
+                "pause_point_hit",
+                $"Pause point hit: {snapshot.Id}",
+                new { Id = snapshot.Id, snapshot.HitCount, CapturedVariablesTruncated = truncated });
         }
 
         internal static (UloopPausePointCapturedVariableFrame Frame, List<UloopCapturedVariable> Variables, bool Truncated)

--- a/Packages/src/Editor/FirstPartyTools/Raycast/RaycastTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/Raycast/RaycastTool.cs
@@ -40,6 +40,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 RaycastResponse noCameraResponse = CreateBaseResponse(raycastResult.Conversion);
                 noCameraResponse.Success = false;
                 noCameraResponse.Message = "Camera.main was not found. Add an active camera tagged MainCamera before using raycast.";
+                LogRaycastExecuted(inputPosition, noCameraResponse);
                 return Task.FromResult(noCameraResponse);
             }
 
@@ -51,6 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 noHitResponse.Message = $"No physics hit at ({inputPosition.x:F1}, {inputPosition.y:F1}).";
                 noHitResponse.CameraName = raycastResult.Camera.name;
                 noHitResponse.CameraPath = GameObjectPathUtility.GetFullPath(raycastResult.Camera.gameObject);
+                LogRaycastExecuted(inputPosition, noHitResponse);
                 return Task.FromResult(noHitResponse);
             }
 
@@ -72,7 +74,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             response.HitNormalX = nearestHit.normal.x;
             response.HitNormalY = nearestHit.normal.y;
             response.HitNormalZ = nearestHit.normal.z;
+            LogRaycastExecuted(inputPosition, response);
             return Task.FromResult(response);
+        }
+
+        private static void LogRaycastExecuted(Vector2 inputPosition, RaycastResponse response)
+        {
+            VibeLogger.LogInfo(
+                "raycast_executed",
+                $"Raycast executed at ({inputPosition.x:F1}, {inputPosition.y:F1})",
+                new
+                {
+                    CameraName = response.CameraName,
+                    InputPositionX = inputPosition.x,
+                    InputPositionY = inputPosition.y,
+                    Hit = response.Hit,
+                    HitGameObjectName = response.HitGameObjectName
+                });
         }
 
         private static RaycastResponse CreateBaseResponse(GameViewCoordinateConversion conversion)

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -50,6 +50,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return PausePointStatusResponse.FromSnapshot(snapshot);
         }
 
+        // Why: PausePointTools.LogCleared duplicates this instead of sharing it, since this
+        // bridge must not reference that Editor-only tool assembly. Keep both in sync if the
+        // log shape or wording changes.
         private static void LogCleared(string target, string statusBeforeClear)
         {
             VibeLogger.LogInfo(
@@ -58,6 +61,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 new { Target = target, StatusBeforeClear = statusBeforeClear });
         }
 
+        // Why: PausePointTools.LogExpired duplicates this instead of sharing it, since this
+        // bridge must not reference that Editor-only tool assembly. Keep both in sync if the
+        // log shape or wording changes.
         private static void LogExpired(string id, long elapsedSinceEnabledMilliseconds)
         {
             VibeLogger.LogInfo(

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -41,7 +41,29 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             // that Editor-only tool assembly directly - never leaves a Harmony injection attached
             // after the marker itself reports Cleared.
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(id);
+            LogCleared(id, snapshot.StatusBeforeClear);
+            if (snapshot.StatusBeforeClear == UloopPausePointStatus.Expired)
+            {
+                LogExpired(id, snapshot.ElapsedSinceEnabledMilliseconds);
+            }
+
             return PausePointStatusResponse.FromSnapshot(snapshot);
+        }
+
+        private static void LogCleared(string target, string statusBeforeClear)
+        {
+            VibeLogger.LogInfo(
+                "pause_point_cleared",
+                $"Pause point cleared: {target}",
+                new { Target = target, StatusBeforeClear = statusBeforeClear });
+        }
+
+        private static void LogExpired(string id, long elapsedSinceEnabledMilliseconds)
+        {
+            VibeLogger.LogInfo(
+                "pause_point_expired",
+                $"Pause point expired before being cleared: {id}",
+                new { Id = id, ElapsedSinceEnabledMilliseconds = elapsedSinceEnabledMilliseconds });
         }
 
         private static string ReadId(JToken paramsToken)


### PR DESCRIPTION
## Summary
- Pause-point enable/hit/clear/expiry and raycast executions now leave a trace in the vibe log, so a pause-point workflow can be diagnosed after the fact instead of only by re-running it live.

## User Impact
- Before: nothing in `.uloop/outputs/VibeLogs/` recorded when a pause point was armed, hit, cleared, or expired, or when a raycast ran — an agent debugging a failed workflow had no log-based evidence for what actually happened.
- After: five new operations (`pause_point_enable`, `pause_point_hit`, `pause_point_cleared`, `pause_point_expired`, `raycast_executed`) appear in the vibe log with lean context fields (ids, hit counts, camera/hit names, elapsed time) — no code content or full `CapturedVariables` payloads.

## Changes
- `PausePointTools.cs` (`PausePointUseCase`): logs `pause_point_enable` on both the id-based and source-based enable paths, and `pause_point_cleared`/`pause_point_expired` from `Clear` (single id and `--all`).
- `PausePointStatusBridgeCommand.cs`: logs the same `pause_point_cleared`/`pause_point_expired` events from the CLI status-bridge's own `Clear` path, since that path calls the registry directly and would otherwise miss the same fix (the Round-4 regression this series has already run into once).
- `SourcePausePointCapture.cs`: logs `pause_point_hit` after a source-patched hit is recorded.
- `RaycastTool.cs`: logs `raycast_executed` on every exit path (no-camera, no-hit, and hit), including camera name, input coordinates, hit flag, and hit target name.
- Added unit tests asserting each operation actually appears via `VibeLogger.GetLogsForAi(...)`.

## Verification
- `dist/darwin-arm64/uloop compile --project-path .` — 0 errors, 0 warnings.
- `dist/darwin-arm64/uloop run-tests --project-path . --filter-value "PausePointTests|SourcePausePointCaptureTests|RaycastToolTests|PausePointStatusResponseContractTests|PausePointToolModeTests|PausePointCaptureModeTests" --test-mode EditMode` — 104/104 passed.
- Confirmed Red→Green on the `pause_point_enable` log test (test failed with the log call removed, passed once restored).
- Live round trip against a running Unity Editor: entered PlayMode, enabled a pause point, triggered a hit, cleared it, ran a raycast, and separately let a short-timeout marker expire before clearing it. All 5 operations were confirmed present in `.uloop/outputs/VibeLogs/unity_vibe_20260721.json` with the expected context fields.
- This PR targets the integration branch, so repository CI workflows are not expected to trigger (as with the prior PRs in this series); verification here is the local compile/test run plus the live round trip above.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

