### PR TITLE
fix: Remove fork context from one-shot uloop tool skills

### DIFF
--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-execute-dynamic-code
 toolName: execute-dynamic-code
 description: "Execute C# with Unity APIs when existing uloop tools cannot inspect or edit enough. Use for reachable scene/component state, scene/prefab/menu automation, and PlayMode checks"
-context: fork
 ---
 
 # Task

--- a/.agents/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.agents/skills/uloop-simulate-keyboard/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-simulate-keyboard
 toolName: simulate-keyboard
 description: "Simulate keyboard input in PlayMode through Unity Input System. Use for key presses, holds, releases, and game controls such as WASD or Space."
-context: fork
 ---
 
 # Task

--- a/.agents/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-input/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-simulate-mouse-input
 toolName: simulate-mouse-input
 description: "Simulate Mouse.current input in PlayMode through Unity Input System. Use for gameplay mouse clicks, held button input, movement delta, or scroll. Use simulate-mouse-ui for UI."
-context: fork
 ---
 
 # Task

--- a/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-simulate-mouse-ui
 toolName: simulate-mouse-ui
 description: "Simulate PlayMode EventSystem UI mouse actions using screen coordinates. Use for UI clicks, long-presses, or drags from annotated screenshots."
-context: fork
 ---
 
 # Task

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-execute-dynamic-code
 toolName: execute-dynamic-code
 description: "Execute C# with Unity APIs when existing uloop tools cannot inspect or edit enough. Use for reachable scene/component state, scene/prefab/menu automation, and PlayMode checks"
-context: fork
 ---
 
 # Task

--- a/.claude/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.claude/skills/uloop-simulate-keyboard/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-simulate-keyboard
 toolName: simulate-keyboard
 description: "Simulate keyboard input in PlayMode through Unity Input System. Use for key presses, holds, releases, and game controls such as WASD or Space."
-context: fork
 ---
 
 # Task

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-simulate-mouse-input
 toolName: simulate-mouse-input
 description: "Simulate Mouse.current input in PlayMode through Unity Input System. Use for gameplay mouse clicks, held button input, movement delta, or scroll. Use simulate-mouse-ui for UI."
-context: fork
 ---
 
 # Task

--- a/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-simulate-mouse-ui
 toolName: simulate-mouse-ui
 description: "Simulate PlayMode EventSystem UI mouse actions using screen coordinates. Use for UI clicks, long-presses, or drags from annotated screenshots."
-context: fork
 ---
 
 # Task

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-execute-dynamic-code
 toolName: execute-dynamic-code
 description: "Execute C# with Unity APIs when existing uloop tools cannot inspect or edit enough. Use for reachable scene/component state, scene/prefab/menu automation, and PlayMode checks"
-context: fork
 ---
 
 # Task

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-simulate-keyboard
 toolName: simulate-keyboard
 description: "Simulate keyboard input in PlayMode through Unity Input System. Use for key presses, holds, releases, and game controls such as WASD or Space."
-context: fork
 ---
 
 # Task

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-simulate-mouse-input
 toolName: simulate-mouse-input
 description: "Simulate Mouse.current input in PlayMode through Unity Input System. Use for gameplay mouse clicks, held button input, movement delta, or scroll. Use simulate-mouse-ui for UI."
-context: fork
 ---
 
 # Task

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
@@ -2,7 +2,6 @@
 name: uloop-simulate-mouse-ui
 toolName: simulate-mouse-ui
 description: "Simulate PlayMode EventSystem UI mouse actions using screen coordinates. Use for UI clicks, long-presses, or drags from annotated screenshots."
-context: fork
 ---
 
 # Task


### PR DESCRIPTION
## Summary

Part of Round-6 pause-point usability improvements (PR-3 of 5, targeting the `feature/round6-pause-point-improvements` integration branch).

Removes the `context: fork` frontmatter from the four uloop tool skills that wrap single CLI commands:

- `uloop-simulate-keyboard`
- `uloop-simulate-mouse-input`
- `uloop-simulate-mouse-ui`
- `uloop-execute-dynamic-code`

## Why

`context: fork` makes a skill run as a forked subagent that does not receive the caller's task. In the Round-6 field verification sessions (3D voxel sandbox project), invoking these skills through a `Skill()` call spawned a subagent that only asked "what should I do?" and executed nothing, forcing the agent to fall back to raw `uloop` CLI calls via Bash. These skills are thin wrappers around one-shot commands and gain nothing from subagent isolation, so they should load inline with the caller's context.

## Changes

- Removed the `context: fork` line from the four source `SKILL.md` files under `Packages/src/Editor/FirstPartyTools/<Tool>/Skill/`.
- Regenerated `.claude/skills/` and `.agents/skills/` copies with `uloop skills install --claude --agents`.

## Verification

- `git grep -n "context: fork" -- Packages .claude .agents` returns only a historical CHANGELOG entry; no skill file retains the fork context.
- Skill bodies contain no fork-dependent wording (checked for `fork` / `subagent` references).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

