### PR TITLE
feat: Scope clear-pause-point resume to pause-point-owned pauses

### DIFF
--- a/Assets/Tests/Editor/PausePointCaptureModeTests.cs
+++ b/Assets/Tests/Editor/PausePointCaptureModeTests.cs
@@ -116,7 +116,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.Continuous, 20);
             UloopPausePointRegistry.Hit("jump");
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, _) = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(snapshot.IsEnabled, Is.False);
             Assert.That(snapshot.CapturedVariableHistory, Has.Count.EqualTo(1));

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -392,6 +392,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Clear_WhenWindowOpenButEditorAlreadyExternallyUnpaused_DoesNotReportResumeAndClosesStaleWindow()
+        {
+            // Verifies the still-open window is reconciled before deciding: a hit opened the
+            // window, then the Editor was unpaused externally before the update tick observed it.
+            // Clear must not claim it resumed Play Mode (Resume is a no-op on an unpaused Editor)
+            // and must close the stale window so it stops freezing expiry. ClearAll shares the same
+            // ResumeEditorPauseIfOwnedByPausePoint path, so this covers both entry points.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+            _pauseController.ResumeExternally();
+
+            (UloopPausePointSnapshot _, bool resumedFromPause) = UloopPausePointRegistry.Clear("jump");
+
+            Assert.That(resumedFromPause, Is.False);
+            Assert.That(_pauseController.ResumeCount, Is.EqualTo(0));
+            // The stale window is closed: an unrelated marker's countdown is no longer frozen.
+            UloopPausePointRegistry.Enable("dash", 1);
+            _nowUtc = _nowUtc.AddSeconds(2);
+            UloopPausePointRegistry.ApplyCaptureWindowExpirations();
+            Assert.That(UloopPausePointRegistry.GetStatus("dash").Status, Is.EqualTo(UloopPausePointStatus.Expired));
+        }
+
+        [Test]
         public void ApplyCaptureWindowExpirations_WhenHitPastTimeoutWhilePaused_DoesNotExpireUntilResumed()
         {
             // Verifies a hit's own Editor pause freezes the capture window countdown, so an

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -315,7 +315,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies explicit clear prevents later marker hits from pausing Unity.
             UloopPausePointRegistry.Enable("jump", 30);
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, _) = UloopPausePointRegistry.Clear("jump");
             UloopPausePoint.Pause("jump");
 
             Assert.That(snapshot.Status, Is.EqualTo(UloopPausePointStatus.Cleared));
@@ -330,35 +330,65 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePoint.Pause("jump");
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, _) = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(snapshot.Message, Is.EqualTo("Pause point was already hit (auto-disarmed); nothing to clear."));
             Assert.That(_pauseController.IsPaused, Is.False);
         }
 
         [Test]
-        public void Clear_AfterHit_ShouldResumeEditorPause()
+        public void Clear_AfterHit_ResumesPausePointOwnedPauseAndReportsResumed()
         {
-            // Verifies Option B: Clear resumes even when the pause was left from a pause-point hit.
+            // Verifies Clear resumes and reports ResumedFromPause when a pause-point hit owns the pause.
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePoint.Pause("jump");
             Assert.That(_pauseController.IsPaused, Is.True);
 
-            UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot _, bool resumedFromPause) = UloopPausePointRegistry.Clear("jump");
 
+            Assert.That(resumedFromPause, Is.True);
             Assert.That(_pauseController.IsPaused, Is.False);
         }
 
         [Test]
-        public void ClearAll_AfterHit_ShouldResumeEditorPause()
+        public void Clear_WhenEditorManuallyPaused_LeavesPauseUntouchedAndReportsNotResumed()
         {
-            // Verifies ClearAll also resumes under Option B.
+            // Verifies Clear preserves a manual pause (no open pause window) instead of resuming it.
+            UloopPausePointRegistry.Enable("jump", 30);
+            _pauseController.PauseExternally();
+
+            (UloopPausePointSnapshot _, bool resumedFromPause) = UloopPausePointRegistry.Clear("jump");
+
+            Assert.That(resumedFromPause, Is.False);
+            Assert.That(_pauseController.IsPaused, Is.True);
+            Assert.That(_pauseController.ResumeCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ClearAll_AfterHit_ResumesPausePointOwnedPauseAndReportsResumed()
+        {
+            // Verifies ClearAll resumes and reports ResumedFromPause when a hit owns the pause.
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePoint.Pause("jump");
 
-            UloopPausePointRegistry.ClearAll();
+            UloopPausePointClearAllResult result = UloopPausePointRegistry.ClearAll();
 
+            Assert.That(result.ResumedFromPause, Is.True);
             Assert.That(_pauseController.IsPaused, Is.False);
+        }
+
+        [Test]
+        public void ClearAll_WhenEditorManuallyPaused_LeavesPauseUntouchedAndReportsNotResumed()
+        {
+            // Verifies ClearAll preserves a manual pause (no open pause window) instead of resuming it.
+            UloopPausePointRegistry.Enable("jump", 30);
+            _pauseController.PauseExternally();
+
+            UloopPausePointClearAllResult result = UloopPausePointRegistry.ClearAll();
+
+            Assert.That(result.ResumedFromPause, Is.False);
+            Assert.That(_pauseController.IsPaused, Is.True);
+            Assert.That(_pauseController.ResumeCount, Is.EqualTo(0));
         }
 
         [Test]
@@ -549,7 +579,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 1);
             _nowUtc = _nowUtc.AddSeconds(2);
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, _) = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(snapshot.Message, Is.EqualTo("Pause point had already expired before being hit; nothing to clear."));
         }
@@ -561,7 +591,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePointRegistry.Clear("jump");
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, _) = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(snapshot.Message, Is.EqualTo("Pause point was already cleared."));
         }
@@ -583,6 +613,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.EditorState.IsPaused, Is.False);
             Assert.That(response.EditorState.CapturedAt, Is.EqualTo(UloopPausePointEditorStateCapturedAt.ClearAll));
             Assert.That(response.Message, Is.EqualTo("No active pause points to clear."));
+        }
+
+        [Test]
+        public async Task Clear_WhenResumingPausePointOwnedPause_SetsResumedPlayModeWarning()
+        {
+            // Verifies the clear-pause-point tool warns when the clear resumed a pause-point-owned pause.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["id"] = "jump" };
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Warning, Is.EqualTo(SourcePausePointConstants.ClearResumedPlayModeWarning));
+        }
+
+        [Test]
+        public async Task Clear_WhenManualPausePreserved_SetsNoWarning()
+        {
+            // Verifies the clear-pause-point tool emits no resume warning when it preserves a manual pause.
+            UloopPausePointRegistry.Enable("jump", 30);
+            _pauseController.PauseExternally();
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["id"] = "jump" };
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Warning, Is.Empty);
+        }
+
+        [Test]
+        public async Task ClearAll_WhenResumingPausePointOwnedPause_SetsResumedPlayModeWarning()
+        {
+            // Verifies clear-pause-point --all warns when the bulk clear resumed a pause-point-owned pause.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["all"] = true };
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Warning, Is.EqualTo(SourcePausePointConstants.ClearResumedPlayModeWarning));
         }
 
         [Test]
@@ -1267,6 +1339,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public void ResumeExternally()
             {
                 IsPaused = false;
+            }
+
+            // Simulates a manual pause set outside the pause-point workflow (control-play-mode
+            // --action Pause, or the Editor's own pause button). It never opens a pause window, so
+            // clear must leave it untouched. PauseCount is not incremented because no pause-point
+            // hit requested it.
+            public void PauseExternally()
+            {
+                IsPaused = true;
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -133,7 +133,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 EditorState = PausePointEditorState.FromSnapshot(result.EditorState),
                 Message = result.ClearedCount == 0
                     ? "No active pause points to clear."
-                    : "Pause points cleared."
+                    : "Pause points cleared.",
+                Warning = result.ResumedFromPause
+                    ? SourcePausePointConstants.ClearResumedPlayModeWarning
+                    : string.Empty
             };
         }
     }
@@ -321,14 +324,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return CreateValidationFailure(idError);
             }
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(parameters.Id);
+            (UloopPausePointSnapshot snapshot, bool resumedFromPause) = UloopPausePointRegistry.Clear(parameters.Id);
             LogCleared(snapshot.Id, snapshot.StatusBeforeClear);
             if (snapshot.StatusBeforeClear == UloopPausePointStatus.Expired)
             {
                 LogExpired(snapshot.Id, snapshot.ElapsedSinceEnabledMilliseconds);
             }
 
-            return PausePointResponse.FromSnapshot(snapshot);
+            PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
+            if (resumedFromPause)
+            {
+                response.Warning = SourcePausePointConstants.ClearResumedPlayModeWarning;
+            }
+
+            return response;
         }
 
         // Why: PausePointStatusBridgeCommand duplicates this instead of sharing it, since that

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -84,6 +84,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string PreLineSnapshotTimingNote =
             "pre-line: variables are captured before ResolvedLine executes";
 
+        // Surfaced only when a clear actually resumed Play Mode, so the caller understands the
+        // clear had a side effect on run state. A manual pause (control-play-mode --action Pause
+        // or the Editor pause button) is left untouched by clear and never triggers this.
+        public const string ClearResumedPlayModeWarning =
+            "This clear resumed Play Mode because the pause was owned by a pause-point hit. "
+            + "A manual pause set outside the pause-point workflow would have been left untouched.";
+
         // Release code optimization strips most sequence points and hoists/elides locals, so the
         // Resolver's PDB-driven lookup cannot reliably find a patch location; rejecting up front
         // avoids patching the wrong instruction instead of failing later in a confusing way.

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -40,7 +40,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             // SourcePausePointPatcher wires into it, so this bridge - which must not reference
             // that Editor-only tool assembly directly - never leaves a Harmony injection attached
             // after the marker itself reports Cleared.
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(id);
+            // The CLI polling bridge only reports marker status; the resumed-from-pause side
+            // effect is surfaced through the clear-pause-point tool response, not this path.
+            (UloopPausePointSnapshot snapshot, bool _) = UloopPausePointRegistry.Clear(id);
             LogCleared(id, snapshot.StatusBeforeClear);
             if (snapshot.StatusBeforeClear == UloopPausePointStatus.Expired)
             {

--- a/Packages/src/Runtime/PausePoints/UloopPausePointClearAllResult.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointClearAllResult.cs
@@ -13,7 +13,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             int clearedCount,
             DateTime clearedAtUtc,
             UloopPausePointEditorStateSnapshot editorState,
-            string[] clearedIds)
+            string[] clearedIds,
+            bool resumedFromPause)
         {
             Debug.Assert(editorState != null, "editorState must not be null");
             Debug.Assert(clearedIds != null, "clearedIds must not be null");
@@ -22,12 +23,18 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             ClearedAtUtc = clearedAtUtc;
             EditorState = editorState;
             ClearedIds = clearedIds;
+            ResumedFromPause = resumedFromPause;
         }
 
         public int ClearedCount { get; }
         public DateTime ClearedAtUtc { get; }
         public UloopPausePointEditorStateSnapshot EditorState { get; }
         public string[] ClearedIds { get; }
+
+        // True when the bulk clear actually resumed a pause-point-owned Editor pause, so callers
+        // can warn that Play Mode was resumed as a side effect. False when no pause window was
+        // open (e.g. nothing was paused, or only a manual pause the clear intentionally preserved).
+        public bool ResumedFromPause { get; }
     }
 }
 #endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -412,6 +412,12 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         // Editor even when the pause was manual.
         private static bool ResumeEditorPauseIfOwnedByPausePoint()
         {
+            // A manual unpause (Editor pause button / control-play-mode) may not have been observed
+            // yet, because the external-resume sync runs on the Editor update tick. Reconcile first
+            // so a window left open by that unobserved unpause is credited and closed here instead
+            // of being misreported as a resume this clear performed (it would be a no-op resume of
+            // an already-unpaused Editor) and instead of leaving the stale window freezing expiry.
+            ClosePauseWindowIfEditorResumedExternally();
             if (!_pauseWindowStartUtc.HasValue)
             {
                 return false;

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -75,7 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             return entry.ToSnapshot(now, _pauseController);
         }
 
-        public static UloopPausePointSnapshot Clear(string id)
+        public static (UloopPausePointSnapshot Snapshot, bool ResumedFromPause) Clear(string id)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(id), "id must not be null or empty");
 
@@ -84,7 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             DateTime now = NowUtc();
             if (!Entries.ContainsKey(id))
             {
-                return UloopPausePointSnapshot.NotEnabled(id, _pauseController);
+                return (UloopPausePointSnapshot.NotEnabled(id, _pauseController), false);
             }
 
             UloopPausePointEntry entry = Entries[id];
@@ -105,9 +105,14 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             };
             entry.MarkCleared(UloopPausePointClearedReason.ExplicitClear, message);
             ClearHitSnapshotAndRawCaptureForId(id);
-            // Why always Resume: Option B does not distinguish manual vs pause-point pause.
-            ResumeEditorPause();
-            return entry.ToSnapshot(now, _pauseController);
+            // Why only when pause-point-owned: a clear must not steal ownership of a manual pause
+            // the user set outside the pause-point workflow (control-play-mode --action Pause or
+            // the Editor pause button). It resumes only while a pause window is open - i.e. while
+            // a pause-point hit is what is holding the Editor paused. Manual pauses leave no open
+            // window, so they are left untouched. (Client disconnect and expiry still resume
+            // unconditionally: those paths must guarantee release even for a manual pause.)
+            bool resumedFromPause = ResumeEditorPauseIfOwnedByPausePoint();
+            return (entry.ToSnapshot(now, _pauseController), resumedFromPause);
         }
 
         public static UloopPausePointClearAllResult ClearAll(
@@ -131,13 +136,17 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
             ClearLatestHitSnapshot();
             UloopPausePointRawCaptureHolder.Clear();
-            // Why always Resume: Option B does not distinguish manual vs pause-point pause.
-            ResumeEditorPause();
+            // Why only when pause-point-owned: like Clear, a bulk clear must not resume a manual
+            // pause the user set outside the pause-point workflow. It resumes only while a pause
+            // window is open (a pause-point hit is holding the Editor paused). Client disconnect
+            // and expiry still resume unconditionally to guarantee release.
+            bool resumedFromPause = ResumeEditorPauseIfOwnedByPausePoint();
 
             UloopPausePointEditorStateSnapshot editorState = UloopPausePointEditorStateSnapshot.FromController(
                 _pauseController,
                 UloopPausePointEditorStateCapturedAt.ClearAll);
-            return new UloopPausePointClearAllResult(clearedIds.Count, now, editorState, clearedIds.ToArray());
+            return new UloopPausePointClearAllResult(
+                clearedIds.Count, now, editorState, clearedIds.ToArray(), resumedFromPause);
         }
 
         public static UloopPausePointSnapshot GetStatus(string id)
@@ -394,6 +403,22 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         {
             CreditPauseWindowAndClose(NowUtc());
             _pauseController.Resume();
+        }
+
+        // Resumes the Editor only when a pause-point hit currently owns the pause (a pause window
+        // is open) and reports whether it did. Clear/ClearAll use this so they never resume a
+        // manual pause that no pause-point hit is responsible for. Disconnect and expiry paths
+        // deliberately call ResumeEditorPause directly instead, because they must release the
+        // Editor even when the pause was manual.
+        private static bool ResumeEditorPauseIfOwnedByPausePoint()
+        {
+            if (!_pauseWindowStartUtc.HasValue)
+            {
+                return false;
+            }
+
+            ResumeEditorPause();
+            return true;
         }
 
         /// <summary>

--- a/Packages/src/Runtime/PausePoints/UnityEditorPausePointPauseController.cs
+++ b/Packages/src/Runtime/PausePoints/UnityEditorPausePointPauseController.cs
@@ -18,8 +18,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         public void Resume()
         {
-            // Why unconditional: Option B clears any Editor pause on disconnect/clear/expiry,
-            // including a manual pause that happens to be active.
+            // This is the low-level unpause primitive and is intentionally unconditional; it does
+            // not know why the Editor is paused. The registry decides when to call it: clear only
+            // resumes a pause-point-owned pause, while disconnect and expiry resume unconditionally.
             EditorApplication.isPaused = false;
         }
     }


### PR DESCRIPTION
## Summary

Round-6 pause-point improvements, **PR-1 of 5**. Base branch: `feature/round6-pause-point-improvements` (the Round-6 integration branch), not `v3-beta`.

`clear-pause-point` (both `--id` and `--all`) previously called `ResumeEditorPause()` unconditionally. Clearing a marker therefore also resumed a **manual** pause the user had set outside the pause-point workflow (`control-play-mode --action Pause`, or the Editor pause button), discarding their run state.

This scopes the resume so a clear only ever resumes a **pause-point-owned** pause.

## Changes

- **`UloopPausePointRegistry`**: `Clear`/`ClearAll` now resume only while a pause window is open (`_pauseWindowStartUtc.HasValue`) — i.e. only when a pause-point hit is what is holding the Editor paused. A manual pause leaves no open window and is left untouched. New private helper `ResumeEditorPauseIfOwnedByPausePoint()` centralizes the decision and reports whether it resumed.
- **Client-disconnect and expiry paths are unchanged**: `ApplyPendingClientDisconnectResume` and `ApplyCaptureWindowExpirations` still resume unconditionally, because they must guarantee release of the Editor even when the pause was manual.
- **Resume propagation** (no `out`/`ref`, per repo convention): `Clear` returns a tuple `(UloopPausePointSnapshot Snapshot, bool ResumedFromPause)`; `UloopPausePointClearAllResult` gains a `ResumedFromPause` field.
- **Warning**: the `clear-pause-point` tool response sets a new `SourcePausePointConstants.ClearResumedPlayModeWarning` when the clear actually resumed Play Mode.
- Rewrote the stale `"Why always Resume: Option B ..."` comments and the `UnityEditorPausePointPauseController.Resume()` comment to match the new design.

## Tests

Added EditMode coverage in `PausePointTests` (via the pure-C# `FakePauseController`, new `PauseExternally()` seam):

- Clear / ClearAll resume and report `ResumedFromPause=true` when a hit owns the pause.
- Clear / ClearAll leave a manual pause untouched (`ResumeCount==0`) and report `ResumedFromPause=false`.
- `clear-pause-point` / `--all` tool responses carry the resume warning when they resume, and no warning when a manual pause is preserved.

Existing disconnect/expiry tests are unchanged and still assert unconditional resume.

## Validation

- `uloop compile`: 0 errors, 0 warnings.
- `uloop run-tests` (EditMode, `.*PausePoint.*`): 222 passed, 0 failed.

Skill files, version fields, changelogs, and `protocolVersion` are intentionally untouched (skill wording is handled separately in PR-5).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

