### PR TITLE
feat: Warn when patching methods called from physics callbacks

### DIFF
--- a/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherPhysicalCallbackHelperMethodFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherPhysicalCallbackHelperMethodFixture.cs
@@ -1,0 +1,26 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointPatcherTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointPatcherFixtures
+{
+    internal sealed class PatcherPhysicalCallbackHelperMethodFixture : MonoBehaviour
+    {
+        public int HitCount;
+
+        private void OnCollisionEnter2D(Collision2D collision)
+        {
+            HandleImpact();
+        }
+
+        private void HandleImpact()
+        {
+            HitCount++;
+        }
+
+        private void UnrelatedHelper()
+        {
+            HitCount++;
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherPhysicalCallbackHelperMethodFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/PatcherPhysicalCallbackHelperMethodFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91ab616c828ce4dd9ad1df4775ff7c5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
@@ -203,6 +203,43 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Patch_HelperMethodCalledFromPhysicalCallback_ReturnsIndirectCachedDispatchWarning()
+        {
+            // Verifies a private helper method invoked (one level deep) from OnCollisionEnter2D on
+            // the same MonoBehaviour reports the indirect cached-dispatch warning, extending the
+            // direct-name check above (Patch_PhysicsMessageMethodOnMonoBehaviour_...) to methods
+            // that are not themselves named after a physics message method.
+            const string id = "patcher-physical-callback-helper-method";
+            SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "PatcherPhysicalCallbackHelperMethodFixture.cs", 18);
+            Assert.That(resolveResult.Success, Is.True);
+
+            UloopPausePointRegistry.Enable(id, 30);
+            SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
+
+            Assert.That(patchResult.Success, Is.True);
+            Assert.That(patchResult.Warning, Does.Contain(SourcePausePointConstants.PhysicalCallbackIndirectCallMayMissExistingInstanceWarning));
+        }
+
+        [Test]
+        public void Patch_HelperMethodNotCalledFromPhysicalCallback_DoesNotReturnIndirectCachedDispatchWarning()
+        {
+            // Verifies a sibling private method that no physical message method calls does not
+            // trigger the indirect-call warning, proving the call-site scan does not over-match
+            // every method declared on the same type.
+            const string id = "patcher-physical-callback-unrelated-helper-method";
+            SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "PatcherPhysicalCallbackHelperMethodFixture.cs", 23);
+            Assert.That(resolveResult.Success, Is.True);
+
+            UloopPausePointRegistry.Enable(id, 30);
+            SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
+
+            Assert.That(patchResult.Success, Is.True);
+            Assert.That(patchResult.Warning, Does.Not.Contain(SourcePausePointConstants.PhysicalCallbackIndirectCallMayMissExistingInstanceWarning));
+        }
+
+        [Test]
         public void Patch_PhysicsNamedMethodOnNonMonoBehaviourType_DoesNotReturnCachedDispatchWarning()
         {
             // Verifies the warning requires both a matching method name AND a MonoBehaviour-derived

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -72,6 +72,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             + "after enabling this pause point, or embed UloopPausePoint.Pause(\"id\") directly in the "
             + "method body and arm it with enable-pause-point --id instead.";
 
+        // The same cached-dispatch risk as PhysicalCallbackMayMissExistingInstanceWarning, but for a
+        // method that is not itself named after a physics message method and is instead called (one
+        // level deep) from one elsewhere in the same compiled assembly - the call site scan cannot
+        // tell whether the calling GameObject predates patching, so the same GameObject-recreation or
+        // manual-marker workaround applies.
+        public const string PhysicalCallbackIndirectCallMayMissExistingInstanceWarning =
+            "This method is called from a Unity physics message method (OnCollision*/OnTrigger*/OnParticleCollision) "
+            + "elsewhere in the same compiled assembly. If the target GameObject already existed before this pause "
+            + "point was enabled, Unity's cached message dispatch may not route through the patch and the pause "
+            + "point may never hit even though the method body runs. Workarounds: destroy and recreate the "
+            + "GameObject after enabling this pause point, or embed UloopPausePoint.Pause(\"id\") directly in the "
+            + "method body and arm it with enable-pause-point --id instead.";
+
         // Surfaces the same JIT-inlining risk documented under Requirements & Safety in the skill,
         // but at enable time instead of only after a confusing HitCount=0 timeout.
         public const string SmallMethodInliningRiskWarning =

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -265,6 +265,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 warnings.Add(SourcePausePointConstants.PhysicalCallbackMayMissExistingInstanceWarning);
             }
+            else if (SourcePausePointPhysicalCallbackCallSiteScanner.IsCalledFromPhysicalMessageMethod(method))
+            {
+                warnings.Add(SourcePausePointConstants.PhysicalCallbackIndirectCallMayMissExistingInstanceWarning);
+            }
 
             if (IsLikelyJitInlined(method))
             {

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPhysicalCallbackCallSiteScanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPhysicalCallbackCallSiteScanner.cs
@@ -1,0 +1,175 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Detects whether a patch target method is called (one level deep) from any of Unity's
+    /// physics message methods elsewhere in the same compiled assembly, so BuildPatchWarning can
+    /// surface the same cached-dispatch risk documented for a directly-named physical message
+    /// method (see PhysicalCallbackMayMissExistingInstanceWarning) even when the patched method is
+    /// only a helper such a callback calls into.
+    /// </summary>
+    internal static class SourcePausePointPhysicalCallbackCallSiteScanner
+    {
+        private const string MonoBehaviourFullName = "UnityEngine.MonoBehaviour";
+
+        public static bool IsCalledFromPhysicalMessageMethod(MethodBase method)
+        {
+            // Re-deriving the dll path from the assembly name (the same way SourcePausePointResolver
+            // locates a compiled assembly) rather than reading Assembly.Location: Unity's domain-reload
+            // load path does not guarantee Location is populated, but the compiled-output layout is fixed.
+            string assemblyName = method.Module.Assembly.GetName().Name;
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string dllPath = Path.Combine(
+                projectRoot,
+                SourcePausePointConstants.ScriptAssembliesRelativeDirectory,
+                assemblyName + SourcePausePointConstants.CompiledAssemblyExtension);
+
+            if (!File.Exists(dllPath))
+            {
+                return false;
+            }
+
+            using FileStream assemblyStream = File.Open(dllPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            ReaderParameters readerParameters = new ReaderParameters { InMemory = true, ReadSymbols = false };
+            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(assemblyStream, readerParameters);
+
+            string declaringTypeFullName = method.DeclaringType.FullName;
+            string methodName = method.Name;
+            string[] parameterTypeFullNames = method.GetParameters()
+                .Select(parameter => parameter.ParameterType.FullName)
+                .ToArray();
+
+            foreach (TypeDefinition type in EnumerateTypes(assemblyDefinition.MainModule))
+            {
+                if (!DerivesFromMonoBehaviour(type))
+                {
+                    continue;
+                }
+
+                foreach (MethodDefinition candidateCaller in type.Methods)
+                {
+                    if (!candidateCaller.HasBody ||
+                        !SourcePausePointPhysicalMessageMethods.IsPhysicalMessageMethod(candidateCaller.Name))
+                    {
+                        continue;
+                    }
+
+                    if (CallsTarget(candidateCaller, declaringTypeFullName, methodName, parameterTypeFullNames))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool CallsTarget(
+            MethodDefinition caller, string declaringTypeFullName, string methodName, string[] parameterTypeFullNames)
+        {
+            foreach (Instruction instruction in caller.Body.Instructions)
+            {
+                if (instruction.OpCode != OpCodes.Call && instruction.OpCode != OpCodes.Callvirt)
+                {
+                    continue;
+                }
+
+                if (instruction.Operand is MethodReference calleeReference &&
+                    IsSameMethod(calleeReference, declaringTypeFullName, methodName, parameterTypeFullNames))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsSameMethod(
+            MethodReference candidate, string declaringTypeFullName, string methodName, string[] parameterTypeFullNames)
+        {
+            if (candidate.Name != methodName)
+            {
+                return false;
+            }
+
+            // Cecil renders nested-type names with '/' between the outer and inner type, while
+            // reflection's Type.FullName uses '+'; normalize before comparing the two worlds.
+            if (candidate.DeclaringType.FullName.Replace('/', '+') != declaringTypeFullName)
+            {
+                return false;
+            }
+
+            if (candidate.Parameters.Count != parameterTypeFullNames.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < parameterTypeFullNames.Length; i++)
+            {
+                if (candidate.Parameters[i].ParameterType.FullName != parameterTypeFullNames[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // Only walks base types Cecil already resolved within the same module (nested classes of a
+        // custom base class in this assembly); an external non-MonoBehaviour base (e.g. a plain
+        // framework type) stops the walk rather than forcing cross-assembly resolution, mirroring
+        // SourcePausePointResolver.IsRefStructType's stance on the same tradeoff.
+        private static bool DerivesFromMonoBehaviour(TypeDefinition type)
+        {
+            TypeReference current = type.BaseType;
+            while (current != null)
+            {
+                if (current.FullName == MonoBehaviourFullName)
+                {
+                    return true;
+                }
+
+                if (current is not TypeDefinition definition)
+                {
+                    return false;
+                }
+
+                current = definition.BaseType;
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<TypeDefinition> EnumerateTypes(ModuleDefinition module)
+        {
+            foreach (TypeDefinition type in module.Types)
+            {
+                foreach (TypeDefinition nested in EnumerateTypesRecursive(type))
+                {
+                    yield return nested;
+                }
+            }
+        }
+
+        private static IEnumerable<TypeDefinition> EnumerateTypesRecursive(TypeDefinition type)
+        {
+            yield return type;
+            foreach (TypeDefinition nestedType in type.NestedTypes)
+            {
+                foreach (TypeDefinition nested in EnumerateTypesRecursive(nestedType))
+                {
+                    yield return nested;
+                }
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPhysicalCallbackCallSiteScanner.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPhysicalCallbackCallSiteScanner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f5b95bc8ec8e4e4b8f81aba4eb51903
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -66,6 +66,14 @@ func pausePointWaitError(
 const (
 	pausePointHintPlayModeNotRunning  = "PlayMode is not running. Start PlayMode (or trigger the marker code path in Edit Mode), then wait again."
 	pausePointHintEditorAlreadyPaused = "Unity is already paused, so gameplay cannot reach the marker. Resume PlayMode before waiting again."
+
+	// Shared by both pausePointTimeoutHint and pausePointExpiredHint: a marker whose method is a
+	// physics/message callback, or is called from one, can miss a GameObject that already existed
+	// when the patch was installed even though the method body genuinely ran. Kept as a single
+	// constant so the two hints stay in sync instead of drifting copies of the same diagnosis.
+	pausePointNonFiringPatternsHint = "If the target line never hit despite the trigger firing, check the non-firing patterns: " +
+		"(1) the method is a physics/message callback or is called from one on a GameObject that existed before enable — recreate the GameObject or embed UloopPausePoint.Pause; " +
+		"(2) the method was already bound into a delegate/event before enable — the pre-bound invocation path bypasses the patch."
 )
 
 // pausePointTimeoutHint maps the final probed status to a deterministic diagnosis,
@@ -82,7 +90,7 @@ func pausePointTimeoutHint(response pausePointStatusResponse) string {
 			"If the marker targets a Unity message method such as OnCollisionEnter2D/OnTriggerEnter2D, check whether `enable-pause-point`'s response carried a Warning about cached message dispatch: Unity can resolve a GameObject's message dispatch before the marker patch is installed, so a GameObject that already existed at enable time may never reach the marker even though the method body runs. Recreating the GameObject after enabling, or embedding UloopPausePoint.Pause(\"id\") directly in the method body, avoids this. " +
 			"If the target line is inside a very small method, Mono's JIT may have inlined it into callers and the pause point never fires; move the pause point into the calling method. " +
 			"If PlayMode kept progressing on its own while you were arranging state (timers, gravity, spawners), the scenario may have already been consumed before this marker could fire; next time, run `control-play-mode --action Pause` before setup and resume with `control-play-mode --action Play` only after `enable-pause-point` succeeds. " +
-			"If the target line never hit despite the trigger firing, check the non-firing patterns: (1) the method is a physics/message callback or is called from one on a GameObject that existed before enable — recreate the GameObject or embed UloopPausePoint.Pause; (2) the method was already bound into a delegate/event before enable — the pre-bound invocation path bypasses the patch."
+			pausePointNonFiringPatternsHint
 	}
 	return ""
 }
@@ -98,7 +106,8 @@ func pausePointExpiredHint(response pausePointStatusResponse) string {
 		return pausePointHintEditorAlreadyPaused
 	}
 	if response.HitCount == 0 {
-		return "Marker expired before it was hit: the enable-pause-point --timeout-seconds window (measured from enable, not from this wait) ran out. Re-enable the marker with a longer --timeout-seconds and trigger the code path again."
+		return "Marker expired before it was hit: the enable-pause-point --timeout-seconds window (measured from enable, not from this wait) ran out. Re-enable the marker with a longer --timeout-seconds and trigger the code path again. " +
+			pausePointNonFiringPatternsHint
 	}
 	return ""
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -999,7 +999,8 @@ func TestPausePointExpiredErrorIncludesDiagnosisHint(t *testing.T) {
 				EditorState: pausePointEditorState{IsPlaying: true, CapturedAt: "Current"},
 				HitCount:    0,
 			},
-			wantHint: "Marker expired before it was hit: the enable-pause-point --timeout-seconds window (measured from enable, not from this wait) ran out. Re-enable the marker with a longer --timeout-seconds and trigger the code path again.",
+			wantHint: "Marker expired before it was hit: the enable-pause-point --timeout-seconds window (measured from enable, not from this wait) ran out. Re-enable the marker with a longer --timeout-seconds and trigger the code path again. " +
+				"If the target line never hit despite the trigger firing, check the non-firing patterns: (1) the method is a physics/message callback or is called from one on a GameObject that existed before enable — recreate the GameObject or embed UloopPausePoint.Pause; (2) the method was already bound into a delegate/event before enable — the pre-bound invocation path bypasses the patch.",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- `enable-pause-point` now warns about the same cached-dispatch risk even when the target line is a helper method called from a physics callback, not just when the target itself is named `OnCollisionEnter2D`/`OnTriggerEnter2D`/etc.
- The `PAUSE_POINT_EXPIRED` timeout diagnosis now includes the same non-firing-pattern guidance the plain timeout diagnosis already had.

## User Impact
- Before: patching a private helper method that a physics callback (e.g. `OnCollisionEnter2D`) calls into produced no warning at enable time, even though it can silently miss a GameObject that already existed when the pause point was enabled. Agents only discovered this the hard way, via a confusing `HitCount == 0` timeout.
- After: `enable-pause-point`'s response Warning field flags this case up front and suggests the same workarounds (recreate the GameObject, or embed `UloopPausePoint.Pause("id")` directly). Additionally, when a marker expires (`PAUSE_POINT_EXPIRED`) before being hit, the CLI now surfaces the same non-firing-pattern checklist that a plain timeout already showed, instead of a much shorter message.

## Changes
- Added `SourcePausePointPhysicalCallbackCallSiteScanner`: reads the compiled assembly with Mono.Cecil and checks (one call level deep) whether any Unity physics message method in the same assembly calls the patch target.
- Wired it into `SourcePausePointPatcher.BuildPatchWarning` as a fallback when the direct name/type check doesn't match, adding a new `PhysicalCallbackIndirectCallMayMissExistingInstanceWarning` constant.
- Extended the Go-side `pausePointExpiredHint` with the same non-firing-pattern guidance already present in `pausePointTimeoutHint`, extracting the shared text into a `pausePointNonFiringPatternsHint` constant so the two hints can't drift apart.
- Scan scope: the whole compiled assembly (not just the patched method's declaring class), since this only runs once per `enable-pause-point` call rather than on a hot path.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo>`: 0 errors, 0 warnings.
- `dist/darwin-arm64/uloop run-tests` (EditMode, filter `PausePoint`): 225/225 passed (was 223 before this PR; +2 new tests).
- Confirmed the new call-site-scan test actually exercises the new code path: disabled the new branch, recompiled, and observed it fail (1/27 in `SourcePausePointPatcherTests`) before re-enabling it, which then passed 27/27 again.
- `sh scripts/check-go-cli.sh`: format/vet/lint (0 issues) and tests all passed, including the updated `project-runner` test package.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

