### PR TITLE
feat: Add press-edge diagnostics to simulate-keyboard

### DIFF
--- a/Assets/Tests/Editor/PressEdgeDiagnosticsMessageFormatterTests.cs
+++ b/Assets/Tests/Editor/PressEdgeDiagnosticsMessageFormatterTests.cs
@@ -1,0 +1,73 @@
+#nullable enable
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Pure unit tests for the press-edge-miss diagnostic message suffix.
+    /// </summary>
+    public sealed class PressEdgeDiagnosticsMessageFormatterTests
+    {
+        [Test]
+        public void BuildSuffix_WhenKeyAlreadyPressedBeforeQueue_ReportsNoTransition()
+        {
+            // Verifies a pre-existing down state (no edge possible) is reported over other causes.
+            string suffix = PressEdgeDiagnosticsMessageFormatter.BuildSuffix(
+                consumedByUpdateType: "Dynamic",
+                anyDynamicUpdateObserved: true,
+                keyAlreadyPressedBeforeQueue: true);
+
+            Assert.That(suffix, Does.Contain("already down"));
+        }
+
+        [Test]
+        public void BuildSuffix_WhenNotConsumedAndNoDynamicUpdateRan_ReportsNoDynamicUpdate()
+        {
+            // Verifies a stalled Dynamic update loop is distinguished from a dropped event.
+            string suffix = PressEdgeDiagnosticsMessageFormatter.BuildSuffix(
+                consumedByUpdateType: null,
+                anyDynamicUpdateObserved: false,
+                keyAlreadyPressedBeforeQueue: false);
+
+            Assert.That(suffix, Does.Contain("no Dynamic update ran"));
+        }
+
+        [Test]
+        public void BuildSuffix_WhenNotConsumedButDynamicUpdatesRan_ReportsDroppedEvent()
+        {
+            // Verifies the event-never-consumed case is distinguished from a stalled update loop.
+            string suffix = PressEdgeDiagnosticsMessageFormatter.BuildSuffix(
+                consumedByUpdateType: null,
+                anyDynamicUpdateObserved: true,
+                keyAlreadyPressedBeforeQueue: false);
+
+            Assert.That(suffix, Does.Contain("not consumed by any recorded"));
+        }
+
+        [Test]
+        public void BuildSuffix_WhenConsumedByEditorUpdate_ReportsEditorInvisibility()
+        {
+            // Verifies the Editor-update-consumed case names the reason gameplay could not see it.
+            string suffix = PressEdgeDiagnosticsMessageFormatter.BuildSuffix(
+                consumedByUpdateType: "Editor",
+                anyDynamicUpdateObserved: false,
+                keyAlreadyPressedBeforeQueue: false);
+
+            Assert.That(suffix, Does.Contain("Editor update"));
+        }
+
+        [Test]
+        public void BuildSuffix_WhenConsumedByOtherUpdateType_NamesThatUpdateType()
+        {
+            // Verifies an unexpected consuming update type (e.g. Fixed) is surfaced by name.
+            string suffix = PressEdgeDiagnosticsMessageFormatter.BuildSuffix(
+                consumedByUpdateType: "Fixed",
+                anyDynamicUpdateObserved: true,
+                keyAlreadyPressedBeforeQueue: false);
+
+            Assert.That(suffix, Does.Contain("Fixed update"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/PressEdgeDiagnosticsMessageFormatterTests.cs.meta
+++ b/Assets/Tests/Editor/PressEdgeDiagnosticsMessageFormatterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8452ba5be2074cc880fe7a53721c585
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressEdgeDiagnosticsMessageFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressEdgeDiagnosticsMessageFormatter.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Pure formatting of the diagnostic suffix appended to Press/KeyDown responses when the
+    /// gameplay press edge (wasPressedThisFrame) was not observed. Why: the root cause of an
+    /// unobserved edge cannot be reproduced on demand (see Round-6 investigation), so instead of
+    /// a speculative behavior change this records enough context to diagnose the next real
+    /// occurrence from the response alone.
+    /// </summary>
+    internal static class PressEdgeDiagnosticsMessageFormatter
+    {
+        public static string BuildSuffix(
+            string? consumedByUpdateType,
+            bool anyDynamicUpdateObserved,
+            bool keyAlreadyPressedBeforeQueue)
+        {
+            if (keyAlreadyPressedBeforeQueue)
+            {
+                return " (key was already down before this action, so no press transition occurred)";
+            }
+
+            if (consumedByUpdateType == null)
+            {
+                return anyDynamicUpdateObserved
+                    ? " (the key-down event was not consumed by any recorded Input System update, even though Dynamic updates ran during the wait)"
+                    : " (no Dynamic update ran during the wait, so gameplay Update polling never had a chance to observe it)";
+            }
+
+            if (consumedByUpdateType == "Editor")
+            {
+                return " (the key-down event was consumed during an Editor update, which gameplay Update polling cannot see)";
+            }
+
+            return $" (the key-down event was consumed during a {consumedByUpdateType} update, but wasPressedThisFrame was still not observed)";
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressEdgeDiagnosticsMessageFormatter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressEdgeDiagnosticsMessageFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ec0e3d422d1840dda9ee4456187d173
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs
@@ -47,9 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool pressWasApplied = false;
             bool pressEdgeObserved = false;
             int pressHoldExtendedFrames = 0;
-            string? edgeMissConsumedByUpdateType = null;
-            bool edgeMissAnyDynamicUpdateObserved = false;
-            bool edgeMissKeyAlreadyPressedBeforeQueue = false;
+            PressEdgeMissDiagnostics edgeMissDiagnostics = new();
             InputSimulationWaitOutcome waitOutcome = InputSimulationWaitOutcome.Completed;
 
             // The edge must be probed inside gameplay input updates: editor-tick polling can
@@ -59,11 +57,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action pressEdgeMonitor = () =>
             {
                 pressEdgeObserved |= IsGameplayPressEdgeVisible(keyboard, key);
-                RecordPressEdgeMissDiagnostics(
-                    keyboard,
-                    key,
-                    ref edgeMissConsumedByUpdateType,
-                    ref edgeMissAnyDynamicUpdateObserved);
+                RecordPressEdgeMissDiagnostics(keyboard, key, edgeMissDiagnostics);
             };
             InputSystem.onAfterUpdate += pressEdgeMonitor;
 
@@ -72,7 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 waitOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
                     () =>
                     {
-                        edgeMissKeyAlreadyPressedBeforeQueue = keyboard[key].isPressed;
+                        edgeMissDiagnostics.KeyAlreadyPressedBeforeQueue = keyboard[key].isPressed;
                         KeyboardKeyState.SetKeyState(keyboard, key, true);
                     },
                     ct).ConfigureAwait(false);
@@ -160,9 +154,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 edgeText =
                     " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it, so retry or verify with a focused log)" +
                     PressEdgeDiagnosticsMessageFormatter.BuildSuffix(
-                        edgeMissConsumedByUpdateType,
-                        edgeMissAnyDynamicUpdateObserved,
-                        edgeMissKeyAlreadyPressedBeforeQueue);
+                        edgeMissDiagnostics.ConsumedByUpdateType,
+                        edgeMissDiagnostics.AnyDynamicUpdateObserved,
+                        edgeMissDiagnostics.KeyAlreadyPressedBeforeQueue);
             }
 
             return new SimulateKeyboardResponse
@@ -173,9 +167,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 KeyName = keyName,
                 PressEdgeObserved = pressEdgeObserved,
                 PressHoldExtendedFrames = pressHoldExtendedFrames > 0 ? pressHoldExtendedFrames : null,
-                PressEdgeConsumedByUpdateType = pressEdgeObserved ? null : edgeMissConsumedByUpdateType,
-                PressEdgeAnyDynamicUpdateObserved = pressEdgeObserved ? null : edgeMissAnyDynamicUpdateObserved,
-                PressEdgeKeyAlreadyPressedBeforeQueue = pressEdgeObserved ? null : edgeMissKeyAlreadyPressedBeforeQueue
+                PressEdgeConsumedByUpdateType = pressEdgeObserved ? null : edgeMissDiagnostics.ConsumedByUpdateType,
+                PressEdgeAnyDynamicUpdateObserved = pressEdgeObserved ? null : edgeMissDiagnostics.AnyDynamicUpdateObserved,
+                PressEdgeKeyAlreadyPressedBeforeQueue = pressEdgeObserved ? null : edgeMissDiagnostics.KeyAlreadyPressedBeforeQueue
             };
         }
 
@@ -200,20 +194,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool keyDownApplied = false;
             bool committed = false;
             bool pressEdgeObserved = false;
-            string? edgeMissConsumedByUpdateType = null;
-            bool edgeMissAnyDynamicUpdateObserved = false;
-            bool edgeMissKeyAlreadyPressedBeforeQueue = false;
+            PressEdgeMissDiagnostics edgeMissDiagnostics = new();
             InputSimulationWaitOutcome waitOutcome = InputSimulationWaitOutcome.Completed;
 
             await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
             Action keyDownEdgeMonitor = () =>
             {
                 pressEdgeObserved |= IsGameplayPressEdgeVisible(keyboard, key);
-                RecordPressEdgeMissDiagnostics(
-                    keyboard,
-                    key,
-                    ref edgeMissConsumedByUpdateType,
-                    ref edgeMissAnyDynamicUpdateObserved);
+                RecordPressEdgeMissDiagnostics(keyboard, key, edgeMissDiagnostics);
             };
             InputSystem.onAfterUpdate += keyDownEdgeMonitor;
 
@@ -222,7 +210,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 waitOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
                     () =>
                     {
-                        edgeMissKeyAlreadyPressedBeforeQueue = keyboard[key].isPressed;
+                        edgeMissDiagnostics.KeyAlreadyPressedBeforeQueue = keyboard[key].isPressed;
                         KeyboardKeyState.SetKeyState(keyboard, key, true);
                     },
                     ct).ConfigureAwait(false);
@@ -283,9 +271,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ? ""
                 : " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it)" +
                   PressEdgeDiagnosticsMessageFormatter.BuildSuffix(
-                      edgeMissConsumedByUpdateType,
-                      edgeMissAnyDynamicUpdateObserved,
-                      edgeMissKeyAlreadyPressedBeforeQueue);
+                      edgeMissDiagnostics.ConsumedByUpdateType,
+                      edgeMissDiagnostics.AnyDynamicUpdateObserved,
+                      edgeMissDiagnostics.KeyAlreadyPressedBeforeQueue);
             return new SimulateKeyboardResponse
             {
                 Success = true,
@@ -293,9 +281,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Action = UnityCliLoopKeyboardAction.KeyDown.ToString(),
                 KeyName = keyName,
                 PressEdgeObserved = pressEdgeObserved,
-                PressEdgeConsumedByUpdateType = pressEdgeObserved ? null : edgeMissConsumedByUpdateType,
-                PressEdgeAnyDynamicUpdateObserved = pressEdgeObserved ? null : edgeMissAnyDynamicUpdateObserved,
-                PressEdgeKeyAlreadyPressedBeforeQueue = pressEdgeObserved ? null : edgeMissKeyAlreadyPressedBeforeQueue
+                PressEdgeConsumedByUpdateType = pressEdgeObserved ? null : edgeMissDiagnostics.ConsumedByUpdateType,
+                PressEdgeAnyDynamicUpdateObserved = pressEdgeObserved ? null : edgeMissDiagnostics.AnyDynamicUpdateObserved,
+                PressEdgeKeyAlreadyPressedBeforeQueue = pressEdgeObserved ? null : edgeMissDiagnostics.KeyAlreadyPressedBeforeQueue
             };
         }
 
@@ -380,19 +368,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static void RecordPressEdgeMissDiagnostics(
             Keyboard keyboard,
             Key key,
-            ref string? consumedByUpdateType,
-            ref bool anyDynamicUpdateObserved)
+            PressEdgeMissDiagnostics diagnostics)
         {
             InputUpdateType currentUpdateType = InputState.currentUpdateType;
             if (currentUpdateType == InputUpdateType.Dynamic)
             {
-                anyDynamicUpdateObserved = true;
+                diagnostics.AnyDynamicUpdateObserved = true;
             }
 
-            if (consumedByUpdateType == null && keyboard[key].wasPressedThisFrame)
+            if (diagnostics.ConsumedByUpdateType == null && keyboard[key].wasPressedThisFrame)
             {
-                consumedByUpdateType = currentUpdateType.ToString();
+                diagnostics.ConsumedByUpdateType = currentUpdateType.ToString();
             }
+        }
+
+        // Mutable accumulator for RecordPressEdgeMissDiagnostics, captured by the onAfterUpdate
+        // monitor lambda. A class (not out/ref locals) so the lambda closure can write to it
+        // across repeated update callbacks without ref parameters.
+        private sealed class PressEdgeMissDiagnostics
+        {
+            public string? ConsumedByUpdateType;
+            public bool AnyDynamicUpdateObserved;
+            public bool KeyAlreadyPressedBeforeQueue;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.LowLevel;
 
 using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -46,19 +47,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool pressWasApplied = false;
             bool pressEdgeObserved = false;
             int pressHoldExtendedFrames = 0;
+            string? edgeMissConsumedByUpdateType = null;
+            bool edgeMissAnyDynamicUpdateObserved = false;
+            bool edgeMissKeyAlreadyPressedBeforeQueue = false;
             InputSimulationWaitOutcome waitOutcome = InputSimulationWaitOutcome.Completed;
 
             // The edge must be probed inside gameplay input updates: editor-tick polling can
             // miss the single frame where wasPressedThisFrame is true, and an editor-update
             // consumed press is exactly the failure gameplay code cannot see.
             await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            Action pressEdgeMonitor = () => pressEdgeObserved |= IsGameplayPressEdgeVisible(keyboard, key);
+            Action pressEdgeMonitor = () =>
+            {
+                pressEdgeObserved |= IsGameplayPressEdgeVisible(keyboard, key);
+                RecordPressEdgeMissDiagnostics(
+                    keyboard,
+                    key,
+                    ref edgeMissConsumedByUpdateType,
+                    ref edgeMissAnyDynamicUpdateObserved);
+            };
             InputSystem.onAfterUpdate += pressEdgeMonitor;
 
             try
             {
                 waitOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                    () => KeyboardKeyState.SetKeyState(keyboard, key, true),
+                    () =>
+                    {
+                        edgeMissKeyAlreadyPressedBeforeQueue = keyboard[key].isPressed;
+                        KeyboardKeyState.SetKeyState(keyboard, key, true);
+                    },
                     ct).ConfigureAwait(false);
                 if (waitOutcome == InputSimulationWaitOutcome.Completed)
                 {
@@ -142,7 +158,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             else
             {
                 edgeText =
-                    " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it, so retry or verify with a focused log)";
+                    " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it, so retry or verify with a focused log)" +
+                    PressEdgeDiagnosticsMessageFormatter.BuildSuffix(
+                        edgeMissConsumedByUpdateType,
+                        edgeMissAnyDynamicUpdateObserved,
+                        edgeMissKeyAlreadyPressedBeforeQueue);
             }
 
             return new SimulateKeyboardResponse
@@ -152,7 +172,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Action = UnityCliLoopKeyboardAction.Press.ToString(),
                 KeyName = keyName,
                 PressEdgeObserved = pressEdgeObserved,
-                PressHoldExtendedFrames = pressHoldExtendedFrames > 0 ? pressHoldExtendedFrames : null
+                PressHoldExtendedFrames = pressHoldExtendedFrames > 0 ? pressHoldExtendedFrames : null,
+                PressEdgeConsumedByUpdateType = pressEdgeObserved ? null : edgeMissConsumedByUpdateType,
+                PressEdgeAnyDynamicUpdateObserved = pressEdgeObserved ? null : edgeMissAnyDynamicUpdateObserved,
+                PressEdgeKeyAlreadyPressedBeforeQueue = pressEdgeObserved ? null : edgeMissKeyAlreadyPressedBeforeQueue
             };
         }
 
@@ -177,16 +200,31 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool keyDownApplied = false;
             bool committed = false;
             bool pressEdgeObserved = false;
+            string? edgeMissConsumedByUpdateType = null;
+            bool edgeMissAnyDynamicUpdateObserved = false;
+            bool edgeMissKeyAlreadyPressedBeforeQueue = false;
             InputSimulationWaitOutcome waitOutcome = InputSimulationWaitOutcome.Completed;
 
             await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            Action keyDownEdgeMonitor = () => pressEdgeObserved |= IsGameplayPressEdgeVisible(keyboard, key);
+            Action keyDownEdgeMonitor = () =>
+            {
+                pressEdgeObserved |= IsGameplayPressEdgeVisible(keyboard, key);
+                RecordPressEdgeMissDiagnostics(
+                    keyboard,
+                    key,
+                    ref edgeMissConsumedByUpdateType,
+                    ref edgeMissAnyDynamicUpdateObserved);
+            };
             InputSystem.onAfterUpdate += keyDownEdgeMonitor;
 
             try
             {
                 waitOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                    () => KeyboardKeyState.SetKeyState(keyboard, key, true),
+                    () =>
+                    {
+                        edgeMissKeyAlreadyPressedBeforeQueue = keyboard[key].isPressed;
+                        KeyboardKeyState.SetKeyState(keyboard, key, true);
+                    },
                     ct).ConfigureAwait(false);
                 if (waitOutcome == InputSimulationWaitOutcome.Completed)
                 {
@@ -243,14 +281,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             string keyDownEdgeText = pressEdgeObserved
                 ? ""
-                : " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it)";
+                : " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it)" +
+                  PressEdgeDiagnosticsMessageFormatter.BuildSuffix(
+                      edgeMissConsumedByUpdateType,
+                      edgeMissAnyDynamicUpdateObserved,
+                      edgeMissKeyAlreadyPressedBeforeQueue);
             return new SimulateKeyboardResponse
             {
                 Success = true,
                 Message = $"Key '{keyName}' held down{keyDownEdgeText}",
                 Action = UnityCliLoopKeyboardAction.KeyDown.ToString(),
                 KeyName = keyName,
-                PressEdgeObserved = pressEdgeObserved
+                PressEdgeObserved = pressEdgeObserved,
+                PressEdgeConsumedByUpdateType = pressEdgeObserved ? null : edgeMissConsumedByUpdateType,
+                PressEdgeAnyDynamicUpdateObserved = pressEdgeObserved ? null : edgeMissAnyDynamicUpdateObserved,
+                PressEdgeKeyAlreadyPressedBeforeQueue = pressEdgeObserved ? null : edgeMissKeyAlreadyPressedBeforeQueue
             };
         }
 
@@ -320,11 +365,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // consumed there never surfaces as wasPressedThisFrame to gameplay Update polling.
         private static bool IsGameplayPressEdgeVisible(Keyboard keyboard, Key key)
         {
-            if (UnityEngine.InputSystem.LowLevel.InputState.currentUpdateType == UnityEngine.InputSystem.LowLevel.InputUpdateType.Editor)
+            if (InputState.currentUpdateType == InputUpdateType.Editor)
             {
                 return false;
             }
             return keyboard[key].wasPressedThisFrame;
+        }
+
+        // Runs inside InputSystem.onAfterUpdate alongside the edge visibility check above.
+        // Why: the root cause of an unobserved edge could not be reproduced (see Round-6
+        // investigation), so this records which update type (if any) actually saw
+        // wasPressedThisFrame become true, and whether a Dynamic update ran at all, to diagnose
+        // the next real occurrence directly from the response instead of guessing.
+        private static void RecordPressEdgeMissDiagnostics(
+            Keyboard keyboard,
+            Key key,
+            ref string? consumedByUpdateType,
+            ref bool anyDynamicUpdateObserved)
+        {
+            InputUpdateType currentUpdateType = InputState.currentUpdateType;
+            if (currentUpdateType == InputUpdateType.Dynamic)
+            {
+                anyDynamicUpdateObserved = true;
+            }
+
+            if (consumedByUpdateType == null && keyboard[key].wasPressedThisFrame)
+            {
+                consumedByUpdateType = currentUpdateType.ToString();
+            }
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
@@ -26,6 +26,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public int? PressHoldExtendedFrames { get; set; }
 
+        /// <summary>
+        /// Diagnostics set only when PressEdgeObserved is false, to help diagnose the next
+        /// occurrence without changing Press/KeyDown timing, grace, or retry behavior.
+        /// </summary>
+        public string? PressEdgeConsumedByUpdateType { get; set; }
+
+        public bool? PressEdgeAnyDynamicUpdateObserved { get; set; }
+
+        public bool? PressEdgeKeyAlreadyPressedBeforeQueue { get; set; }
+
         public SimulateKeyboardResponse()
         {
         }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
@@ -26,14 +26,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public int? PressHoldExtendedFrames { get; set; }
 
+        // The following three PressEdge* fields are diagnostics set only when PressEdgeObserved
+        // is false, to help diagnose the next occurrence without changing Press/KeyDown timing,
+        // grace, or retry behavior.
+
         /// <summary>
-        /// Diagnostics set only when PressEdgeObserved is false, to help diagnose the next
-        /// occurrence without changing Press/KeyDown timing, grace, or retry behavior.
+        /// Which Input System update type (if any) consumed the key-down event, or null if it
+        /// was never consumed.
         /// </summary>
         public string? PressEdgeConsumedByUpdateType { get; set; }
 
+        /// <summary>
+        /// Whether any Dynamic update ran while waiting for the press edge to be observed.
+        /// </summary>
         public bool? PressEdgeAnyDynamicUpdateObserved { get; set; }
 
+        /// <summary>
+        /// Whether the key was already pressed before this action was queued, meaning no press
+        /// transition could have occurred.
+        /// </summary>
         public bool? PressEdgeKeyAlreadyPressedBeforeQueue { get; set; }
 
         public SimulateKeyboardResponse()


### PR DESCRIPTION
## Summary
- `simulate-keyboard`'s Press/KeyDown response now carries extra diagnostic detail whenever it reports "press edge was not observed", so a real occurrence can be diagnosed directly from the response instead of needing a fresh investigation.

## User Impact
- Before: when `simulate-keyboard` occasionally reported a Press/KeyDown "press edge was not observed" warning, there was no way to tell from the response alone whether the key-down event was consumed at the wrong moment, never consumed at all, whether gameplay updates even ran during the wait, or whether the key was already down before the action started.
- After: the same warning message now includes a short, concrete reason, and the response carries matching fields (`PressEdgeConsumedByUpdateType`, `PressEdgeAnyDynamicUpdateObserved`, `PressEdgeKeyAlreadyPressedBeforeQueue`) set only in that case. Timing, grace period, and retry behavior for Press/KeyDown are unchanged.

## Investigation
- The original plan for this change was to extend the existing edge-observation grace window. Before doing that, we tried to reproduce the reported miss to confirm the window was actually the cause.
- Roughly 200 reproduction attempts across this repo's development project and a separate verification project (concurrent command launches, a main-thread busy-loop, an unfocused Editor with `runInBackground=false`, and pause-point races) never reproduced a missed edge — the injected key-down event was consumed by a Dynamic update in every single case.
- Given that negative result, changing the observation window (or adding a speculative re-press) would be a guess rather than a fix. This PR instead adds the diagnostics needed to pin down the actual cause the next time it happens in the field.

## Changes
- Extended the existing `onAfterUpdate` press-edge monitor in `KeyboardInputActionExecutor` (both `ExecutePress` and `ExecuteKeyDown`) to also record which Input System update type (if any) saw `wasPressedThisFrame`, whether any Dynamic update ran during the wait, and whether the key was already down right before the event was queued.
- Added a pure `PressEdgeDiagnosticsMessageFormatter` that turns those three signals into a short message suffix, covered by unit tests.
- Added the three nullable fields to `SimulateKeyboardResponse`, populated only when the press edge was not observed.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo>`: 0 errors, 0 warnings.
- Verified the new formatter tests actually fail without the implementation: temporarily forced `BuildSuffix` to return `""`, recompiled, confirmed 5/5 new tests failed, then reverted and recompiled to confirm 0 errors/warnings again.
- `dist/darwin-arm64/uloop run-tests` filtered to `PausePoint|SimulateKeyboard|PressEdge|PressHoldUntilEdge`: 240/240 passed.
- `dist/darwin-arm64/uloop run-tests` (full EditMode suite): 2262/2272 passed; the 3 failures are pre-existing in `CliSetupApplicationServiceTests` (dispatcher release tag string-length assertions) and unrelated to this change — not modified by this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

