### PR TITLE
fix: Detect pause-point interruption during Press/KeyDown observation wait

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Directory-level responsibilities. Kept deliberately coarse — check the directo
 - `Packages/src/` — the Unity package (C#). Each first-party tool lives in `Editor/FirstPartyTools/<Tool>/` with its implementation and agent skill (`Skill/SKILL.md`, optional `Skill/references/`).
 - `Packages/src/Editor/CliOnlyTools~/<Tool>/Skill/` — skills for CLI-only commands (launch, pause-point, etc.) that have no Unity tool class. Tilde-suffixed folders are ignored by Unity, so files there need no `.meta`; files under `FirstPartyTools` do (run `uloop compile` to let Unity generate them).
 - `Assets/` — the development/test Unity project, including custom-command samples under `Assets/Editor/CustomCommandSamples/`.
+- `Assets/RegressionHarness/<TrapName>/` — permanent manual repro scenes for verification-round "traps" (pause-point, simulate-keyboard, physics callbacks, etc.), paired with a driver script under `scripts/regression-harness-<trap-name>.sh`. See `docs/regression-harness.md`.
 - `cli/dispatcher/` — the globally installed `uloop` entry command (also owns `uloop skills install` and skill syncing).
 - `cli/project-runner/` — the per-project CLI runner that talks to the Unity-side IPC server.
 - `cli/common/` — Go modules shared by dispatcher and project runner. Tool parameter schemas live in `cli/common/tools/default-tools.json`; skill discovery in `cli/common/skillscan/`.

--- a/Assets/RegressionHarness.meta
+++ b/Assets/RegressionHarness.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: beada1e3fb2b54ba1aef7c3dee39774a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RegressionHarness/KeyStateAfterPauseInterruption.meta
+++ b/Assets/RegressionHarness/KeyStateAfterPauseInterruption.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 86072ae90e4c54b0d9765f79208509e7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RegressionHarness/KeyStateAfterPauseInterruption/KeyStateAfterPauseInterruption.unity
+++ b/Assets/RegressionHarness/KeyStateAfterPauseInterruption/KeyStateAfterPauseInterruption.unity
@@ -1,0 +1,173 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &2146224881
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2146224883}
+  - component: {fileID: 2146224882}
+  m_Layer: 0
+  m_Name: SpaceHoldPoller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2146224882
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2146224881}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e602a2e0ba7848be8bd61924581fed7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &2146224883
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2146224881}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 2146224883}

--- a/Assets/RegressionHarness/KeyStateAfterPauseInterruption/KeyStateAfterPauseInterruption.unity.meta
+++ b/Assets/RegressionHarness/KeyStateAfterPauseInterruption/KeyStateAfterPauseInterruption.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e6ce7ca621ea94754ba2fc45c39a9d8e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RegressionHarness/KeyStateAfterPauseInterruption/SpaceHoldPoller.cs
+++ b/Assets/RegressionHarness/KeyStateAfterPauseInterruption/SpaceHoldPoller.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace io.github.hatayama.UnityCliLoop.RegressionHarness
+{
+    // Minimal MonoBehaviour for the KeyStateAfterPauseInterruption regression harness.
+    // Its only job is to give simulate-keyboard/pause-point scenarios a stable, unconditionally
+    // executing line to arm a pause-point marker on (see docs/regression-harness.md).
+    public sealed class SpaceHoldPoller : MonoBehaviour
+    {
+        public bool IsSpaceHeld { get; private set; }
+
+        private void Update()
+        {
+            IsSpaceHeld = Keyboard.current != null && Keyboard.current[Key.Space].isPressed;
+        }
+    }
+}

--- a/Assets/RegressionHarness/KeyStateAfterPauseInterruption/SpaceHoldPoller.cs
+++ b/Assets/RegressionHarness/KeyStateAfterPauseInterruption/SpaceHoldPoller.cs
@@ -4,15 +4,20 @@ using UnityEngine.InputSystem;
 namespace io.github.hatayama.UnityCliLoop.RegressionHarness
 {
     // Minimal MonoBehaviour for the KeyStateAfterPauseInterruption regression harness.
-    // Its only job is to give simulate-keyboard/pause-point scenarios a stable, unconditionally
-    // executing line to arm a pause-point marker on (see docs/regression-harness.md).
+    // The marker line only executes while Space is actually held, so arming a pause-point
+    // there before simulate-keyboard Press starts does not fire immediately — it fires
+    // naturally from game code once Press drives the key down (see docs/regression-harness.md).
     public sealed class SpaceHoldPoller : MonoBehaviour
     {
         public bool IsSpaceHeld { get; private set; }
 
         private void Update()
         {
-            IsSpaceHeld = Keyboard.current != null && Keyboard.current[Key.Space].isPressed;
+            bool isHeld = Keyboard.current != null && Keyboard.current[Key.Space].isPressed;
+            if (isHeld)
+            {
+                IsSpaceHeld = isHeld;
+            }
         }
     }
 }

--- a/Assets/RegressionHarness/KeyStateAfterPauseInterruption/SpaceHoldPoller.cs.meta
+++ b/Assets/RegressionHarness/KeyStateAfterPauseInterruption/SpaceHoldPoller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e602a2e0ba7848be8bd61924581fed7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/PressLifetimeIterationResolverTests.cs
+++ b/Assets/Tests/Editor/PressLifetimeIterationResolverTests.cs
@@ -1,0 +1,91 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests pause-priority decisions for one WaitForPressLifetime loop iteration.
+    /// </summary>
+    public sealed class PressLifetimeIterationResolverTests
+    {
+        [Test]
+        public void ResolvePostWaitOutcome_WhenFrameWaitObservesPause_ReturnsPausedRegardlessOfDuration()
+        {
+            // Verifies a pause observed directly by the frame-wait race always wins, even when
+            // the requested duration has already elapsed (baseWaitSatisfied=true).
+            PressLifetimeIterationDecision decision = PressLifetimeIterationResolver.ResolvePostWaitOutcome(
+                frameWaitOutcome: InputSimulationWaitOutcome.Paused,
+                baseWaitSatisfied: true,
+                isPausedFallback: false);
+
+            Assert.That(decision, Is.EqualTo(PressLifetimeIterationDecision.Paused));
+        }
+
+        [Test]
+        public void ResolvePostWaitOutcome_WhenFrameWaitObservesPauseDuringEdgeExtension_ReturnsPaused()
+        {
+            // Verifies a pause takes priority even while still extending the hold for press-edge
+            // observation (duration not yet satisfied).
+            PressLifetimeIterationDecision decision = PressLifetimeIterationResolver.ResolvePostWaitOutcome(
+                frameWaitOutcome: InputSimulationWaitOutcome.Paused,
+                baseWaitSatisfied: false,
+                isPausedFallback: false);
+
+            Assert.That(decision, Is.EqualTo(PressLifetimeIterationDecision.Paused));
+        }
+
+        [Test]
+        public void ResolvePostWaitOutcome_WhenTimedOutWithDurationSatisfiedAndPausedFallback_ReturnsPaused()
+        {
+            // Verifies the defensive re-check: a per-frame-wait timeout that coincided with the
+            // duration completing must still report Paused when Unity is actually paused,
+            // instead of silently absorbing the pause into a Completed result.
+            PressLifetimeIterationDecision decision = PressLifetimeIterationResolver.ResolvePostWaitOutcome(
+                frameWaitOutcome: InputSimulationWaitOutcome.TimedOut,
+                baseWaitSatisfied: true,
+                isPausedFallback: true);
+
+            Assert.That(decision, Is.EqualTo(PressLifetimeIterationDecision.Paused));
+        }
+
+        [Test]
+        public void ResolvePostWaitOutcome_WhenTimedOutWithDurationSatisfiedAndNotPaused_ReturnsCompleted()
+        {
+            // Verifies the pre-existing legitimate behavior is preserved: a per-frame-wait
+            // timeout after the duration has genuinely elapsed, with no pause involved, still
+            // completes the Press/KeyDown successfully.
+            PressLifetimeIterationDecision decision = PressLifetimeIterationResolver.ResolvePostWaitOutcome(
+                frameWaitOutcome: InputSimulationWaitOutcome.TimedOut,
+                baseWaitSatisfied: true,
+                isPausedFallback: false);
+
+            Assert.That(decision, Is.EqualTo(PressLifetimeIterationDecision.Completed));
+        }
+
+        [Test]
+        public void ResolvePostWaitOutcome_WhenTimedOutBeforeDurationSatisfied_ReturnsTimedOut()
+        {
+            // Verifies a genuine timeout (duration not yet reached) is still reported as TimedOut.
+            PressLifetimeIterationDecision decision = PressLifetimeIterationResolver.ResolvePostWaitOutcome(
+                frameWaitOutcome: InputSimulationWaitOutcome.TimedOut,
+                baseWaitSatisfied: false,
+                isPausedFallback: false);
+
+            Assert.That(decision, Is.EqualTo(PressLifetimeIterationDecision.TimedOut));
+        }
+
+        [Test]
+        public void ResolvePostWaitOutcome_WhenFrameObserved_ReturnsContinue()
+        {
+            // Verifies a normally observed frame just advances the loop to recheck duration/frame
+            // count on the next iteration.
+            PressLifetimeIterationDecision decision = PressLifetimeIterationResolver.ResolvePostWaitOutcome(
+                frameWaitOutcome: InputSimulationWaitOutcome.Completed,
+                baseWaitSatisfied: false,
+                isPausedFallback: false);
+
+            Assert.That(decision, Is.EqualTo(PressLifetimeIterationDecision.Continue));
+        }
+    }
+}

--- a/Assets/Tests/Editor/PressLifetimeIterationResolverTests.cs.meta
+++ b/Assets/Tests/Editor/PressLifetimeIterationResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd92ab2d6c295457ca5f6217155155f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/EditorPauseAwaiter.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/EditorPauseAwaiter.cs
@@ -1,0 +1,65 @@
+#nullable enable
+#if ULOOP_HAS_INPUT_SYSTEM
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Awaits the Editor entering Play Mode pause via <see cref="EditorApplication.pauseStateChanged"/>,
+    /// so a wait can react to a pause the instant it happens instead of only noticing it the next
+    /// time some other wait (a frame, a timeout) happens to resolve.
+    /// </summary>
+    /// <remarks>
+    /// Why event-based: while Play Mode is paused, the Editor tick that drives frame-count-based
+    /// waits (<see cref="EditorFrameWaiter"/>) can go a long time between observations, so a
+    /// caller racing only a frame wait and a wall-clock timeout can miss a pause that started and
+    /// ended entirely inside one such wait.
+    /// </remarks>
+    internal static class EditorPauseAwaiter
+    {
+        /// <summary>
+        /// Must be called from the main thread: <see cref="EditorApplication.pauseStateChanged"/>
+        /// is main-thread-only. Only reacts to a future transition into pause — a pause already
+        /// in effect at subscribe time is caught instead by the caller's own timeout-side
+        /// fallback re-check (see PressLifetimeIterationResolver's isPausedFallback), because
+        /// reading <see cref="EditorApplication.isPaused"/> synchronously here is not safe at
+        /// every call site (observed to throw when invoked while a PlayMode test's scene is
+        /// still being loaded).
+        /// </summary>
+        public static Task WaitForPauseAsync(CancellationToken ct)
+        {
+            TaskCompletionSource<bool> completionSource =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            void OnPauseStateChanged(PauseState state)
+            {
+                if (state != PauseState.Paused)
+                {
+                    return;
+                }
+
+                EditorApplication.pauseStateChanged -= OnPauseStateChanged;
+                completionSource.TrySetResult(true);
+            }
+
+            EditorApplication.pauseStateChanged += OnPauseStateChanged;
+
+            CancellationTokenRegistration registration = ct.Register(() =>
+            {
+                EditorApplication.pauseStateChanged -= OnPauseStateChanged;
+                completionSource.TrySetCanceled(ct);
+            });
+
+            _ = completionSource.Task.ContinueWith(
+                _ => registration.Dispose(),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            return completionSource.Task;
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/EditorPauseAwaiter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/EditorPauseAwaiter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b87fe7de79ff4da1bc337e9f4814f02
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemRuntimeFrameWaiter.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemRuntimeFrameWaiter.cs
@@ -192,9 +192,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return InputSimulationWaitOutcome.TimedOut;
             }
 
-            // Must subscribe on the main thread: EditorPauseAwaiter reads EditorApplication.isPaused
-            // and subscribes to EditorApplication.pauseStateChanged, both main-thread-only, and a
-            // caller's prior ConfigureAwait(false) may have left us on a thread-pool thread.
+            // Must subscribe on the main thread: EditorPauseAwaiter subscribes to
+            // EditorApplication.pauseStateChanged, which is main-thread-only, and a caller's
+            // prior ConfigureAwait(false) may have left us on a thread-pool thread.
             await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
 
             using CancellationTokenSource raceCancellation = CancellationTokenSource.CreateLinkedTokenSource(ct);

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemRuntimeFrameWaiter.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemRuntimeFrameWaiter.cs
@@ -27,15 +27,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             while (observedFrames < frameCount)
             {
+                // Polled in addition to the mid-wait race below: a test-only fake pause provider
+                // (see InputSystemUpdateHelper.ConfigurePauseProviderForTests) never fires the
+                // real EditorApplication.pauseStateChanged event that race relies on, so this
+                // poll is what a fake-paused test actually gets caught by.
                 if (InputSystemUpdateHelper.IsPaused())
                 {
                     return InputSimulationWaitOutcome.Paused;
                 }
 
+                // WaitOneRuntimeFrameOrTimeout races a pause signal alongside the frame/timeout
+                // wait, so a genuine (non-faked) pause is caught the instant it happens instead
+                // of only between completed waits (see EditorPauseAwaiter).
                 InputSimulationWaitOutcome frameOutcome = await WaitOneRuntimeFrameOrTimeout(
                     InputSystemUpdateHelper.FrameObservationTimeoutMilliseconds,
                     stopwatch,
                     ct).ConfigureAwait(false);
+                if (frameOutcome == InputSimulationWaitOutcome.Paused)
+                {
+                    return InputSimulationWaitOutcome.Paused;
+                }
+
                 if (frameOutcome == InputSimulationWaitOutcome.TimedOut)
                 {
                     return InputSimulationWaitOutcome.TimedOut;
@@ -99,29 +111,56 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         extendedFrames);
                 }
 
+                // Polled in addition to the mid-wait race below: a test-only fake pause provider
+                // (see InputSystemUpdateHelper.ConfigurePauseProviderForTests) never fires the
+                // real EditorApplication.pauseStateChanged event that race relies on, so this
+                // poll is what a fake-paused test actually gets caught by.
                 if (InputSystemUpdateHelper.IsPaused())
                 {
                     return new InputSystemUpdateHelper.PressLifetimeWaitResult(InputSimulationWaitOutcome.Paused, 0);
                 }
 
+                // WaitOneRuntimeFrameOrTimeout races a pause signal alongside the frame/timeout
+                // wait, so a genuine (non-faked) pause is caught the instant it happens instead
+                // of only between completed waits (see EditorPauseAwaiter).
                 InputSimulationWaitOutcome frameOutcome = await WaitOneRuntimeFrameOrTimeout(
                     timeoutMilliseconds,
                     stopwatch,
                     ct).ConfigureAwait(false);
-                if (frameOutcome == InputSimulationWaitOutcome.TimedOut)
+
+                // Must switch back to the main thread before reading IsPaused() below: the
+                // ConfigureAwait(false) above can resume this continuation on a thread-pool
+                // thread even though WaitOneRuntimeFrameOrTimeout ran on the main thread
+                // internally.
+                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+
+                // Why: a pause and an already-satisfied duration can both become true within the
+                // same real-time window (Time.realtimeSinceStartup keeps advancing while paused),
+                // so IsPaused() is re-checked here even when frameOutcome says TimedOut — without
+                // it, a pause could be silently absorbed into a Completed result.
+                PressLifetimeIterationDecision decision = PressLifetimeIterationResolver.ResolvePostWaitOutcome(
+                    frameOutcome,
+                    baseWaitSatisfied,
+                    InputSystemUpdateHelper.IsPaused());
+                if (decision == PressLifetimeIterationDecision.Paused)
+                {
+                    return new InputSystemUpdateHelper.PressLifetimeWaitResult(InputSimulationWaitOutcome.Paused, 0);
+                }
+
+                if (decision == PressLifetimeIterationDecision.Completed)
                 {
                     // Why: timeout during edge-extension still completes Press successfully with
                     // PressEdgeObserved=false — same contract as before, not a hard failure.
-                    if (baseWaitSatisfied)
-                    {
-                        int extendedFrames = baseSatisfiedFrameCount < 0
-                            ? 0
-                            : PressHoldUntilEdgeLogic.CountExtendedFrames(observedFrames, baseSatisfiedFrameCount);
-                        return new InputSystemUpdateHelper.PressLifetimeWaitResult(
-                            InputSimulationWaitOutcome.Completed,
-                            extendedFrames);
-                    }
+                    int extendedFrames = baseSatisfiedFrameCount < 0
+                        ? 0
+                        : PressHoldUntilEdgeLogic.CountExtendedFrames(observedFrames, baseSatisfiedFrameCount);
+                    return new InputSystemUpdateHelper.PressLifetimeWaitResult(
+                        InputSimulationWaitOutcome.Completed,
+                        extendedFrames);
+                }
 
+                if (decision == PressLifetimeIterationDecision.TimedOut)
+                {
                     return new InputSystemUpdateHelper.PressLifetimeWaitResult(InputSimulationWaitOutcome.TimedOut, 0);
                 }
 
@@ -136,6 +175,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
+        // Races a pause signal alongside the frame/timeout wait so a pause is observed the
+        // instant it happens. Without this, a pause that starts and ends entirely inside the
+        // frame wait below is invisible to callers until that wait's own timeout expires — and
+        // by then real time (which keeps advancing while paused) can have already satisfied a
+        // duration/frame-count condition, silently absorbing the pause into a false "completed"
+        // result (see PressLifetimeIterationResolver for the caller-side defense in depth).
         private static async Task<InputSimulationWaitOutcome> WaitOneRuntimeFrameOrTimeout(
             int timeoutMilliseconds,
             System.Diagnostics.Stopwatch stopwatch,
@@ -147,10 +192,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return InputSimulationWaitOutcome.TimedOut;
             }
 
-            bool frameObserved = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+            // Must subscribe on the main thread: EditorPauseAwaiter reads EditorApplication.isPaused
+            // and subscribes to EditorApplication.pauseStateChanged, both main-thread-only, and a
+            // caller's prior ConfigureAwait(false) may have left us on a thread-pool thread.
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+
+            using CancellationTokenSource raceCancellation = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            Task<bool> frameTask = EditorFrameWaiter.WaitFramesOrTimeoutAsync(
                 1,
                 remainingMilliseconds,
-                ct).ConfigureAwait(false);
+                raceCancellation.Token);
+            Task pauseTask = EditorPauseAwaiter.WaitForPauseAsync(raceCancellation.Token);
+
+            Task winner = await Task.WhenAny(frameTask, pauseTask).ConfigureAwait(false);
+            raceCancellation.Cancel();
+
+            if (winner == pauseTask)
+            {
+                return InputSimulationWaitOutcome.Paused;
+            }
+
+            bool frameObserved = await frameTask.ConfigureAwait(false);
             return frameObserved
                 ? InputSimulationWaitOutcome.Completed
                 : InputSimulationWaitOutcome.TimedOut;

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemRuntimeFrameWaiter.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemRuntimeFrameWaiter.cs
@@ -50,6 +50,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 if (frameOutcome == InputSimulationWaitOutcome.TimedOut)
                 {
+                    // Why: the wall-clock timeout keeps advancing during a real pause, so a
+                    // timeout that coincided with one must still report Paused — otherwise a
+                    // pause could be silently absorbed into a TimedOut result (same class of bug
+                    // as the Completed-absorption case WaitForPressLifetime guards against).
+                    await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+                    if (InputSystemUpdateHelper.IsPaused())
+                    {
+                        return InputSimulationWaitOutcome.Paused;
+                    }
+
                     return InputSimulationWaitOutcome.TimedOut;
                 }
 
@@ -205,6 +215,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Task pauseTask = EditorPauseAwaiter.WaitForPauseAsync(raceCancellation.Token);
 
             Task winner = await Task.WhenAny(frameTask, pauseTask).ConfigureAwait(false);
+
+            // Must switch back to the main thread before canceling: EditorPauseAwaiter's
+            // cancellation callback unsubscribes EditorApplication.pauseStateChanged, which is
+            // main-thread-only, and the ConfigureAwait(false) above may have left us off-thread.
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
             raceCancellation.Cancel();
 
             if (winner == pauseTask)

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressLifetimeIterationResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressLifetimeIterationResolver.cs
@@ -1,0 +1,61 @@
+#nullable enable
+#if ULOOP_HAS_INPUT_SYSTEM
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Outcome of one WaitForPressLifetime loop iteration, decided after a pause-aware
+    /// per-frame wait resolves.
+    /// </summary>
+    internal enum PressLifetimeIterationDecision
+    {
+        Continue = 0,
+        Completed = 1,
+        Paused = 2,
+        TimedOut = 3
+    }
+
+    /// <summary>
+    /// Pure decision logic for one WaitForPressLifetime loop iteration, extracted from
+    /// InputSystemRuntimeFrameWaiter so the pause-priority rules can be unit tested without
+    /// driving the Editor player loop.
+    /// </summary>
+    internal static class PressLifetimeIterationResolver
+    {
+        /// <summary>
+        /// Resolves what a WaitForPressLifetime iteration should do once the pause-aware
+        /// per-frame wait has returned. A pause takes priority over an already-satisfied
+        /// duration, whether observed directly from the frame-wait race
+        /// (<paramref name="frameWaitOutcome"/> is Paused) or defensively re-checked after a
+        /// timeout that coincided with <paramref name="baseWaitSatisfied"/>
+        /// (<paramref name="isPausedFallback"/>) — the second case exists because a timeout and
+        /// a pause can both become true in the same real-time window, and this defends against a
+        /// completed-duration check absorbing a pause that raced it.
+        /// </summary>
+        public static PressLifetimeIterationDecision ResolvePostWaitOutcome(
+            InputSimulationWaitOutcome frameWaitOutcome,
+            bool baseWaitSatisfied,
+            bool isPausedFallback)
+        {
+            if (frameWaitOutcome == InputSimulationWaitOutcome.Paused)
+            {
+                return PressLifetimeIterationDecision.Paused;
+            }
+
+            if (frameWaitOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                if (baseWaitSatisfied)
+                {
+                    return isPausedFallback
+                        ? PressLifetimeIterationDecision.Paused
+                        : PressLifetimeIterationDecision.Completed;
+                }
+
+                return PressLifetimeIterationDecision.TimedOut;
+            }
+
+            return PressLifetimeIterationDecision.Continue;
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressLifetimeIterationResolver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressLifetimeIterationResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05f2390a6602c4a29a99a29ec4de5f0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/regression-harness.md
+++ b/docs/regression-harness.md
@@ -1,0 +1,32 @@
+# Regression harness for verification traps
+
+Manual verification rounds against `uloop` (pause-point, simulate-keyboard,
+physics callbacks, etc.) repeatedly rediscover the same handful of edge cases
+("traps") because each round's repro lives only in a throwaway feedback memo.
+This harness makes a trap's repro steps a permanent, re-runnable asset instead.
+
+## Layout
+
+- Scene + helper C# for a trap: `Assets/RegressionHarness/<TrapName>/`. Keep
+  each scene minimal — just enough MonoBehaviour/GameObject setup to trigger
+  the trap's condition, not a playable game. Do not mix these with
+  `Assets/Editor/CustomCommandSamples/` (that folder is for first-party tool
+  usage samples, not bug-repro scenes).
+- uloop command sequence for a trap: `scripts/regression-harness-<trap-name>.sh`
+  (POSIX sh, flat under `scripts/` to match this repo's existing script
+  layout). The script drives the trap end to end — enable/arm, trigger the
+  action, await the result — and compares the response against the expected
+  outcome, exiting non-zero on mismatch.
+
+## Execution
+
+These scenarios require a running Unity Editor with the trap scene open, so
+they are not part of automated CI. Run them manually (or via an agent) before
+merging a PR that touches the pause-point or simulate-keyboard code paths the
+scenario covers.
+
+## Existing scenarios
+
+| Trap | Scene | Script |
+|------|-------|--------|
+| Key state divergence after a pause-point interruption | `Assets/RegressionHarness/KeyStateAfterPauseInterruption/` | `scripts/regression-harness-key-state-after-pause-interruption.sh` |

--- a/scripts/regression-harness-key-state-after-pause-interruption.sh
+++ b/scripts/regression-harness-key-state-after-pause-interruption.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+set -e
+# Regression harness for the KeyStateAfterPauseInterruption trap: a pause-point
+# hit during simulate-keyboard Press must be reported as an interruption
+# (InterruptedByPausePoint=true) instead of being silently absorbed into a
+# successful Completed result. See docs/regression-harness.md.
+#
+# Contract under test: arm the pause-point on the key-consuming line in
+# SpaceHoldPoller.cs *before* starting Press, so the hit fires naturally from
+# game code once Press drives the key down (not from a concurrent CLI call).
+# The environment-dependent editor-tick-stall path that can also swallow a
+# pause is covered by PressLifetimeIterationResolverTests (unit-level), not by
+# this live harness — see that test file for the decisive Red/Green coverage.
+#
+# Usage: sh scripts/regression-harness-key-state-after-pause-interruption.sh [--project-path <path>]
+#
+# Prerequisites:
+#   - Assets/RegressionHarness/KeyStateAfterPauseInterruption/KeyStateAfterPauseInterruption.unity
+#     must be open in a running Unity Editor
+#   - uloop CLI must be installed
+#   - jq must be installed
+
+PROJECT_PATH=""
+if [ "$1" = "--project-path" ] && [ -n "$2" ]; then
+    PROJECT_PATH="$2"
+fi
+
+MARKER_FILE="Assets/RegressionHarness/KeyStateAfterPauseInterruption/SpaceHoldPoller.cs"
+MARKER_LINE="19"
+PRESS_DURATION="5"
+RESULT_FILE="$(mktemp)"
+
+run_uloop() {
+    if [ -n "$PROJECT_PATH" ]; then
+        uloop "$@" --project-path "$PROJECT_PATH"
+    else
+        uloop "$@"
+    fi
+}
+
+log() {
+    printf "\033[36m[key-state-after-pause]\033[0m %s\n" "$1"
+}
+
+cleanup() {
+    rm -f "$RESULT_FILE"
+    run_uloop clear-pause-point --all > /dev/null 2>&1 || true
+    run_uloop control-play-mode --action Stop > /dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+log "Stopping any existing Play Mode session..."
+run_uloop control-play-mode --action Stop > /dev/null
+
+log "Clearing any existing pause-point markers..."
+run_uloop clear-pause-point --all > /dev/null
+
+log "Starting Play Mode..."
+run_uloop control-play-mode --action Play > /dev/null
+
+log "Arming pause-point on $MARKER_FILE:$MARKER_LINE (before Press starts)..."
+run_uloop enable-pause-point --file "$MARKER_FILE" --line "$MARKER_LINE" --timeout-seconds 30 > /dev/null
+
+log "Pressing Space for ${PRESS_DURATION}s in the background (the key-down should hit the marker)..."
+START_SECONDS=$(date +%s)
+run_uloop simulate-keyboard --action Press --key Space --duration "$PRESS_DURATION" > "$RESULT_FILE" 2>&1 &
+PRESS_PID=$!
+
+wait "$PRESS_PID"
+ELAPSED_SECONDS=$(( $(date +%s) - START_SECONDS ))
+
+INTERRUPTED="$(jq -r '.InterruptedByPausePoint' "$RESULT_FILE")"
+SUCCESS="$(jq -r '.Success' "$RESULT_FILE")"
+
+if [ "$SUCCESS" != "true" ] || [ "$INTERRUPTED" != "true" ]; then
+    log "FAIL: expected Success=true and InterruptedByPausePoint=true, got Success=$SUCCESS InterruptedByPausePoint=$INTERRUPTED"
+    cat "$RESULT_FILE"
+    exit 1
+fi
+
+# Why: a swallowed pause completes only after the full requested duration, so
+# an early return is what distinguishes a real interruption from a coincidence.
+if [ "$ELAPSED_SECONDS" -ge "$PRESS_DURATION" ]; then
+    log "FAIL: Press took ${ELAPSED_SECONDS}s, not less than the requested ${PRESS_DURATION}s — the pause did not interrupt it early."
+    cat "$RESULT_FILE"
+    exit 1
+fi
+
+log "PASS: Press was interrupted by the pause-point hit after ${ELAPSED_SECONDS}s (< ${PRESS_DURATION}s requested)."
+exit 0

--- a/scripts/regression-harness-key-state-after-pause-interruption.sh
+++ b/scripts/regression-harness-key-state-after-pause-interruption.sh
@@ -66,7 +66,7 @@ START_SECONDS=$(date +%s)
 run_uloop simulate-keyboard --action Press --key Space --duration "$PRESS_DURATION" > "$RESULT_FILE" 2>&1 &
 PRESS_PID=$!
 
-wait "$PRESS_PID"
+wait "$PRESS_PID" || true
 ELAPSED_SECONDS=$(( $(date +%s) - START_SECONDS ))
 
 INTERRUPTED="$(jq -r '.InterruptedByPausePoint' "$RESULT_FILE")"


### PR DESCRIPTION
## Summary

- `WaitForPressLifetime`/`WaitForRuntimeFrames` could silently absorb a genuine Unity pause into a false `Completed` result: real time keeps advancing while paused, so a duration/frame-count condition could become satisfied inside the same real-time window a pause started, and the original code re-checked pause state at some return points but not the `TimedOut`-with-duration-already-satisfied one.
- Added `EditorPauseAwaiter` (event-based, races `EditorApplication.pauseStateChanged` against the existing frame/timeout wait) so a pause is observed the instant it happens instead of only between completed waits.
- Extracted the post-wait decision into `PressLifetimeIterationResolver` so the pause-priority rule is unit-testable independent of the Editor player loop.
- Added a regression harness scene/script (`Assets/RegressionHarness/KeyStateAfterPauseInterruption/`, `scripts/regression-harness-key-state-after-pause-interruption.sh`) that arms a pause-point on a key-consuming line *before* Press starts, so the hit fires naturally from game code, and verifies the interruption is reported before the requested duration elapses.

## Verification

- **Live deterministic reproduction is not possible from the CLI.** The swallow only triggers when `EditorApplication.update` ticks stall for several seconds while paused (main-thread continuation starvation) — an environment condition, not something a CLI command sequence can reliably orchestrate. Attempting to synthesize the stall (e.g. racing a second CLI command against Press) was tried and rejected: any concurrent CLI command is itself subject to the same starvation, making that approach structurally unstable and non-deterministic.
- **Red was confirmed at the unit level instead.** With the `isPausedFallback` check in `PressLifetimeIterationResolver.ResolvePostWaitOutcome` temporarily reverted to pre-fix behavior, `PressLifetimeIterationResolverTests.ResolvePostWaitOutcome_WhenTimedOutWithDurationSatisfiedAndPausedFallback_ReturnsPaused` fails: `Expected: Paused / But was: Completed`. With the fix restored, the same test (and the other 5 in the file) pass: 6/6.
- Full suite after the fix: PlayMode 93/93 passed; EditMode 2268/2271 passed (7 skipped). The 3 EditMode failures are pre-existing and unrelated to this change — confirmed by stashing all files in this PR and re-running the same 3 tests against the unmodified `feature/round7-pause-point-improvements` HEAD, which fail identically (2 dispatcher-version-pin drift assertions in `CliSetupApplicationServiceTests`, 1 `DescriptionAttribute` exposure assertion in `FirstPartyToolSchemaMetadataTests` — none touch files this PR changes).
- Live E2E with the correct procedure (arm the pause-point on the key-consuming line before Press, not via a concurrent CLI command) passes with the fix restored: `simulate-keyboard Press --key Space --duration 5` returns `InterruptedByPausePoint: true` immediately (0s elapsed, well under the 5s requested).
- `uloop compile`: 0 errors, 0 warnings.

## Known related observation (out of scope for this PR)

The ~5s+ delay in `enable-pause-point`'s reported `EnabledAtUtc` sometimes observed during heavy concurrent CLI usage is a symptom of main-thread continuation-queue starvation, not command serialization — there is no locking in the IPC command dispatch path. This is the same root cause that makes the swallow bug in this PR environment-dependent. Fixing the starvation itself is out of scope here.

## Test plan

- [x] `uloop compile` — 0 errors, 0 warnings
- [x] `uloop run-tests --test-mode EditMode --filter-value PressLifetimeIterationResolverTests` — 6/6 passed (and confirmed failing pre-fix)
- [x] `uloop run-tests --test-mode PlayMode` — 93/93 passed
- [x] `uloop run-tests --test-mode EditMode` — 2268/2271 passed, 3 pre-existing unrelated failures confirmed via baseline stash comparison
- [x] `scripts/regression-harness-key-state-after-pause-interruption.sh` — PASS (interrupted after 0s, under the 5s requested duration)
