### PR TITLE
feat: Expand multidimensional array and dictionary previews in CapturedVariables

### DIFF
--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
@@ -411,6 +411,146 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Format_WithNullableEnumMultidimensionalArray_AnnotatesPreviewWithShape()
+        {
+            // Verifies a T?[,] preview (e.g. a Tetris board of nullable piece-type cells) gets the
+            // same Shape/TotalElements/Elements treatment as a non-nullable T[,], including null
+            // cells rendering as JSON null rather than the whole array degrading to a type-name string.
+            PausePointTestEnum?[,] board = new PausePointTestEnum?[2, 2]
+            {
+                { PausePointTestEnum.Alpha, null },
+                { null, PausePointTestEnum.Beta }
+            };
+            object[] locals = { "board", board };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            string value = variables.Single().Value;
+            Assert.That(value, Does.Contain("\"TotalElements\":4"));
+            Assert.That(value, Does.Contain("\"Elements\":[\"Alpha\",null,null,\"Beta\"]"));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WithNullableEnumSingleDimensionalArray_SerializesAsPlainJsonArrayWithoutShape()
+        {
+            // Boundary case for the Shape annotation above: a T?[] (Rank 1) must stay a bare JSON
+            // array, mirroring the existing non-nullable single-dimensional array behavior.
+            PausePointTestEnum?[] row = { PausePointTestEnum.Alpha, null, PausePointTestEnum.Beta };
+            object[] locals = { "row", row };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            Assert.That(variables.Single().Value, Is.EqualTo("[\"Alpha\",null,\"Beta\"]"));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WithNullableIntMultidimensionalArray_AnnotatesPreviewWithShape()
+        {
+            // Boundary case distinguishing a nullable enum element from a nullable primitive
+            // element: both must hit the same Shape annotation path.
+            int?[,] board = new int?[1, 2] { { 1, null } };
+            object[] locals = { "board", board };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            string value = variables.Single().Value;
+            Assert.That(value, Does.Contain("\"TotalElements\":2"));
+            Assert.That(value, Does.Contain("\"Elements\":[1,null]"));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WithNullableEnumMultidimensionalArrayAsNestedField_AnnotatesPreviewWithShape()
+        {
+            // Reproduces the reported Tetris "Board._cells" shape: a T?[,] one member-access hop
+            // deep (not the top-level captured variable itself) must still get the Shape/Elements
+            // treatment instead of degrading to a bare type-name string.
+            BoardWithNullableEnumCells board = new(new PausePointTestEnum?[2, 2]
+            {
+                { PausePointTestEnum.Alpha, null },
+                { null, PausePointTestEnum.Beta }
+            });
+            object[] locals = { "board", board };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            string value = variables.Single().Value;
+            Assert.That(value, Does.Contain("\"TotalElements\":4"));
+            Assert.That(value, Does.Contain("\"Elements\":[\"Alpha\",null,null,\"Beta\"]"));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WithNullableEnumMultidimensionalArrayTwoFieldHopsDeep_AnnotatesPreviewWithShape()
+        {
+            // Reproduces the reported Tetris "Board._cells" bug exactly: with
+            // MaxCollectionPreviewDepth=2, a T?[,] reached via two field-access hops (captured
+            // object -> Board -> _cells) used to exhaust remainingDepth before BuildToken ever
+            // inspected the array itself, degrading the whole array to a bare type-name ToString
+            // fallback. A primitive/enum-element array must still get Shape/Elements here.
+            GameStateWithNestedBoard gameState = new(new BoardWithNullableEnumCells(new PausePointTestEnum?[2, 2]
+            {
+                { PausePointTestEnum.Alpha, null },
+                { null, PausePointTestEnum.Beta }
+            }));
+            object[] locals = { "gameState", gameState };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            string value = variables.Single().Value;
+            Assert.That(value, Does.Contain("\"TotalElements\":4"));
+            Assert.That(value, Does.Contain("\"Elements\":[\"Alpha\",null,null,\"Beta\"]"));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WithPrimitiveValueDictionaryTwoFieldHopsDeep_SerializesAsJsonObject()
+        {
+            // Dictionary counterpart of the array depth-exemption above: a Dictionary<string, int>
+            // reached via two field-access hops must still expand to a JSON object instead of
+            // degrading to a bare type-name string, since its key and value types are both
+            // primitives that resolve regardless of remaining depth budget.
+            GameStateWithNestedPrimitiveDictionary gameState = new(new WrapperWithPrimitiveDictionary(
+                new Dictionary<string, int> { { "hp", 100 }, { "mp", 50 } }));
+            object[] locals = { "gameState", gameState };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            string value = variables.Single().Value;
+            Assert.That(value, Does.Contain("\"hp\":100"));
+            Assert.That(value, Does.Contain("\"mp\":50"));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WithObjectValueDictionaryTwoFieldHopsDeep_FallsBackToTypeNameAtDepthLimit()
+        {
+            // Boundary case distinguishing the exemption above: a Dictionary<string, SomeObject>
+            // reached the same two hops deep must still hit the existing depth-limit fallback,
+            // since its value type is not a primitive/enum and so genuinely needs recursion budget
+            // this call no longer has.
+            GameStateWithNestedObjectValueDictionary gameState = new(new WrapperWithObjectValueDictionary(
+                new Dictionary<string, SimpleCustomValue> { { "item", new SimpleCustomValue { Number = 1 } } }));
+            object[] locals = { "gameState", gameState };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            string value = variables.Single().Value;
+            Assert.That(value, Does.Contain("Dictionary"));
+            Assert.That(value, Does.Not.Contain("\"item\""));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
         public void Format_WhenCollectionElementCountExceedsPreviewCap_TruncatesElementsAndSetsFlag()
         {
             // Verifies only the first preview-cap elements are serialized and truncation is reported.
@@ -748,6 +888,77 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public IEnumerator GetEnumerator()
             {
                 throw new InvalidOperationException("enum boom");
+            }
+        }
+
+        private enum PausePointTestEnum
+        {
+            Alpha,
+            Beta
+        }
+
+        private sealed class BoardWithNullableEnumCells
+        {
+            private readonly PausePointTestEnum?[,] _cells;
+
+            public BoardWithNullableEnumCells(PausePointTestEnum?[,] cells)
+            {
+                _cells = cells;
+            }
+        }
+
+        private sealed class GameStateWithNestedBoard
+        {
+            private readonly BoardWithNullableEnumCells _board;
+
+            public GameStateWithNestedBoard(BoardWithNullableEnumCells board)
+            {
+                _board = board;
+            }
+        }
+
+        private sealed class WrapperWithPrimitiveDictionary
+        {
+            private readonly Dictionary<string, int> _stats;
+
+            public WrapperWithPrimitiveDictionary(Dictionary<string, int> stats)
+            {
+                _stats = stats;
+            }
+        }
+
+        private sealed class GameStateWithNestedPrimitiveDictionary
+        {
+            private readonly WrapperWithPrimitiveDictionary _wrapper;
+
+            public GameStateWithNestedPrimitiveDictionary(WrapperWithPrimitiveDictionary wrapper)
+            {
+                _wrapper = wrapper;
+            }
+        }
+
+        private sealed class SimpleCustomValue
+        {
+            public int Number;
+        }
+
+        private sealed class WrapperWithObjectValueDictionary
+        {
+            private readonly Dictionary<string, SimpleCustomValue> _items;
+
+            public WrapperWithObjectValueDictionary(Dictionary<string, SimpleCustomValue> items)
+            {
+                _items = items;
+            }
+        }
+
+        private sealed class GameStateWithNestedObjectValueDictionary
+        {
+            private readonly WrapperWithObjectValueDictionary _wrapper;
+
+            public GameStateWithNestedObjectValueDictionary(WrapperWithObjectValueDictionary wrapper)
+            {
+                _wrapper = wrapper;
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
@@ -24,11 +25,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const string OffMainThreadValue = "(captured off main thread)";
         private const string DestroyedValue = "(destroyed)";
 
+        // Why: without this converter, Newtonsoft serializes enums by their underlying integer,
+        // diverging from the scalar-capture path (which already renders enum values by name) and
+        // producing an inconsistent preview like [0,null,1] instead of ["Alpha",null,"Beta"].
         private static readonly JsonSerializer PrimitiveSerializer = JsonSerializer.Create(
             new JsonSerializerSettings
             {
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                Error = HandleSerializationError
+                Error = HandleSerializationError,
+                Converters = { new StringEnumConverter() }
             });
 
         public static bool TrySerialize(object rawValue, ref bool truncated, out string preview)
@@ -112,7 +117,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return new JValue("(circular)");
                 }
 
-                if (remainingDepth <= 0)
+                // Why: an array or dictionary whose elements/keys/values are all primitives/enums
+                // costs no further recursion budget once reached (each one resolves via the
+                // IsJsonPrimitive branch above regardless of depth), so gating it on remainingDepth
+                // here would degrade a nested field like "Board._cells" (a PieceType?[,]) to a bare
+                // type-name string purely because two field-access hops already spent the depth
+                // budget, not because previewing it is actually unsafe or unbounded.
+                bool isPrimitiveElementArray =
+                    value is Array primitiveElementArray && IsJsonPrimitiveElementType(primitiveElementArray.GetType().GetElementType());
+                bool isPrimitiveKeyValueDictionary =
+                    value is IDictionary && IsPrimitiveKeyValueDictionaryType(value.GetType());
+
+                if (remainingDepth <= 0 && !isPrimitiveElementArray && !isPrimitiveKeyValueDictionary)
                 {
                     return new JValue(SafeToString(value));
                 }
@@ -302,6 +318,40 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 or decimal
                 or char
                 or Enum;
+        }
+
+        // Type-level counterpart of IsJsonPrimitive (plus string, which BuildToken also resolves
+        // unconditionally above), used to recognize an array/dictionary whose elements will always
+        // resolve regardless of remaining depth budget.
+        private static bool IsJsonPrimitiveElementType(Type elementType)
+        {
+            Type underlyingType = Nullable.GetUnderlyingType(elementType) ?? elementType;
+            return underlyingType == typeof(bool)
+                || underlyingType == typeof(byte) || underlyingType == typeof(sbyte)
+                || underlyingType == typeof(short) || underlyingType == typeof(ushort)
+                || underlyingType == typeof(int) || underlyingType == typeof(uint)
+                || underlyingType == typeof(long) || underlyingType == typeof(ulong)
+                || underlyingType == typeof(float) || underlyingType == typeof(double)
+                || underlyingType == typeof(decimal)
+                || underlyingType == typeof(char)
+                || underlyingType == typeof(string)
+                || underlyingType.IsEnum;
+        }
+
+        // Dictionary counterpart of IsJsonPrimitiveElementType: recognizes an IDictionary<TKey,
+        // TValue> whose key and value types will both always resolve through the IsJsonPrimitive
+        // branch regardless of remaining depth budget.
+        private static bool IsPrimitiveKeyValueDictionaryType(Type dictionaryType)
+        {
+            Type dictionaryInterface = dictionaryType.GetInterfaces()
+                .FirstOrDefault(candidate => candidate.IsGenericType && candidate.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+            if (dictionaryInterface == null)
+            {
+                return false;
+            }
+
+            Type[] typeArguments = dictionaryInterface.GetGenericArguments();
+            return IsJsonPrimitiveElementType(typeArguments[0]) && IsJsonPrimitiveElementType(typeArguments[1]);
         }
 
         private static string FormatUnityObjectElement(UnityEngine.Object unityObject)


### PR DESCRIPTION
## Summary
- CapturedVariables previews for multidimensional arrays and dictionaries no longer degrade to a bare type-name string when nested a couple of field-access hops deep inside a captured variable.
- Enum values inside array/dictionary previews now render by name instead of their underlying integer.

## User Impact
Before this fix, inspecting a captured variable like a Tetris board's `_cells` field (`PieceType?[,]`) showed only an opaque type-name string such as `"System.Nullable\`1[...PieceType][,]"` -- no shape, no cell values. Nested `Dictionary<string, int>` fields hit the same problem. Separately, even where a preview did expand, enum elements showed up as raw integers (`[0,null,1]`) instead of readable names.

After this fix:
- `Board._cells` (and any array/dictionary of primitives, enums, or strings) previews as a real `Shape`/`Elements` (or key/value) structure at any nesting depth reachable from a captured variable.
- Enum elements render by name (`["Alpha",null,"Beta"]`), consistent with how a plain enum-typed local already renders.
- Collections whose elements are themselves non-primitive objects still fall back to a type name once the preview depth limit is reached -- this fix does not remove the depth limit, only exempts primitive/enum/string leaves from consuming it.

## Changes
- `SourcePausePointCollectionPreviewSerializer.cs`:
  - Registered `StringEnumConverter` on the shared primitive `JsonSerializer` so enum values serialize by name.
  - Added `IsJsonPrimitiveElementType`/`IsPrimitiveKeyValueDictionaryType` to detect arrays/dictionaries whose elements (or keys and values) are all primitives, enums, or strings, and exempt those from the `remainingDepth <= 0` fallback gate.

## Verification
- `dist/darwin-arm64/uloop compile --project-path .`: 0 errors, 0 warnings
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "SourcePausePointVariableFormatterTests" --test-mode EditMode`: 42/42 passed (6 new tests covering 1D/2D nullable-enum arrays, primitive-value dictionaries, and the two-hop nesting boundary for both, plus a boundary case confirming non-primitive collections still respect the depth limit)
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "SourcePausePoint" --test-mode EditMode`: 124/124 passed, no regressions


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

