### PR TITLE
fix: Speed up V3 custom tool migration auto-scan and show progress feedback

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -4843,6 +4843,58 @@ public sealed class HelloResponse : BaseToolResponse
         }
 
         [Test]
+        public async Task PreviewMigrationAsync_WhenCalledTwiceWithoutProjectChanges_ReusesCachedPlanWithoutRescanning()
+        {
+            // Verifies that a second PreviewMigrationAsync call reuses the cached plan instead of running a full rescan.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "HelloTool.cs");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : BaseToolSchema
+{
+}
+
+public sealed class HelloResponse : BaseToolResponse
+{
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                List<ThirdPartyToolMigrationProgress> firstReports = new();
+                ThirdPartyToolMigrationPreview firstPreview =
+                    await service.PreviewMigrationAsync(
+                        projectRoot,
+                        new RecordingMigrationProgress(firstReports),
+                        CancellationToken.None);
+
+                List<ThirdPartyToolMigrationProgress> secondReports = new();
+                ThirdPartyToolMigrationPreview secondPreview =
+                    await service.PreviewMigrationAsync(
+                        projectRoot,
+                        new RecordingMigrationProgress(secondReports),
+                        CancellationToken.None);
+
+                Assert.That(firstPreview.HasTargets, Is.True);
+                Assert.That(secondPreview.FileCount, Is.EqualTo(firstPreview.FileCount));
+                Assert.That(secondPreview.FilePaths, Is.EqualTo(firstPreview.FilePaths));
+                Assert.That(firstReports, Is.Not.Empty);
+                Assert.That(secondReports, Is.Empty);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public async Task ApplyMigrationAsync_WhenProjectChangesAfterPreview_RebuildsPlan()
         {
             // Verifies that cached preview plans are not applied after project files change.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -4901,6 +4901,65 @@ public sealed class HelloResponse : BaseToolResponse
         }
 
         [Test]
+        public async Task PreviewMigrationAsync_WhenCanceledDuringCacheFingerprintCheck_DoesNotInvalidateCache()
+        {
+            // Verifies that canceling a call while it verifies the cache fingerprint does not discard an
+            // otherwise-valid cached plan (a canceled inventory walk returns a partial/empty inventory that
+            // would never match the fingerprint, so it must be treated as "unknown", not "changed").
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "HelloTool.cs");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : BaseToolSchema
+{
+}
+
+public sealed class HelloResponse : BaseToolResponse
+{
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                List<ThirdPartyToolMigrationProgress> firstReports = new();
+                ThirdPartyToolMigrationPreview firstPreview =
+                    await service.PreviewMigrationAsync(
+                        projectRoot,
+                        new RecordingMigrationProgress(firstReports),
+                        CancellationToken.None);
+
+                using CancellationTokenSource canceledSource = new();
+                canceledSource.Cancel();
+                await service.PreviewMigrationAsync(
+                    projectRoot,
+                    new RecordingMigrationProgress(new List<ThirdPartyToolMigrationProgress>()),
+                    canceledSource.Token);
+
+                List<ThirdPartyToolMigrationProgress> thirdReports = new();
+                ThirdPartyToolMigrationPreview thirdPreview =
+                    await service.PreviewMigrationAsync(
+                        projectRoot,
+                        new RecordingMigrationProgress(thirdReports),
+                        CancellationToken.None);
+
+                Assert.That(thirdPreview.FileCount, Is.EqualTo(firstPreview.FileCount));
+                Assert.That(thirdPreview.FilePaths, Is.EqualTo(firstPreview.FilePaths));
+                Assert.That(thirdReports.Count, Is.LessThan(firstReports.Count));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public async Task ApplyMigrationAsync_WhenProjectChangesAfterPreview_RebuildsPlan()
         {
             // Verifies that cached preview plans are not applied after project files change.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -4845,7 +4845,9 @@ public sealed class HelloResponse : BaseToolResponse
         [Test]
         public async Task PreviewMigrationAsync_WhenCalledTwiceWithoutProjectChanges_ReusesCachedPlanWithoutRescanning()
         {
-            // Verifies that a second PreviewMigrationAsync call reuses the cached plan instead of running a full rescan.
+            // Verifies that a second PreviewMigrationAsync call reuses the cached plan and skips the expensive
+            // migration analysis phase, even though it still walks the file inventory asynchronously to verify
+            // the cache's fingerprint is still valid.
             string projectRoot = CreateProjectRoot();
             try
             {
@@ -4886,7 +4888,11 @@ public sealed class HelloResponse : BaseToolResponse
                 Assert.That(secondPreview.FileCount, Is.EqualTo(firstPreview.FileCount));
                 Assert.That(secondPreview.FilePaths, Is.EqualTo(firstPreview.FilePaths));
                 Assert.That(firstReports, Is.Not.Empty);
-                Assert.That(secondReports, Is.Empty);
+                // The cache-hit path still walks the file inventory asynchronously to verify the fingerprint,
+                // so it reports some progress, but far less than a full rebuild (which also analyzes assembly
+                // usage and processes every C# file).
+                Assert.That(secondReports, Is.Not.Empty);
+                Assert.That(secondReports.Count, Is.LessThan(firstReports.Count));
             }
             finally
             {

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationProjectFileInventoryTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationProjectFileInventoryTests.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 using NUnit.Framework;
 
+using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
@@ -13,6 +17,36 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public sealed class ThirdPartyToolMigrationProjectFileInventoryTests
     {
+        [Test]
+        public async Task CreateAsync_WhenAssetsContainsManyFiles_ReportsIncreasingProcessedItemCount()
+        {
+            // Verifies that the inventory walk reports actual scanned-file counts instead of always 0/0.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string vendorDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(vendorDirectory);
+                for (int i = 0; i < 40; i++)
+                {
+                    File.WriteAllText(
+                        Path.Combine(vendorDirectory, $"Tool{i}.cs"),
+                        $"public sealed class Tool{i} {{}}");
+                }
+
+                List<ThirdPartyToolMigrationProgress> reports = new();
+                RecordingInventoryProgress progress = new(reports);
+
+                await ProjectFileInventory.CreateAsync(projectRoot, progress, CancellationToken.None);
+
+                Assert.That(reports, Is.Not.Empty);
+                Assert.That(reports[^1].ProcessedItemCount, Is.GreaterThan(0));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
         [Test]
         public void Create_WhenAssetsContainsSelfReferentialSymbolicLink_CompletesWithoutLooping()
         {
@@ -65,5 +99,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         [DllImport("libc", EntryPoint = "symlink", SetLastError = true)]
         private static extern int Symlink(string targetPath, string linkPath);
+
+        private sealed class RecordingInventoryProgress : IProgress<ThirdPartyToolMigrationProgress>
+        {
+            private readonly List<ThirdPartyToolMigrationProgress> _reports;
+
+            public RecordingInventoryProgress(List<ThirdPartyToolMigrationProgress> reports)
+            {
+                Assert.That(reports, Is.Not.Null);
+
+                _reports = reports;
+            }
+
+            public void Report(ThirdPartyToolMigrationProgress value)
+            {
+                _reports.Add(value);
+            }
+        }
     }
 }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -164,13 +164,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            if (!TryGetCachedPlanForFingerprintCheck(projectRoot, out MigrationPlan cachedPlan))
+            (bool found, MigrationPlan cachedPlan) = TryGetCachedPlanForFingerprintCheck(projectRoot);
+            if (!found)
             {
                 return CachedMigrationPlanLookup.NotFound;
             }
 
             ProjectFileInventory inventory = ProjectFileInventory.Create(projectRoot);
-            return ResolveCachedPlanAgainstInventory(cachedPlan, inventory);
+            return ResolveCachedPlanAgainstInventory(cachedPlan, inventory, wasCanceled: false);
         }
 
         private async Task<CachedMigrationPlanLookup> GetCurrentCachedPlanAsync(
@@ -181,35 +182,42 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(progress != null, "progress must not be null");
 
-            if (!TryGetCachedPlanForFingerprintCheck(projectRoot, out MigrationPlan cachedPlan))
+            (bool found, MigrationPlan cachedPlan) = TryGetCachedPlanForFingerprintCheck(projectRoot);
+            if (!found)
             {
                 return CachedMigrationPlanLookup.NotFound;
             }
 
             ProjectFileInventory inventory = await ProjectFileInventory.CreateAsync(projectRoot, progress, ct);
-            return ResolveCachedPlanAgainstInventory(cachedPlan, inventory);
+            // A canceled walk returns a partial inventory that would never match the cached fingerprint;
+            // treat that as "unknown" instead of invalidating a cache that may still be valid.
+            return ResolveCachedPlanAgainstInventory(cachedPlan, inventory, ct.IsCancellationRequested);
         }
 
-        private bool TryGetCachedPlanForFingerprintCheck(string projectRoot, out MigrationPlan cachedPlan)
+        private (bool Found, MigrationPlan Plan) TryGetCachedPlanForFingerprintCheck(string projectRoot)
         {
             lock (_migrationCacheLock)
             {
                 if (!_hasCachedPlan ||
                     !string.Equals(_cachedPlanProjectRoot, projectRoot, StringComparison.Ordinal))
                 {
-                    cachedPlan = default;
-                    return false;
+                    return (false, default);
                 }
 
-                cachedPlan = _cachedPlan;
-                return true;
+                return (true, _cachedPlan);
             }
         }
 
         private CachedMigrationPlanLookup ResolveCachedPlanAgainstInventory(
             MigrationPlan cachedPlan,
-            ProjectFileInventory inventory)
+            ProjectFileInventory inventory,
+            bool wasCanceled)
         {
+            if (wasCanceled)
+            {
+                return CachedMigrationPlanLookup.NotFound;
+            }
+
             if (!cachedPlan.ProjectFingerprint.Matches(inventory))
             {
                 InvalidateMigrationCaches();

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -151,7 +151,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(progress != null, "progress must not be null");
 
-            CachedMigrationPlanLookup cachedPlan = GetCurrentCachedPlan(projectRoot);
+            CachedMigrationPlanLookup cachedPlan = await GetCurrentCachedPlanAsync(projectRoot, progress, ct);
             if (cachedPlan.Found)
             {
                 return cachedPlan.Plan;
@@ -164,19 +164,52 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            MigrationPlan cachedPlan;
+            if (!TryGetCachedPlanForFingerprintCheck(projectRoot, out MigrationPlan cachedPlan))
+            {
+                return CachedMigrationPlanLookup.NotFound;
+            }
+
+            ProjectFileInventory inventory = ProjectFileInventory.Create(projectRoot);
+            return ResolveCachedPlanAgainstInventory(cachedPlan, inventory);
+        }
+
+        private async Task<CachedMigrationPlanLookup> GetCurrentCachedPlanAsync(
+            string projectRoot,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(progress != null, "progress must not be null");
+
+            if (!TryGetCachedPlanForFingerprintCheck(projectRoot, out MigrationPlan cachedPlan))
+            {
+                return CachedMigrationPlanLookup.NotFound;
+            }
+
+            ProjectFileInventory inventory = await ProjectFileInventory.CreateAsync(projectRoot, progress, ct);
+            return ResolveCachedPlanAgainstInventory(cachedPlan, inventory);
+        }
+
+        private bool TryGetCachedPlanForFingerprintCheck(string projectRoot, out MigrationPlan cachedPlan)
+        {
             lock (_migrationCacheLock)
             {
                 if (!_hasCachedPlan ||
                     !string.Equals(_cachedPlanProjectRoot, projectRoot, StringComparison.Ordinal))
                 {
-                    return CachedMigrationPlanLookup.NotFound;
+                    cachedPlan = default;
+                    return false;
                 }
 
                 cachedPlan = _cachedPlan;
+                return true;
             }
+        }
 
-            ProjectFileInventory inventory = ProjectFileInventory.Create(projectRoot);
+        private CachedMigrationPlanLookup ResolveCachedPlanAgainstInventory(
+            MigrationPlan cachedPlan,
+            ProjectFileInventory inventory)
+        {
             if (!cachedPlan.ProjectFingerprint.Matches(inventory))
             {
                 InvalidateMigrationCaches();

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -52,7 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(progress != null, "progress must not be null");
 
             string normalizedProjectRoot = NormalizeProjectRoot(projectRoot);
-            MigrationPlan plan = await ThirdPartyToolMigrationPlanBuilder.CreateAsync(normalizedProjectRoot, progress, ct);
+            MigrationPlan plan = await GetCurrentMigrationPlanAsync(normalizedProjectRoot, progress, ct);
             if (ct.IsCancellationRequested)
             {
                 return new ThirdPartyToolMigrationPreview(0, 0, Array.Empty<string>());

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationProjectFileInventory.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationProjectFileInventory.cs
@@ -148,7 +148,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Stack<string> pendingDirectories = new();
             pendingDirectories.Push(assetsDirectory);
             int inspectedEntryCount = 0;
-            progress.Report(new ThirdPartyToolMigrationProgress(0, 0));
+            // Total item count is unknown while the directory tree is still being walked, so only
+            // the processed count is reported here (see ThirdPartyToolMigrationProgress: a total of
+            // 0 means "unknown total" rather than "no work").
+            progress.Report(new ThirdPartyToolMigrationProgress(inspectedEntryCount, 0));
 
             while (pendingDirectories.Count > 0)
             {
@@ -164,7 +167,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     inspectedEntryCount++;
                     if (inspectedEntryCount % ThirdPartyToolMigrationFileServiceConstants.PreviewYieldBatchSize == 0)
                     {
-                        progress.Report(new ThirdPartyToolMigrationProgress(0, 0));
+                        progress.Report(new ThirdPartyToolMigrationProgress(inspectedEntryCount, 0));
                         await Task.Yield();
                     }
                 }
@@ -180,7 +183,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     inspectedEntryCount++;
                     if (inspectedEntryCount % ThirdPartyToolMigrationFileServiceConstants.PreviewYieldBatchSize == 0)
                     {
-                        progress.Report(new ThirdPartyToolMigrationProgress(0, 0));
+                        progress.Report(new ThirdPartyToolMigrationProgress(inspectedEntryCount, 0));
                         await Task.Yield();
                     }
                 }

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardText.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardText.cs
@@ -34,6 +34,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal const string MigrationConfirmDialogTitle = "Migrate C# Sources?";
         internal const string MigrationConfirmDialogOkText = "Migrate";
         internal const string MigrationConfirmDialogCancelText = "Cancel";
+        internal const string AutoScanProgressTitle = "Unity CLI Loop";
+        internal const string AutoScanProgressDescription = "Checking for V3 custom tool migration targets...";
         private const string MigrationCheckingText = "Scanning C# source files for V3 custom tool API migration...";
         private const string MigrationApplyingText = "Migrating C# source files to V3 custom tool APIs...";
         private const string MigrationButtonReadyText = "Migrate";

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -61,13 +61,31 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal static void ShowWindowForAutoScan()
         {
-            _ = RunAutoScanAsync(
-                HasMigrationTargetsForAutoScanAsync,
-                SwitchToMainThreadForAutoScanAsync,
-                OpenWindowAfterAutoScan,
-                ConsumeAutoScanSessionState,
-                LogAutoScanException,
-                CancellationToken.None);
+            _ = RunAutoScanWithProgressAsync(CancellationToken.None);
+        }
+
+        private static async Task RunAutoScanWithProgressAsync(CancellationToken ct)
+        {
+            int progressId = Progress.Start(
+                ThirdPartyToolMigrationWizardText.AutoScanProgressTitle,
+                ThirdPartyToolMigrationWizardText.AutoScanProgressDescription);
+            try
+            {
+                IProgress<ThirdPartyToolMigrationProgress> progress =
+                    new AutoScanMigrationProgressReporter(progressId);
+                await RunAutoScanAsync(
+                    innerCt => HasMigrationTargetsForAutoScanAsync(progress, innerCt),
+                    SwitchToMainThreadForAutoScanAsync,
+                    OpenWindowAfterAutoScan,
+                    ConsumeAutoScanSessionState,
+                    LogAutoScanException,
+                    ct);
+            }
+            finally
+            {
+                // Progress.Start/Report/Remove are all native-thread-safe, so no main-thread marshaling is needed here.
+                Progress.Remove(progressId);
+            }
         }
 
         internal static async Task<bool> RunAutoScanAsync(
@@ -107,16 +125,33 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
         }
 
-        private static async Task<bool> HasMigrationTargetsForAutoScanAsync(CancellationToken ct)
+        private static async Task<bool> HasMigrationTargetsForAutoScanAsync(
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct)
         {
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             ThirdPartyToolMigrationUseCase migrationUseCase =
                 GetThirdPartyToolMigrationUseCase();
-            IProgress<ThirdPartyToolMigrationProgress> progress =
-                new Progress<ThirdPartyToolMigrationProgress>();
             ThirdPartyToolMigrationPreview preview = await Task.Run(async () =>
                 await migrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct), ct);
             return preview.HasTargets;
+        }
+
+        // Progress.Start/Report/Remove are declared IsThreadSafe=true in Unity's native bindings,
+        // so this reporter can relay directly from the background scan thread.
+        private sealed class AutoScanMigrationProgressReporter : IProgress<ThirdPartyToolMigrationProgress>
+        {
+            private readonly int _progressId;
+
+            internal AutoScanMigrationProgressReporter(int progressId)
+            {
+                _progressId = progressId;
+            }
+
+            public void Report(ThirdPartyToolMigrationProgress value)
+            {
+                Progress.Report(_progressId, value.ProcessedItemCount, value.TotalItemCount);
+            }
         }
 
         private static async Task SwitchToMainThreadForAutoScanAsync(CancellationToken ct)

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -132,8 +132,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             ThirdPartyToolMigrationUseCase migrationUseCase =
                 GetThirdPartyToolMigrationUseCase();
-            ThirdPartyToolMigrationPreview preview = await Task.Run(async () =>
-                await migrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct), ct);
+            ThirdPartyToolMigrationPreview preview = await Task.Run(() =>
+                migrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct), ct);
             return preview.HasTargets;
         }
 

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -112,8 +112,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             ThirdPartyToolMigrationUseCase migrationUseCase =
                 GetThirdPartyToolMigrationUseCase();
-            return await Task.Run(async () =>
-                await migrationUseCase.HasMigrationTargetsAsync(projectRoot, ct), ct);
+            IProgress<ThirdPartyToolMigrationProgress> progress =
+                new Progress<ThirdPartyToolMigrationProgress>();
+            ThirdPartyToolMigrationPreview preview = await Task.Run(async () =>
+                await migrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct), ct);
+            return preview.HasTargets;
         }
 
         private static async Task SwitchToMainThreadForAutoScanAsync(CancellationToken ct)

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -150,6 +150,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             public void Report(ThirdPartyToolMigrationProgress value)
             {
+                // TotalItemCount <= 0 means "unknown total" (see ThirdPartyToolMigrationProjectFileInventory);
+                // Progress.Report's totalSteps=0 behavior is undocumented and unverifiable from managed code,
+                // so skip the items overload and leave the task showing as a plain busy indicator instead.
+                if (value.TotalItemCount <= 0)
+                {
+                    return;
+                }
+
                 Progress.Report(_progressId, value.ProcessedItemCount, value.TotalItemCount);
             }
         }


### PR DESCRIPTION
## Summary
- Speeds up the V3 custom tool migration wizard that opens automatically after a V2-to-V3 upgrade, cutting both the wait before the window appears and the re-check right after it opens
- Shows scan progress in the Editor status bar while the wizard is checking for migration targets

## User Impact
- Before: the auto-scan gave no visual feedback before the window opened, and once it opened, the exact same project scan ran again from scratch. On projects with many files (or on Windows with real-time antivirus scanning), this looked like a hang
- After: the auto-scan's result is reused for the post-open check, so the scan no longer runs twice. While scanning, the Editor's background task status bar shows "Unity CLI Loop: Checking for V3 custom tool migration targets..."
- The existing behavior of not showing the window at all when there is nothing to migrate is unchanged

## Changes
- Added the same fingerprint-verified plan cache to the async preview path that the sync path already had, so the second scan right after the window opens hits the cache instead of rescanning
- Switched the auto-scan check from a cache-blind boolean check to a full preview call, so its result carries over into the cache
- Wrapped the auto-scan in `UnityEditor.Progress.Start`/`Report`/`Remove`, relaying scan progress to the status bar and always removing the task on completion, exception, or cancellation (`Progress.Start/Report/Remove` are declared thread-safe in Unity's native bindings, so the reporter calls them directly from the background scan thread)
- Fixed the file-inventory phase, which always reported a static 0/0 progress value, to report the actual number of files scanned so far
- Kept the existing boolean-only migration-target check (`HasMigrationTargetsAsync`) in place rather than removing it: about 40 existing tests exercise it directly, and rewriting that whole suite is out of scope for this change
- Made the plan cache's fingerprint check itself asynchronous: it previously walked the whole project via a synchronous `ProjectFileInventory.Create` even on a cache hit, which would have quietly re-introduced a blocking full scan on every cache reuse

## Verification
- `dist/darwin-arm64/uloop compile`: no errors or warnings
- `dist/darwin-arm64/uloop run-tests` (all 428 `ThirdPartyToolMigration`-related tests): all green
- Added regression tests (cache reuse, progress reporting) following TDD Red -> Green
- Manual check: opened the custom tool migration wizard on macOS and confirmed scan -> result display still works as before
- Not verified: the full auto-scan path reproduced via a real V2-to-V3 upgrade on Windows

