### PR TITLE
chore: Split an oversized pause-point CLI file to fix the architecture size check

### DIFF
--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -25,11 +25,9 @@ const (
 	pausePointStatusNotEnabled        = "NotEnabled"
 	pausePointStatusExpired           = "Expired"
 	pausePointStatusCleared           = "Cleared"
-	pausePointFinalStatusProbeTimeout = 250 * time.Millisecond
 )
 
 var (
-	pausePointStatusPoll   = 50 * time.Millisecond
 	queryPausePointStatus  = queryPausePointStatusFromUnity
 	clearPausePointStatus  = clearPausePointStatusFromUnity
 	extendPausePointExpiry = extendPausePointExpiryFromUnity
@@ -58,16 +56,6 @@ type pausePointStatusOptions struct {
 	capturedVariablesMode pausePointCapturedVariablesMode
 	capturedVariableNames []string
 }
-
-type pausePointWaitState string
-
-const (
-	pausePointWaitStateHit        pausePointWaitState = "hit"
-	pausePointWaitStateTimeout    pausePointWaitState = "timeout"
-	pausePointWaitStateNotEnabled pausePointWaitState = "not_enabled"
-	pausePointWaitStateExpired    pausePointWaitState = "expired"
-	pausePointWaitStateCleared    pausePointWaitState = "cleared"
-)
 
 func normalizePausePointStatusResponse(response pausePointStatusResponse) pausePointStatusResponse {
 	if response.Status == pausePointStatusExpired {
@@ -412,137 +400,4 @@ func parsePausePointTimeoutSeconds(value string) (int, error) {
 		return 0, clierrors.InvalidValueArgumentError("--"+PausePointTimeoutFlagName, value, "positive integer")
 	}
 	return timeoutSeconds, nil
-}
-
-// waitForPausePoint confirms the marker is actually armed with one status query before starting
-// the --trigger command: extendPausePointExpiryBeforeWait (the await-pause-point entry point) is
-// best-effort and does not confirm arm, so a typo'd or already-expired --id must not still get the
-// trigger dispatched into the running game before the wait immediately fails on it. Once confirmed
-// armed (or already hit), the trigger races the status poll loop and is joined once the wait itself
-// settles, so a slow trigger cannot delay reporting a pause-point hit.
-func waitForPausePoint(
-	ctx context.Context,
-	connection unityipc.Connection,
-	options waitForPausePointOptions,
-) (pausePointStatusResponse, pausePointWaitState, *pausePointTriggerResult, error) {
-	var triggerHandle *pausePointTriggerHandle
-	var skippedTriggerResult *pausePointTriggerResult
-	if options.triggerCommand != "" {
-		if pausePointIsArmed(ctx, connection, options.id) {
-			triggerHandle = startPausePointTrigger(ctx, connection, options.startPath, options.triggerCommand, options.triggerArgs)
-		} else {
-			// --trigger always yields a TriggerResult when given, even when skipped: a silently
-			// omitted TriggerResult would be indistinguishable from "the trigger ran but this CLI
-			// exited before it reported anything," hiding the real reason (marker not confirmed
-			// armed) behind a plain timeout/not-enabled error with no clue why the trigger never fired.
-			skippedTriggerResult = &pausePointTriggerResult{
-				Command: pausePointTriggerCommandString(options.triggerCommand, options.triggerArgs),
-				Error:   "trigger was not dispatched: the marker could not be confirmed armed at wait start",
-			}
-		}
-	}
-
-	response, state, err := waitForPausePointStatus(ctx, connection, options)
-	if skippedTriggerResult != nil {
-		return response, state, skippedTriggerResult, err
-	}
-	return response, state, triggerHandle.join(), err
-}
-
-// pausePointIsArmed reports whether the marker is enabled or already hit. A query failure is
-// treated as not armed: dispatching a --trigger command against a marker this CLI cannot even
-// confirm exists would inject the trigger's action into the game with no corresponding wait.
-func pausePointIsArmed(ctx context.Context, connection unityipc.Connection, id string) bool {
-	response, err := queryPausePointStatus(ctx, connection, id)
-	if err != nil {
-		return false
-	}
-	state := pausePointWaitStateForStatus(response.Status)
-	return state == "" || state == pausePointWaitStateHit
-}
-
-func waitForPausePointStatus(
-	ctx context.Context,
-	connection unityipc.Connection,
-	options waitForPausePointOptions,
-) (pausePointStatusResponse, pausePointWaitState, error) {
-	waitContext, cancel := context.WithTimeout(ctx, options.timeout)
-	defer cancel()
-
-	lastResponse := pausePointStatusResponse{Id: options.id}
-	var lastErr error
-	hasResponse := false
-	ticker := time.NewTicker(pausePointStatusPoll)
-	defer ticker.Stop()
-	for {
-		response, err := queryPausePointStatus(waitContext, connection, options.id)
-		if err == nil {
-			lastResponse = response
-			hasResponse = true
-			state := pausePointWaitStateForStatus(response.Status)
-			if state != "" {
-				return response, state, nil
-			}
-		} else {
-			lastErr = err
-		}
-
-		select {
-		case <-waitContext.Done():
-			if ctx.Err() != nil {
-				return lastResponse, "", ctx.Err()
-			}
-			finalResponse, finalState, hasFinalResponse, finalErr := queryPausePointStatusAtTimeout(ctx, connection, options.id)
-			if hasFinalResponse {
-				lastResponse = finalResponse
-				hasResponse = true
-				if finalState != "" {
-					return finalResponse, finalState, nil
-				}
-			} else if lastErr == nil {
-				lastErr = finalErr
-			}
-			if hasResponse {
-				return lastResponse, pausePointWaitStateTimeout, nil
-			}
-			if lastErr != nil {
-				return lastResponse, "", fmt.Errorf("timed out waiting for pause point status: %w", lastErr)
-			}
-			return lastResponse, pausePointWaitStateTimeout, nil
-		case <-ticker.C:
-		}
-	}
-}
-
-func queryPausePointStatusAtTimeout(
-	ctx context.Context,
-	connection unityipc.Connection,
-	id string,
-) (pausePointStatusResponse, pausePointWaitState, bool, error) {
-	finalContext, cancel := context.WithTimeout(ctx, pausePointFinalStatusProbeTimeout)
-	defer cancel()
-
-	response, err := queryPausePointStatus(finalContext, connection, id)
-	if err != nil {
-		return pausePointStatusResponse{}, "", false, err
-	}
-
-	return response, pausePointWaitStateForStatus(response.Status), true, nil
-}
-
-func pausePointWaitStateForStatus(status string) pausePointWaitState {
-	switch status {
-	case pausePointStatusHit:
-		return pausePointWaitStateHit
-	case pausePointStatusNotEnabled:
-		return pausePointWaitStateNotEnabled
-	case pausePointStatusExpired:
-		return pausePointWaitStateExpired
-	case pausePointStatusCleared:
-		return pausePointWaitStateCleared
-	case pausePointStatusEnabled:
-		return ""
-	default:
-		return ""
-	}
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_poll.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_poll.go
@@ -1,0 +1,156 @@
+package projectrunner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+const pausePointFinalStatusProbeTimeout = 250 * time.Millisecond
+
+var pausePointStatusPoll = 50 * time.Millisecond
+
+type pausePointWaitState string
+
+const (
+	pausePointWaitStateHit        pausePointWaitState = "hit"
+	pausePointWaitStateTimeout    pausePointWaitState = "timeout"
+	pausePointWaitStateNotEnabled pausePointWaitState = "not_enabled"
+	pausePointWaitStateExpired    pausePointWaitState = "expired"
+	pausePointWaitStateCleared    pausePointWaitState = "cleared"
+)
+
+// waitForPausePoint confirms the marker is actually armed with one status query before starting
+// the --trigger command: extendPausePointExpiryBeforeWait (the await-pause-point entry point) is
+// best-effort and does not confirm arm, so a typo'd or already-expired --id must not still get the
+// trigger dispatched into the running game before the wait immediately fails on it. Once confirmed
+// armed (or already hit), the trigger races the status poll loop and is joined once the wait itself
+// settles, so a slow trigger cannot delay reporting a pause-point hit.
+func waitForPausePoint(
+	ctx context.Context,
+	connection unityipc.Connection,
+	options waitForPausePointOptions,
+) (pausePointStatusResponse, pausePointWaitState, *pausePointTriggerResult, error) {
+	var triggerHandle *pausePointTriggerHandle
+	var skippedTriggerResult *pausePointTriggerResult
+	if options.triggerCommand != "" {
+		if pausePointIsArmed(ctx, connection, options.id) {
+			triggerHandle = startPausePointTrigger(ctx, connection, options.startPath, options.triggerCommand, options.triggerArgs)
+		} else {
+			// --trigger always yields a TriggerResult when given, even when skipped: a silently
+			// omitted TriggerResult would be indistinguishable from "the trigger ran but this CLI
+			// exited before it reported anything," hiding the real reason (marker not confirmed
+			// armed) behind a plain timeout/not-enabled error with no clue why the trigger never fired.
+			skippedTriggerResult = &pausePointTriggerResult{
+				Command: pausePointTriggerCommandString(options.triggerCommand, options.triggerArgs),
+				Error:   "trigger was not dispatched: the marker could not be confirmed armed at wait start",
+			}
+		}
+	}
+
+	response, state, err := waitForPausePointStatus(ctx, connection, options)
+	if skippedTriggerResult != nil {
+		return response, state, skippedTriggerResult, err
+	}
+	return response, state, triggerHandle.join(), err
+}
+
+// pausePointIsArmed reports whether the marker is enabled or already hit. A query failure is
+// treated as not armed: dispatching a --trigger command against a marker this CLI cannot even
+// confirm exists would inject the trigger's action into the game with no corresponding wait.
+func pausePointIsArmed(ctx context.Context, connection unityipc.Connection, id string) bool {
+	response, err := queryPausePointStatus(ctx, connection, id)
+	if err != nil {
+		return false
+	}
+	state := pausePointWaitStateForStatus(response.Status)
+	return state == "" || state == pausePointWaitStateHit
+}
+
+func waitForPausePointStatus(
+	ctx context.Context,
+	connection unityipc.Connection,
+	options waitForPausePointOptions,
+) (pausePointStatusResponse, pausePointWaitState, error) {
+	waitContext, cancel := context.WithTimeout(ctx, options.timeout)
+	defer cancel()
+
+	lastResponse := pausePointStatusResponse{Id: options.id}
+	var lastErr error
+	hasResponse := false
+	ticker := time.NewTicker(pausePointStatusPoll)
+	defer ticker.Stop()
+	for {
+		response, err := queryPausePointStatus(waitContext, connection, options.id)
+		if err == nil {
+			lastResponse = response
+			hasResponse = true
+			state := pausePointWaitStateForStatus(response.Status)
+			if state != "" {
+				return response, state, nil
+			}
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-waitContext.Done():
+			if ctx.Err() != nil {
+				return lastResponse, "", ctx.Err()
+			}
+			finalResponse, finalState, hasFinalResponse, finalErr := queryPausePointStatusAtTimeout(ctx, connection, options.id)
+			if hasFinalResponse {
+				lastResponse = finalResponse
+				hasResponse = true
+				if finalState != "" {
+					return finalResponse, finalState, nil
+				}
+			} else if lastErr == nil {
+				lastErr = finalErr
+			}
+			if hasResponse {
+				return lastResponse, pausePointWaitStateTimeout, nil
+			}
+			if lastErr != nil {
+				return lastResponse, "", fmt.Errorf("timed out waiting for pause point status: %w", lastErr)
+			}
+			return lastResponse, pausePointWaitStateTimeout, nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func queryPausePointStatusAtTimeout(
+	ctx context.Context,
+	connection unityipc.Connection,
+	id string,
+) (pausePointStatusResponse, pausePointWaitState, bool, error) {
+	finalContext, cancel := context.WithTimeout(ctx, pausePointFinalStatusProbeTimeout)
+	defer cancel()
+
+	response, err := queryPausePointStatus(finalContext, connection, id)
+	if err != nil {
+		return pausePointStatusResponse{}, "", false, err
+	}
+
+	return response, pausePointWaitStateForStatus(response.Status), true, nil
+}
+
+func pausePointWaitStateForStatus(status string) pausePointWaitState {
+	switch status {
+	case pausePointStatusHit:
+		return pausePointWaitStateHit
+	case pausePointStatusNotEnabled:
+		return pausePointWaitStateNotEnabled
+	case pausePointStatusExpired:
+		return pausePointWaitStateExpired
+	case pausePointStatusCleared:
+		return pausePointWaitStateCleared
+	case pausePointStatusEnabled:
+		return ""
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary
- No user-visible behavior change. This is a pure file split to fix a failing architecture check on the integration branch.

## User Impact
- N/A (internal-only refactor; `await-pause-point` and `pause-point-status` CLI behavior is unchanged).

## Changes
- `pause_point_wait.go` had grown to 548 lines across PR-2's review-response commits, tripping `TestProductionGoFilesStayFocused`'s 500-line gate and turning the Round-7 integration PR's CI red (`build-cli`, `Go CLI Security Analysis`, `test-windows-installers`).
- Move the trigger-arming and status-poll-loop functions (`waitForPausePoint`, `pausePointIsArmed`, `waitForPausePointStatus`, `queryPausePointStatusAtTimeout`, `pausePointWaitStateForStatus`, plus the `pausePointWaitState` type and its supporting const/var) into a new `pause_point_wait_poll.go` file.
- `pause_point_wait.go` keeps command entry points, option parsing, and response normalization/formatting. No public signatures changed.

## Verification
- `sh scripts/check-go-cli.sh` -- format/vet/lint/tests/binary rebuild all pass.
- `go test ./internal/architecture/... -run TestProductionGoFilesStayFocused -v` (from `cli/release-automation`) -- passes.
- `go test ./internal/projectrunner/... -run "PausePoint" -v` (from `cli/project-runner`) -- all pass, unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

