### PR TITLE
fix: Silence a Unity 6000.5 compile warning in physics pause-point diagnostics

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -461,9 +461,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // -1 signals "not applicable": counting instances only means something when the
             // declaring type is a MonoBehaviour (the physics dispatch miss this diagnostic exists
             // for is scoped to MonoBehaviour physics message methods).
+#if UNITY_6000_4_OR_NEWER
+            int instanceCount = isMonoBehaviourDerived
+                ? UnityEngine.Object.FindObjectsByType(declaringType, FindObjectsInactive.Include).Length
+                : -1;
+#else
             int instanceCount = isMonoBehaviourDerived
                 ? UnityEngine.Object.FindObjectsByType(declaringType, FindObjectsInactive.Include, FindObjectsSortMode.None).Length
                 : -1;
+#endif
 
             VibeLogger.LogInfo(
                 operation,


### PR DESCRIPTION
## Summary
- No user-visible behavior change. Fixes a Unity 6000.5 compile warning that was failing the Round-7 integration PR's CI.

## User Impact
- N/A (internal-only fix; physics-callback pause point diagnostics behavior is unchanged on every Unity version).

## Changes
- `Object.FindObjectsByType(Type, FindObjectsInactive, FindObjectsSortMode)` is marked obsolete (`CS0618`) starting in Unity 6000.5, which failed the Unity Compile Check's warning-zero gate on 6000.5.4f1 (2022.3, the local dev version, built clean).
- Guard the call in `LogPhysicsDispatchDiagnostics` behind `UNITY_6000_4_OR_NEWER`, matching the existing pattern in `UiRaycastHelper.CollectCanvasRaycastSources`: the sort-mode-free overload on 6000.4+, the existing three-argument call below it otherwise.

## Verification
- `uloop compile` (2022.3.62f3, this checkout's Unity version) -- 0 errors, 0 warnings.
- `uloop run-tests --filter-type regex --filter-value "SourcePausePointPatcherTests" --test-mode EditMode` -- 27/27 passed.
- The 6000.5 branch itself is only exercised by CI (this checkout runs 2022.3); confirming its warning-free compile there is the next step.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

