### PR TITLE
fix: Make the migration wizard window resizable, scrollable, and its scan result concise

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -642,7 +642,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Vector2 frameSize = new(18f, 28f);
 
             Rect resizedRect =
-                ThirdPartyToolMigrationWizardWindow.WithContentHeight(initialRect, 180f, frameSize);
+                ThirdPartyToolMigrationWizardWindow.WithContentHeight(initialRect, 180f, frameSize, 1000f);
 
             Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
             Assert.That(resizedRect.size, Is.EqualTo(new Vector2(360f, 208f)));
@@ -656,7 +656,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Vector2 frameSize = new(18f, 28f);
 
             Rect resizedRect =
-                ThirdPartyToolMigrationWizardWindow.WithContentHeight(initialRect, 12f, frameSize);
+                ThirdPartyToolMigrationWizardWindow.WithContentHeight(initialRect, 12f, frameSize, 1000f);
 
             Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
             Assert.That(resizedRect.size, Is.EqualTo(new Vector2(360f, 120f)));
@@ -670,10 +670,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Vector2 frameSize = new(18f, 28f);
 
             Rect resizedRect =
-                ThirdPartyToolMigrationWizardWindow.WithContentHeight(initialRect, 120f, frameSize);
+                ThirdPartyToolMigrationWizardWindow.WithContentHeight(initialRect, 120f, frameSize, 1000f);
 
             Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
             Assert.That(resizedRect.size, Is.EqualTo(new Vector2(360f, 148f)));
+        }
+
+        [Test]
+        public void WithContentHeight_WhenMeasuredHeightExceedsMaxHeight_ClampsToMaxHeight()
+        {
+            // Verifies that content fitting never grows the migration wizard past the supplied maximum height.
+            Rect initialRect = new(123f, 456f, 400f, 220f);
+            Vector2 frameSize = new(18f, 28f);
+
+            Rect resizedRect =
+                ThirdPartyToolMigrationWizardWindow.WithContentHeight(initialRect, 900f, frameSize, 500f);
+
+            Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
+            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(360f, 500f)));
+        }
+
+        [Test]
+        public void WithContentHeight_WhenMaxHeightIsBelowMinimum_ClampsToMinimumHeight()
+        {
+            // Verifies that an unreasonably small maxHeight cannot shrink the window below the usable minimum.
+            Rect initialRect = new(123f, 456f, 400f, 220f);
+            Vector2 frameSize = new(18f, 28f);
+
+            Rect resizedRect =
+                ThirdPartyToolMigrationWizardWindow.WithContentHeight(initialRect, 900f, frameSize, 50f);
+
+            Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
+            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(360f, 120f)));
         }
 
         private static int GetVisualElementIndex(VisualElement root, VisualElement target)

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -152,85 +152,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void GetMigrationStatusText_WhenTargetsExist_IncludesRelativeFilePaths()
+        public void GetMigrationStatusText_WhenTargetsExist_ReturnsCountOnlyMessage()
         {
-            // Verifies the migration status lists project-relative target paths after the summary.
-            string projectRoot = System.IO.Path.Combine(
-                System.IO.Path.GetTempPath(),
-                "UnityCliLoopMigrationStatusRoot",
-                System.Guid.NewGuid().ToString("N"));
-            System.IO.Directory.CreateDirectory(projectRoot);
-            try
-            {
-                string[] filePaths =
-                {
-                    System.IO.Path.Combine(projectRoot, "Assets", "Vendor", "One.cs"),
-                    System.IO.Path.Combine(projectRoot, "Assets", "Vendor", "Two.cs")
-                };
+            // Verifies the migration status is a brief count message with no file paths listed.
+            string text = ThirdPartyToolMigrationWizardWindow.GetMigrationStatusText(12);
 
-                string text = ThirdPartyToolMigrationWizardWindow.GetMigrationStatusText(
-                    filePaths,
-                    projectRoot);
-
-                Assert.That(text, Does.StartWith(
-                    "2 files need V3 C# source structure migration.\n" +
-                    "The Unity Console is showing errors because these files still use the old custom tool API.\n\n" +
-                    "Click Migrate to update them automatically. The errors should disappear after migration.\n\n" +
-                    "Files:\n"));
-                Assert.That(text, Does.Contain("Assets/Vendor/One.cs"));
-                Assert.That(text, Does.Contain("Assets/Vendor/Two.cs"));
-                Assert.That(text, Does.Not.Contain("\\"));
-            }
-            finally
-            {
-                System.IO.Directory.Delete(projectRoot, recursive: true);
-            }
+            Assert.That(text, Is.EqualTo("Found 12 C# files that need V3 migration."));
         }
 
         [Test]
-        public void NormalizeDisplayPathSeparators_WhenPathsUseBackslashes_NormalizesToForwardSlashes()
+        public void GetMigrationStatusText_WhenSingleTargetExists_UsesSingularNoun()
         {
-            // Verifies displayed migration paths always use forward slashes on every platform.
-            string normalized = ThirdPartyToolMigrationWizardStateRules.NormalizeDisplayPathSeparators(
-                "Assets\\Vendor\\Tool.cs");
+            // Verifies the singular file count does not pluralize the noun.
+            string text = ThirdPartyToolMigrationWizardWindow.GetMigrationStatusText(1);
 
-            Assert.That(normalized, Is.EqualTo("Assets/Vendor/Tool.cs"));
-        }
-
-        [Test]
-        public void FormatMigrationTargetPathsForStatus_WhenPathCountExceedsLimit_AppendsOverflowSummary()
-        {
-            // Verifies long target lists truncate with a +N more files suffix.
-            string projectRoot = System.IO.Path.Combine(
-                System.IO.Path.GetTempPath(),
-                "UnityCliLoopMigrationOverflowRoot",
-                System.Guid.NewGuid().ToString("N"));
-            System.IO.Directory.CreateDirectory(projectRoot);
-            try
-            {
-                int totalCount = ThirdPartyToolMigrationWizardStateRules.MaxMigrationTargetPathsInStatus + 3;
-                string[] filePaths = new string[totalCount];
-                for (int index = 0; index < totalCount; index++)
-                {
-                    filePaths[index] = System.IO.Path.Combine(projectRoot, "Assets", $"File{index:D3}.cs");
-                }
-
-                string text = ThirdPartyToolMigrationWizardText.FormatMigrationTargetPathsForStatus(
-                    filePaths,
-                    projectRoot);
-
-                Assert.That(text, Does.Contain("Assets/File000.cs"));
-                Assert.That(
-                    text,
-                    Does.Contain(
-                        $"Assets/File{(ThirdPartyToolMigrationWizardStateRules.MaxMigrationTargetPathsInStatus - 1):D3}.cs"));
-                Assert.That(text, Does.Contain("+3 more files"));
-                Assert.That(text, Does.Not.Contain($"Assets/File{ThirdPartyToolMigrationWizardStateRules.MaxMigrationTargetPathsInStatus:D3}.cs"));
-            }
-            finally
-            {
-                System.IO.Directory.Delete(projectRoot, recursive: true);
-            }
+            Assert.That(text, Is.EqualTo("Found 1 C# file that needs V3 migration."));
         }
 
         [Test]

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -13,6 +13,7 @@
    Block: Main Container
    =========================================== */
 .setup-main-container {
+    flex-grow: 1;
     padding: 12px;
 }
 

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardStateRules.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardStateRules.cs
@@ -10,39 +10,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     internal static class ThirdPartyToolMigrationWizardStateRules
     {
         internal const int MigrationProgressUiUpdateIntervalMilliseconds = 100;
-        internal const int MaxMigrationTargetPathsInStatus = 50;
-
-        internal static int GetMigrationTargetPathsOverflowCount(int totalPathCount, int maxPaths)
-        {
-            Debug.Assert(totalPathCount >= 0, "totalPathCount must not be negative");
-            Debug.Assert(maxPaths > 0, "maxPaths must be positive");
-
-            if (totalPathCount <= maxPaths)
-            {
-                return 0;
-            }
-
-            return totalPathCount - maxPaths;
-        }
-
-        internal static string NormalizeDisplayPathSeparators(string path)
-        {
-            Debug.Assert(path != null, "path must not be null");
-
-            // Status text must stay Windows-safe: never leave backslashes in displayed relative paths.
-            return path.Replace('\\', '/');
-        }
-
-        internal static string ToProjectRelativeDisplayPath(string filePath, string projectRoot)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            string relativePath = System.IO.Path.GetRelativePath(
-                System.IO.Path.GetFullPath(projectRoot),
-                System.IO.Path.GetFullPath(filePath));
-            return NormalizeDisplayPathSeparators(relativePath);
-        }
 
         internal static bool ShouldReportMigrationProgress(
             long lastReportTimestamp,

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardText.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardText.cs
@@ -46,24 +46,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string RemoveMigrationSkillButtonText = "Remove Migration Skill";
         private const string UpdatingMigrationSkillButtonText = "Updating...";
         private const string CopyMigrationSkillPromptButtonText = "Copy AI Prompt";
-        private const string MigrationTargetFilesHeading = "Files:";
 
-        internal static string GetMigrationStatusText(string[] filePaths, string projectRoot)
+        internal static string GetMigrationStatusText(int fileCount)
         {
-            Debug.Assert(filePaths != null, "filePaths must not be null");
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(fileCount >= 0, "fileCount must not be negative");
 
-            int fileCount = filePaths.Length;
             string noun = fileCount == 1 ? "file" : "files";
             string verb = fileCount == 1 ? "needs" : "need";
-            string subject = fileCount == 1 ? "this file still uses" : "these files still use";
-            string objectPronoun = fileCount == 1 ? "it" : "them";
-
-            return $"{fileCount} {noun} {verb} V3 C# source structure migration.\n" +
-                $"The Unity Console is showing errors because {subject} the old custom tool API.\n\n" +
-                $"Click Migrate to update {objectPronoun} automatically. " +
-                "The errors should disappear after migration.\n\n" +
-                FormatMigrationTargetPathsForStatus(filePaths, projectRoot);
+            return $"Found {fileCount} C# {noun} that {verb} V3 migration.";
         }
 
         internal static string GetMigrationConfirmDialogMessage(int fileCount)
@@ -73,38 +63,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string noun = fileCount == 1 ? "file" : "files";
             return $"{fileCount} {noun} will be rewritten in place.\n\n" +
                 "Commit or back up your project first (VCS recommended).";
-        }
-
-        internal static string FormatMigrationTargetPathsForStatus(string[] filePaths, string projectRoot)
-        {
-            Debug.Assert(filePaths != null, "filePaths must not be null");
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            int maxPaths = ThirdPartyToolMigrationWizardStateRules.MaxMigrationTargetPathsInStatus;
-            int overflowCount = ThirdPartyToolMigrationWizardStateRules.GetMigrationTargetPathsOverflowCount(
-                filePaths.Length,
-                maxPaths);
-            int displayCount = filePaths.Length - overflowCount;
-            System.Text.StringBuilder builder = new();
-            builder.Append(MigrationTargetFilesHeading);
-            for (int index = 0; index < displayCount; index++)
-            {
-                builder.Append('\n');
-                builder.Append(
-                    ThirdPartyToolMigrationWizardStateRules.ToProjectRelativeDisplayPath(
-                        filePaths[index],
-                        projectRoot));
-            }
-
-            if (overflowCount > 0)
-            {
-                builder.Append('\n');
-                builder.Append('+');
-                builder.Append(overflowCount);
-                builder.Append(" more files");
-            }
-
-            return builder.ToString();
         }
 
         internal static string GetMigrationProgressText(

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardView.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardView.cs
@@ -143,13 +143,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _refreshButton.SetEnabled(true);
         }
 
-        internal void ShowMigrationTargetsState(string[] filePaths, string projectRoot, bool isMigrating)
+        internal void ShowMigrationTargetsState(string[] filePaths, bool isMigrating)
         {
             Debug.Assert(filePaths != null, "filePaths must not be null");
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
             _migrationStatusTextField.SetValueWithoutNotify(
-                ThirdPartyToolMigrationWizardText.GetMigrationStatusText(filePaths, projectRoot));
+                ThirdPartyToolMigrationWizardText.GetMigrationStatusText(filePaths.Length));
             ViewDataBinder.SetVisible(_migrationProgressBar, false);
             ViewDataBinder.SetVisible(_migrationButtonRow, true);
             _migrateButton.SetEnabled(!isMigrating);

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -229,9 +229,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 maxHeight);
         }
 
-        internal static string GetMigrationStatusText(string[] filePaths, string projectRoot)
+        internal static string GetMigrationStatusText(int fileCount)
         {
-            return ThirdPartyToolMigrationWizardText.GetMigrationStatusText(filePaths, projectRoot);
+            return ThirdPartyToolMigrationWizardText.GetMigrationStatusText(fileCount);
         }
 
         internal static bool ConfirmMigrationApply(

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -216,12 +216,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return ThirdPartyToolMigrationWizardWindowResizer.CreateCenteredRect(bounds, size);
         }
 
-        internal static Rect WithContentHeight(Rect currentRect, float contentHeight, Vector2 frameSize)
+        internal static Rect WithContentHeight(
+            Rect currentRect,
+            float contentHeight,
+            Vector2 frameSize,
+            float maxHeight)
         {
             return ThirdPartyToolMigrationWizardWindowResizer.WithContentHeight(
                 currentRect,
                 contentHeight,
-                frameSize);
+                frameSize,
+                maxHeight);
         }
 
         internal static string GetMigrationStatusText(string[] filePaths, string projectRoot)
@@ -356,7 +361,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 CreateInstance<ThirdPartyToolMigrationWizardWindow>();
             PrepareForOpen(window, WindowTitle, windowPosition, shouldRefreshAfterCreateGui);
             window.ShowUtility();
-            window.ScheduleResizeToContent();
         }
 
         private static ISessionFlagsRepository GetSessionFlagsRepository()
@@ -423,7 +427,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 () => _controller.HandleToggleMigrationSkill().Forget(),
                 Close);
             _resizer = new ThirdPartyToolMigrationWizardWindowResizer(this, _view.MainScrollView);
-            _resizer.BindSizeUpdates();
             _controller = new ThirdPartyToolMigrationWizardWorkflowController(
                 _view,
                 _skillSetupUseCase,
@@ -434,7 +437,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _controller.ShowInitialState(shouldStartInitialRefresh);
             _controller.RefreshMigrationSkillState();
             _controller.ScheduleInitialRefresh(shouldStartInitialRefresh);
-            ScheduleResizeToContent();
         }
 
         private void InitializeApplicationServices()

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindowResizer.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindowResizer.cs
@@ -11,11 +11,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     {
         internal static readonly Vector2 InitialWindowSize = new Vector2(360f, 220f);
         internal static readonly Vector2 MinimumWindowSize = new Vector2(360f, 120f);
+        private const float MaxHeightRatioOfMainWindow = 0.9f;
 
         private readonly EditorWindow _window;
         private readonly VisualElement _root;
         private readonly ScrollView _mainScrollView;
-        private bool _isApplyingContentSize;
+        private bool _hasFittedToContentOnce;
         private IVisualElementScheduledItem _resizeScheduledItem;
 
         internal ThirdPartyToolMigrationWizardWindowResizer(EditorWindow window, ScrollView mainScrollView)
@@ -34,14 +35,19 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return new Rect(centeredPosition, size);
         }
 
-        internal static Rect WithContentHeight(Rect currentRect, float contentHeight, Vector2 frameSize)
+        internal static Rect WithContentHeight(
+            Rect currentRect,
+            float contentHeight,
+            Vector2 frameSize,
+            float maxHeight)
         {
             Debug.Assert(contentHeight >= 0f, "contentHeight must not be negative");
 
             float measuredHeight = contentHeight + frameSize.y;
+            float clampedMaxHeight = Mathf.Max(maxHeight, MinimumWindowSize.y);
             Vector2 targetSize = new Vector2(
                 MinimumWindowSize.x,
-                Mathf.Max(measuredHeight, MinimumWindowSize.y));
+                Mathf.Clamp(measuredHeight, MinimumWindowSize.y, clampedMaxHeight));
             return CreateCenteredRect(currentRect, targetSize);
         }
 
@@ -50,13 +56,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return IsFinite(size.x) && IsFinite(size.y);
         }
 
-        internal void BindSizeUpdates()
-        {
-            _root.RegisterCallback<GeometryChangedEvent>(HandleGeometryChanged);
-        }
-
         internal void ScheduleResizeToContent()
         {
+            if (_hasFittedToContentOnce)
+            {
+                return;
+            }
+
             _resizeScheduledItem?.Pause();
             _resizeScheduledItem = _root.schedule.Execute(ResizeToContent).StartingIn(0);
         }
@@ -99,12 +105,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return IsFinite(height) ? Mathf.Ceil(height) : 0f;
         }
 
-        private static bool Approximately(Vector2 left, Vector2 right)
-        {
-            const float Tolerance = 0.5f;
-            return Mathf.Abs(left.x - right.x) < Tolerance && Mathf.Abs(left.y - right.y) < Tolerance;
-        }
-
         private static bool HasFiniteRect(Rect rect)
         {
             return IsFinite(rect.xMin)
@@ -116,16 +116,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private static bool IsFinite(float value)
         {
             return !float.IsNaN(value) && !float.IsInfinity(value);
-        }
-
-        private void HandleGeometryChanged(GeometryChangedEvent evt)
-        {
-            if (_isApplyingContentSize)
-            {
-                return;
-            }
-
-            ScheduleResizeToContent();
         }
 
         private void ResizeToContent()
@@ -148,24 +138,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return;
             }
 
-            Rect targetRect = WithContentHeight(_window.position, contentHeight, frameSize);
+            float maxHeight = EditorGUIUtility.GetMainWindowPosition().height * MaxHeightRatioOfMainWindow;
+            Rect targetRect = WithContentHeight(_window.position, contentHeight, frameSize, maxHeight);
             if (!HasFiniteSize(targetRect.size))
             {
                 return;
             }
 
-            if (Approximately(_window.position.size, targetRect.size))
-            {
-                _window.minSize = targetRect.size;
-                _window.maxSize = targetRect.size;
-                return;
-            }
-
-            _isApplyingContentSize = true;
-            _window.minSize = targetRect.size;
-            _window.maxSize = targetRect.size;
+            _window.minSize = MinimumWindowSize;
             _window.position = targetRect;
-            _isApplyingContentSize = false;
+            _hasFittedToContentOnce = true;
         }
     }
 }

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs
@@ -260,7 +260,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal void ShowCheckingState(ThirdPartyToolMigrationProgress progress)
         {
             _view.ShowCheckingState(progress, _isMigrating);
-            _scheduleResize();
         }
 
         internal void RefreshMigrationSkillState()
@@ -280,7 +279,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _migrationSkillTarget,
                 _migrationSkillInstallState,
                 _isUpdatingMigrationSkill);
-            _scheduleResize();
         }
 
         internal void HandleMigrationSkillTargetChanged(SkillsTarget target)

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs
@@ -246,8 +246,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             Debug.Assert(filePaths != null, "filePaths must not be null");
 
             _pendingMigrationFilePaths = filePaths;
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            _view.ShowMigrationTargetsState(filePaths, projectRoot, _isMigrating);
+            _view.ShowMigrationTargetsState(filePaths, _isMigrating);
             _scheduleResize();
         }
 


### PR DESCRIPTION
## Summary
- The Custom Tool Migration wizard window can now be resized by the user, and its content scrolls instead of forcing the window ever taller.
- The C# migration scan result no longer lists every target file's path; it now shows a brief count (e.g. "Found 12 C# files that need V3 migration.").

## User Impact
- Before: the window was locked to a fixed size, so a large migration target list (or the AI migration skill section) could push content off-screen with no way to resize or scroll to see it.
- After: the window opens sized to fit its content (capped at 90% of the main Unity window's height) and can be freely resized afterward; a scrollbar appears whenever content still exceeds the window height. The scan result is a short one-line summary instead of a long file listing, so most content no longer overflows in the first place.

## Changes
- Removed the fixed `minSize == maxSize` lock; the window is now user-resizable, with a one-time auto-fit-to-content on open (clamped to 90% of the main window height) that no longer re-triggers on manual resize.
- Auto-fit now only fires once the scan settles into a final state (targets found / no targets), not during the transient "checking" state, avoiding a race where the fit could lock onto a smaller in-progress size.
- Added `flex-grow` to the shared main-container style so the scroll view fills available height and scrolls when content overflows.
- Replaced the file-path enumeration in the migration status text with a concise count-only message; removed the now-unused path-formatting helpers.

## Verification
- `uloop compile`: 0 errors, 0 warnings.
- `uloop run-tests --filter-value ThirdPartyToolMigrationWizardWindowTests --test-mode EditMode`: 60/60 passed.
- Manually verified in a live Unity Editor session (via scripted window open + scan) that the window fits to the settled scan result (not the transient checking state), resizes freely afterward without snapping back, and shows a scrollbar when content overflows.
- Not automated: the feel of an actual OS-native mouse drag-resize was not reproduced; only the underlying size/state logic was verified.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

