### PR TITLE
fix: Show the migration wizard window immediately during auto-scan

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -1,6 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
@@ -88,67 +85,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 Object.DestroyImmediate(window);
             }
-        }
-
-        [TestCase(false, false, false)]
-        [TestCase(true, false, true)]
-        [TestCase(true, true, false)]
-        public void ShouldOpenWindowAfterAutoScan_ReturnsExpectedValue(
-            bool hasMigrationTargets,
-            bool isCancellationRequested,
-            bool expected)
-        {
-            // Verifies that auto-scan opens the migration window only when preflight finds work.
-            bool shouldOpenWindow = ThirdPartyToolMigrationWizardWindow.ShouldOpenWindowAfterAutoScan(
-                hasMigrationTargets,
-                isCancellationRequested);
-
-            Assert.That(shouldOpenWindow, Is.EqualTo(expected));
-        }
-
-        [Test]
-        public async Task RunAutoScanAsync_WhenTargetsExist_OpensWindowAndConsumesState()
-        {
-            // Verifies that a successful auto-scan opens the migration wizard and consumes the session flag.
-            bool openedWindow = false;
-            bool consumedSessionState = false;
-            System.Exception loggedException = null;
-
-            bool didOpenWindow = await ThirdPartyToolMigrationWizardWindow.RunAutoScanAsync(
-                _ => Task.FromResult(true),
-                _ => Task.CompletedTask,
-                () => openedWindow = true,
-                () => consumedSessionState = true,
-                ex => loggedException = ex,
-                CancellationToken.None);
-
-            Assert.That(didOpenWindow, Is.True);
-            Assert.That(openedWindow, Is.True);
-            Assert.That(consumedSessionState, Is.True);
-            Assert.That(loggedException, Is.Null);
-        }
-
-        [Test]
-        public async Task RunAutoScanAsync_WhenScanThrows_LogsExceptionAndConsumesState()
-        {
-            // Verifies that failed auto-scans cannot leak the session flag or crash through async void.
-            bool openedWindow = false;
-            bool consumedSessionState = false;
-            System.InvalidOperationException expectedException = new("scan failed");
-            System.Exception loggedException = null;
-
-            bool didOpenWindow = await ThirdPartyToolMigrationWizardWindow.RunAutoScanAsync(
-                _ => Task.FromException<bool>(expectedException),
-                _ => Task.CompletedTask,
-                () => openedWindow = true,
-                () => consumedSessionState = true,
-                ex => loggedException = ex,
-                CancellationToken.None);
-
-            Assert.That(didOpenWindow, Is.False);
-            Assert.That(openedWindow, Is.False);
-            Assert.That(consumedSessionState, Is.True);
-            Assert.That(loggedException, Is.SameAs(expectedException));
         }
 
         [Test]

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardText.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardText.cs
@@ -34,8 +34,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal const string MigrationConfirmDialogTitle = "Migrate C# Sources?";
         internal const string MigrationConfirmDialogOkText = "Migrate";
         internal const string MigrationConfirmDialogCancelText = "Cancel";
-        internal const string AutoScanProgressTitle = "Unity CLI Loop";
-        internal const string AutoScanProgressDescription = "Checking for V3 custom tool migration targets...";
         private const string MigrationCheckingText = "Scanning C# source files for V3 custom tool API migration...";
         private const string MigrationApplyingText = "Migrating C# source files to V3 custom tool APIs...";
         private const string MigrationButtonReadyText = "Migrate";

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 using UnityEditor;
 using UnityEngine;
@@ -61,139 +59,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal static void ShowWindowForAutoScan()
         {
-            _ = RunAutoScanWithProgressAsync(CancellationToken.None);
-        }
-
-        private static async Task RunAutoScanWithProgressAsync(CancellationToken ct)
-        {
-            int progressId = Progress.Start(
-                ThirdPartyToolMigrationWizardText.AutoScanProgressTitle,
-                ThirdPartyToolMigrationWizardText.AutoScanProgressDescription);
-            try
-            {
-                IProgress<ThirdPartyToolMigrationProgress> progress =
-                    new AutoScanMigrationProgressReporter(progressId);
-                await RunAutoScanAsync(
-                    innerCt => HasMigrationTargetsForAutoScanAsync(progress, innerCt),
-                    SwitchToMainThreadForAutoScanAsync,
-                    OpenWindowAfterAutoScan,
-                    ConsumeAutoScanSessionState,
-                    LogAutoScanException,
-                    ct);
-            }
-            finally
-            {
-                // Progress.Start/Report/Remove are all native-thread-safe, so no main-thread marshaling is needed here.
-                Progress.Remove(progressId);
-            }
-        }
-
-        internal static async Task<bool> RunAutoScanAsync(
-            Func<CancellationToken, Task<bool>> hasMigrationTargetsAsync,
-            Func<CancellationToken, Task> switchToMainThreadAsync,
-            Action openWindow,
-            Action consumeAutoScanSessionState,
-            Action<Exception> logException,
-            CancellationToken ct)
-        {
-            Debug.Assert(hasMigrationTargetsAsync != null, "hasMigrationTargetsAsync must not be null");
-            Debug.Assert(switchToMainThreadAsync != null, "switchToMainThreadAsync must not be null");
-            Debug.Assert(openWindow != null, "openWindow must not be null");
-            Debug.Assert(consumeAutoScanSessionState != null, "consumeAutoScanSessionState must not be null");
-            Debug.Assert(logException != null, "logException must not be null");
-
-            try
-            {
-                bool hasMigrationTargets = await hasMigrationTargetsAsync(ct);
-                await switchToMainThreadAsync(ct);
-                if (!ShouldOpenWindowAfterAutoScan(hasMigrationTargets, ct.IsCancellationRequested))
-                {
-                    return false;
-                }
-
-                openWindow();
-                return true;
-            }
-            catch (Exception ex)
-            {
-                logException(ex);
-                return false;
-            }
-            finally
-            {
-                consumeAutoScanSessionState();
-            }
-        }
-
-        private static async Task<bool> HasMigrationTargetsForAutoScanAsync(
-            IProgress<ThirdPartyToolMigrationProgress> progress,
-            CancellationToken ct)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            ThirdPartyToolMigrationUseCase migrationUseCase =
-                GetThirdPartyToolMigrationUseCase();
-            ThirdPartyToolMigrationPreview preview = await Task.Run(() =>
-                migrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct), ct);
-            return preview.HasTargets;
-        }
-
-        // Progress.Start/Report/Remove are declared IsThreadSafe=true in Unity's native bindings,
-        // so this reporter can relay directly from the background scan thread.
-        private sealed class AutoScanMigrationProgressReporter : IProgress<ThirdPartyToolMigrationProgress>
-        {
-            private readonly int _progressId;
-
-            internal AutoScanMigrationProgressReporter(int progressId)
-            {
-                _progressId = progressId;
-            }
-
-            public void Report(ThirdPartyToolMigrationProgress value)
-            {
-                // TotalItemCount <= 0 means "unknown total" (see ThirdPartyToolMigrationProjectFileInventory);
-                // Progress.Report's totalSteps=0 behavior is undocumented and unverifiable from managed code,
-                // so skip the items overload and leave the task showing as a plain busy indicator instead.
-                if (value.TotalItemCount <= 0)
-                {
-                    return;
-                }
-
-                Progress.Report(_progressId, value.ProcessedItemCount, value.TotalItemCount);
-            }
-        }
-
-        private static async Task SwitchToMainThreadForAutoScanAsync(CancellationToken ct)
-        {
-            if (ct.IsCancellationRequested)
-            {
-                return;
-            }
-
-            await MainThreadSwitcher.SwitchToMainThread();
-        }
-
-        private static void OpenWindowAfterAutoScan()
-        {
+            ConsumeAutoScanSessionState();
             ShowWindowInternal(true);
         }
 
         private static void ConsumeAutoScanSessionState()
         {
             GetSessionFlagsRepository().ConsumeShouldAutoScanThirdPartyToolMigration();
-        }
-
-        private static void LogAutoScanException(Exception ex)
-        {
-            Debug.Assert(ex != null, "ex must not be null");
-
-            Debug.LogException(ex);
-        }
-
-        internal static bool ShouldOpenWindowAfterAutoScan(
-            bool hasMigrationTargets,
-            bool isCancellationRequested)
-        {
-            return hasMigrationTargets && !isCancellationRequested;
         }
 
         internal static void PrepareForOpen(


### PR DESCRIPTION
## Summary
- The V2→V3 custom tool migration wizard now shows its window immediately when auto-scan triggers, instead of running silently in the background with only a status-bar progress indicator.

## User Impact
- Before: after updating to V3, the auto-scan ran in the status bar's `Progress` area, which was easy to miss and gave little sense of what was happening.
- After: the migration wizard window opens right away and shows "Scanning C# source files..." while it checks, then switches to the file count (or "Nothing to migrate") once done. If there is nothing to migrate, the window stays open with that state instead of closing automatically, so the result is not missed.

## Changes
- `ShowWindowForAutoScan()` now just consumes the auto-scan session flag and opens the window immediately; the window's own scan (with its existing fingerprint-based cache) takes over from there.
- Removed the pre-scan scaffolding that ran before the window opened (`RunAutoScanWithProgressAsync`, `RunAutoScanAsync`, the injected-delegate test harness, `AutoScanMigrationProgressReporter`, and the now-unused progress-title/description strings), along with the tests that existed only to cover that scaffolding.

## Verification
- `uloop compile`: 0 errors, 0 warnings.
- `uloop run-tests`: 2284 tests, 5 failures. All 5 are pre-existing and unrelated to this change:
  - 4 fail identically on a clean `origin/v3-beta` checkout (`CliSetupApplicationServiceTests.GetGlobalCliInstallCommand_UsesPinnedDispatcherReleaseTag`, `CliSetupApplicationServiceTests.InstallGlobalCliAsync_UsesPinnedDispatcherReleaseTag`, `FirstPartySchemaProperties_WhenLoaded_ShouldNotExposeDescriptionAttributes`, `OnionAssemblyDependencyTests.ProductionEditorStartupHooks_WhenLoaded_AreOwnedOnlyByCompositionRootBootstrap`).
  - The 5th (`MouseUiPointerTargetResolverTests.ResolvePressablePointerTargets_WithoutRaycastHit_ReturnsEmpty`) passes in isolation on both this branch and `origin/v3-beta` (10/10); it only fails inside the full suite, consistent with pre-existing test-order/isolation flakiness unrelated to files this PR touches.
- Manual verification in a running Editor (via a temporary session-flag trigger + screenshots): the window opens immediately and shows the scanning state with a progress count, then settles into the "Nothing to migrate" state without auto-closing; the auto-scan session flag is consumed exactly once; and the `Progress.Start/Report/Remove` calls are fully removed from the window's source, so no status-bar progress indicator appears.
- `ShowWindowForAutoScan()` itself is intentionally left without a new unit test: no existing test in this repo drives a real `EditorWindow.CreateGUI()` lifecycle, doing so would require re-registering production-only services in a test, and re-introducing delegate injection just for testability would undo the simplification this PR makes. Coverage instead comes from the manual verification above plus the existing session-flag consume-once test (`UnityCliLoopEditorSessionStateRepositoryTests.ConsumeShouldAutoScanThirdPartyToolMigration_WhenFlagIsSet_ReturnsTrueOnce`), which is unchanged.

**Do not merge this PR.** It should stay open pending manual verification against a real V2→V3 project by the requester before merging.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

