### PR TITLE
fix: Custom-tool migration removes a Success property that hides the base response's Success

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationDomainRewriteCharacterizationTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationDomainRewriteCharacterizationTests.cs
@@ -147,5 +147,102 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 migrated,
                 Does.Contain($"{ThirdPartyToolMigrationRuleCatalog.CurrentNamespace}.UnityCliLoopToolRegistrar"));
         }
+
+        [Test]
+        public void RemoveSuccessPropertyHidingDeclarationsInCode_WhenAlreadyMigratedFileHasHidingAutoProperty_RemovesDeclarationAndKeepsConstructorAssignment()
+        {
+            // Pins removal of a real-world-shaped Success auto-property (attributes + XML doc + get-only) on a file already on UnityCliLoopToolResponse.
+            string source =
+                "using Newtonsoft.Json;\n" +
+                "using io.github.hatayama.UnityCliLoop.ToolContracts;\n" +
+                "\n" +
+                "public sealed class SampleResponse : UnityCliLoopToolResponse\n" +
+                "{\n" +
+                "    /// <summary>\n" +
+                "    /// Whether the operation succeeded.\n" +
+                "    /// </summary>\n" +
+                "    [JsonProperty(\"success\")]\n" +
+                "    public bool Success { get; }\n" +
+                "\n" +
+                "    public SampleResponse(bool success)\n" +
+                "    {\n" +
+                "        Success = success;\n" +
+                "    }\n" +
+                "}\n";
+
+            (string content, int replacementCount) =
+                ThirdPartyToolMigrationSuccessPropertyRules.RemoveSuccessPropertyHidingDeclarationsInCode(source);
+
+            Assert.That(replacementCount, Is.GreaterThan(0));
+            Assert.That(content, Does.Not.Contain("public bool Success { get; }"));
+            Assert.That(content, Does.Not.Contain("[JsonProperty(\"success\")]"));
+            Assert.That(content, Does.Not.Contain("Whether the operation succeeded."));
+            Assert.That(content, Does.Contain("Success = success;"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenV2ResponseHasHidingSuccessProperty_ReplacesBaseTypeAndRemovesSuccessDeclaration()
+        {
+            // Pins the full orchestration: BaseToolResponse rename and hiding Success removal happen together for V2 sources.
+            string source =
+                "using io.github.hatayama.uLoopMCP;\n" +
+                "\n" +
+                "public sealed class LegacyResponse : BaseToolResponse\n" +
+                "{\n" +
+                "    public bool Success { get; set; }\n" +
+                "}\n";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationCSharpRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Content, Does.Contain("UnityCliLoopToolResponse"));
+            Assert.That(result.Content, Does.Not.Contain("BaseToolResponse"));
+            Assert.That(result.Content, Does.Not.Contain("public bool Success"));
+            Assert.That(result.ReplacementCount, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void RemoveSuccessPropertyHidingDeclarationsInCode_WhenSuccessGetterHasLogic_DoesNotRewriteButIsDetectable()
+        {
+            // why: a getter with logic cannot be safely auto-rewritten; it must stay untouched but remain detectable so it can be surfaced.
+            string source =
+                "using io.github.hatayama.UnityCliLoop.ToolContracts;\n" +
+                "\n" +
+                "public sealed class CustomLogicResponse : UnityCliLoopToolResponse\n" +
+                "{\n" +
+                "    private readonly bool _succeeded;\n" +
+                "\n" +
+                "    public bool Success { get { return _succeeded && true; } }\n" +
+                "}\n";
+
+            (string content, int replacementCount) =
+                ThirdPartyToolMigrationSuccessPropertyRules.RemoveSuccessPropertyHidingDeclarationsInCode(source);
+            bool isDetectableAsNonAutoHiding =
+                ThirdPartyToolMigrationSuccessPropertyRules.ContainsNonAutoPropertySuccessHidingUnityCliLoopToolResponse(
+                    source);
+
+            Assert.That(replacementCount, Is.EqualTo(0));
+            Assert.That(content, Is.EqualTo(source));
+            Assert.That(isDetectableAsNonAutoHiding, Is.True);
+        }
+
+        [Test]
+        public void ContainsSuccessPropertyHidingUnityCliLoopToolResponse_WhenAlreadyMigratedFileOnlyHasSuccessHiding_ReturnsTrue()
+        {
+            // Pins detection extension: a file with no remaining legacy API but a hiding Success auto-property is still a migration target.
+            string source =
+                "using io.github.hatayama.UnityCliLoop.ToolContracts;\n" +
+                "\n" +
+                "public sealed class AlreadyMigratedResponse : UnityCliLoopToolResponse\n" +
+                "{\n" +
+                "    public bool Success { get; }\n" +
+                "}\n";
+
+            bool containsTarget =
+                ThirdPartyToolMigrationSuccessPropertyRules.ContainsSuccessPropertyHidingUnityCliLoopToolResponse(
+                    source);
+
+            Assert.That(containsTarget, Is.True);
+        }
     }
 }

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationDomainRewriteCharacterizationTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationDomainRewriteCharacterizationTests.cs
@@ -227,6 +227,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void RemoveSuccessPropertyHidingDeclarationsInCode_WhenSuccessIsExpressionBodied_DoesNotRewriteButIsDetectable()
+        {
+            // why: an expression-bodied property ("=> _ok;") is a common C# shape that must never be silently skipped.
+            string source =
+                "using io.github.hatayama.UnityCliLoop.ToolContracts;\n" +
+                "\n" +
+                "public sealed class ExpressionBodiedResponse : UnityCliLoopToolResponse\n" +
+                "{\n" +
+                "    private readonly bool _ok;\n" +
+                "\n" +
+                "    public bool Success => _ok;\n" +
+                "}\n";
+
+            (string content, int replacementCount) =
+                ThirdPartyToolMigrationSuccessPropertyRules.RemoveSuccessPropertyHidingDeclarationsInCode(source);
+            bool isDetectableAsNonAutoHiding =
+                ThirdPartyToolMigrationSuccessPropertyRules.ContainsNonAutoPropertySuccessHidingUnityCliLoopToolResponse(
+                    source);
+
+            Assert.That(replacementCount, Is.EqualTo(0));
+            Assert.That(content, Is.EqualTo(source));
+            Assert.That(isDetectableAsNonAutoHiding, Is.True);
+        }
+
+        [Test]
         public void ContainsSuccessPropertyHidingUnityCliLoopToolResponse_WhenAlreadyMigratedFileOnlyHasSuccessHiding_ReturnsTrue()
         {
             // Pins detection extension: a file with no remaining legacy API but a hiding Success auto-property is still a migration target.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -3648,6 +3648,95 @@ public sealed class HelloResponse : UnityCliLoopToolResponse
         }
 
         [Test]
+        public async Task HasMigrationTargetsAsync_WhenAlreadyMigratedResponseOnlyHasSuccessHiding_ReturnsTrue()
+        {
+            // Verifies that a fully-migrated V3 file with no remaining legacy API, but a hiding Success
+            // auto-property, is still detected as a migration target.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "CurrentHelloTool.cs"),
+                    @"using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+[UnityCliLoopTool]
+public sealed class CurrentHelloTool : UnityCliLoopTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : UnityCliLoopToolSchema
+{
+}
+
+public sealed class HelloResponse : UnityCliLoopToolResponse
+{
+    public bool Success { get; }
+}");
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "VendorTools.Editor.asmdef"),
+                    @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:fc3fd32eddbee40e39c2d76dc184957b""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+
+                bool hasTargets = await service.HasMigrationTargetsAsync(projectRoot, CancellationToken.None);
+
+                Assert.That(hasTargets, Is.True);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ApplyMigration_WhenAlreadyMigratedResponseOnlyHasSuccessHiding_RemovesHidingDeclaration()
+        {
+            // Verifies that apply-migration removes an already-migrated file's own Success property from disk.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "CurrentHelloTool.cs");
+                File.WriteAllText(
+                    toolPath,
+                    @"using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+[UnityCliLoopTool]
+public sealed class CurrentHelloTool : UnityCliLoopTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : UnityCliLoopToolSchema
+{
+}
+
+public sealed class HelloResponse : UnityCliLoopToolResponse
+{
+    public bool Success { get; }
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+                string migratedSource = File.ReadAllText(toolPath);
+
+                Assert.That(result.FilePaths.Contains(toolPath), Is.True);
+                Assert.That(migratedSource, Does.Not.Contain("public bool Success"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public async Task HasMigrationTargetsAsync_WhenLegacyGlobalUsingAndBareToolAttributeAreSplit_ReturnsTrue()
         {
             // Verifies that startup detection treats legacy global usings as assembly-scoped.

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationCSharpLegacyAssemblyMigrationContext.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationCSharpLegacyAssemblyMigrationContext.cs
@@ -33,6 +33,7 @@ using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationScree
 using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationScreenshotDeconstructionRules;
 using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationScreenshotDetectionRules;
 using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationScreenshotRules;
+using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationSuccessPropertyRules;
 using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationTimingArgumentRules;
 using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationTimingCallerRules;
 using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationTimingCleanupRules;
@@ -307,6 +308,13 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 _assemblyDeclaredTypeNames,
                 ref _replacementCount);
             ApplyCSharpReplacementRules();
+        }
+
+        public void ApplySuccessPropertyHidingRemoval()
+        {
+            (string migratedContent, int replacementCount) =
+                RemoveSuccessPropertyHidingDeclarationsInCode(_migratedContent);
+            ApplyReplacementResult(migratedContent, replacementCount);
         }
 
         public void ApplyRegistrarRenames()

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationCSharpRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationCSharpRules.cs
@@ -117,6 +117,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             migrationContext.ApplyMainThreadSwitcherReplacements();
             migrationContext.ApplyEditorWindowCaptureAndTypeReplacements();
             migrationContext.ApplyContractRenames();
+            migrationContext.ApplySuccessPropertyHidingRemoval();
             migrationContext.ApplyRegistrarRenames();
             migrationContext.ApplyCurrentPublicContractNamespaceReplacements();
             return migrationContext.CreateResult();

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationSuccessPropertyRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationSuccessPropertyRules.cs
@@ -32,8 +32,10 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             @"public\s+bool\s+Success\s*\{\s*get;\s*(?:set;\s*)?\}\s*(?:=\s*[^;]+;)?\s*(?:\r?\n)?",
             RegexOptions.Compiled);
 
+        // Matches both a block-bodied property start ("{ ... }") and an expression-bodied one ("=> ...;");
+        // either shape can hide the base member and must be surfaced even when it cannot be auto-removed.
         private static readonly Regex SuccessPropertyStartRegex = new(
-            @"public\s+bool\s+Success\s*\{",
+            @"public\s+bool\s+Success\s*(?:\{|=>)",
             RegexOptions.Compiled);
 
         public static bool ContainsSuccessPropertyHidingUnityCliLoopToolResponse(string source)

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationSuccessPropertyRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationSuccessPropertyRules.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using CodeTextMask = io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationParsingRules.CodeTextMask;
+
+using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationParsingRules;
+using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationTimingCleanupRules;
+using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationTimingMethodBodyRules;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Detects and removes a derived class's own Success declaration when it hides UnityCliLoopToolResponse.Success.
+    /// </summary>
+    public static class ThirdPartyToolMigrationSuccessPropertyRules
+    {
+        private const string CurrentHidingEligibleBaseTypeName = "UnityCliLoopToolResponse";
+        private const string LegacyHidingEligibleBaseTypeName = "BaseToolResponse";
+
+        private static readonly Regex ClassBaseListRegex = new(
+            @"\bclass\s+[A-Za-z_][A-Za-z0-9_]*\s*(?:<[^>{]*>)?\s*:\s*(?<baseList>[^{]+)\{",
+            RegexOptions.Compiled);
+
+        private static readonly Regex HidingEligibleBaseListRegex = new(
+            $@"\b(?:{LegacyHidingEligibleBaseTypeName}|{CurrentHidingEligibleBaseTypeName})\b",
+            RegexOptions.Compiled);
+
+        // Matches only the auto-property shape; a getter with logic (e.g. "{ get { ... } }") never matches.
+        private static readonly Regex SuccessAutoPropertyRegex = new(
+            @"public\s+bool\s+Success\s*\{\s*get;\s*(?:set;\s*)?\}\s*(?:=\s*[^;]+;)?\s*(?:\r?\n)?",
+            RegexOptions.Compiled);
+
+        private static readonly Regex SuccessPropertyStartRegex = new(
+            @"public\s+bool\s+Success\s*\{",
+            RegexOptions.Compiled);
+
+        public static bool ContainsSuccessPropertyHidingUnityCliLoopToolResponse(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            if (!ContainsTextFragment(source, "Success"))
+            {
+                return false;
+            }
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            return FindEligibleClassAutoPropertyMatch(source, codeTextMask) != null;
+        }
+
+        public static bool ContainsNonAutoPropertySuccessHidingUnityCliLoopToolResponse(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            if (!ContainsTextFragment(source, "Success"))
+            {
+                return false;
+            }
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            foreach (Match classMatch in ClassBaseListRegex.Matches(source))
+            {
+                (bool isEligible, int openBraceIndex, int closeBraceIndex) =
+                    ReadEligibleClassBodyRange(source, codeTextMask, classMatch);
+                if (!isEligible)
+                {
+                    continue;
+                }
+
+                int rangeLength = closeBraceIndex - openBraceIndex;
+                Match autoPropertyMatch = SuccessAutoPropertyRegex.Match(source, openBraceIndex, rangeLength);
+                if (autoPropertyMatch.Success && codeTextMask.IsCodeAt(autoPropertyMatch.Index))
+                {
+                    continue;
+                }
+
+                Match successStartMatch = SuccessPropertyStartRegex.Match(source, openBraceIndex, rangeLength);
+                if (successStartMatch.Success && codeTextMask.IsCodeAt(successStartMatch.Index))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static (string Content, int ReplacementCount) RemoveSuccessPropertyHidingDeclarationsInCode(
+            string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            if (!ContainsTextFragment(source, "Success"))
+            {
+                return (source, 0);
+            }
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            StringBuilder builder = new(source.Length);
+            int sourceCopyIndex = 0;
+            int replacementCount = 0;
+
+            foreach (Match classMatch in ClassBaseListRegex.Matches(source))
+            {
+                (bool isEligible, int openBraceIndex, int closeBraceIndex) =
+                    ReadEligibleClassBodyRange(source, codeTextMask, classMatch);
+                if (!isEligible)
+                {
+                    continue;
+                }
+
+                Match propertyMatch = SuccessAutoPropertyRegex.Match(
+                    source,
+                    openBraceIndex,
+                    closeBraceIndex - openBraceIndex);
+                if (!propertyMatch.Success ||
+                    !codeTextMask.IsCodeAt(propertyMatch.Index) ||
+                    propertyMatch.Index < sourceCopyIndex)
+                {
+                    continue;
+                }
+
+                int removalStartIndex = ExtendRemovalStartOverDocComments(
+                    source,
+                    ReadLegacyPlayerLoopTimingDeclarationRemovalStart(source, propertyMatch.Index, codeTextMask));
+                if (removalStartIndex < sourceCopyIndex)
+                {
+                    continue;
+                }
+
+                builder.Append(source, sourceCopyIndex, removalStartIndex - sourceCopyIndex);
+                sourceCopyIndex = propertyMatch.Index + propertyMatch.Length;
+                replacementCount++;
+            }
+
+            if (replacementCount == 0)
+            {
+                return (source, 0);
+            }
+
+            builder.Append(source, sourceCopyIndex, source.Length - sourceCopyIndex);
+            return (builder.ToString(), replacementCount);
+        }
+
+        private static Match FindEligibleClassAutoPropertyMatch(string source, CodeTextMask codeTextMask)
+        {
+            foreach (Match classMatch in ClassBaseListRegex.Matches(source))
+            {
+                (bool isEligible, int openBraceIndex, int closeBraceIndex) =
+                    ReadEligibleClassBodyRange(source, codeTextMask, classMatch);
+                if (!isEligible)
+                {
+                    continue;
+                }
+
+                Match propertyMatch = SuccessAutoPropertyRegex.Match(
+                    source,
+                    openBraceIndex,
+                    closeBraceIndex - openBraceIndex);
+                if (propertyMatch.Success && codeTextMask.IsCodeAt(propertyMatch.Index))
+                {
+                    return propertyMatch;
+                }
+            }
+
+            return null;
+        }
+
+        private static (bool IsEligible, int OpenBraceIndex, int CloseBraceIndex) ReadEligibleClassBodyRange(
+            string source,
+            CodeTextMask codeTextMask,
+            Match classMatch)
+        {
+            if (!codeTextMask.IsCodeAt(classMatch.Index) ||
+                !HidingEligibleBaseListRegex.IsMatch(classMatch.Groups["baseList"].Value))
+            {
+                return (false, -1, -1);
+            }
+
+            int openBraceIndex = classMatch.Index + classMatch.Length - 1;
+            int closeBraceIndex = FindBlockClosingBraceIndex(source, codeTextMask, openBraceIndex);
+            return closeBraceIndex < 0 ? (false, -1, -1) : (true, openBraceIndex, closeBraceIndex);
+        }
+
+        // Extends a removal start index over immediately preceding "///" XML doc comment lines,
+        // so a property's doc comment is deleted along with the property it documents.
+        private static int ExtendRemovalStartOverDocComments(string source, int removalStartIndex)
+        {
+            int index = removalStartIndex;
+            while (index > 0)
+            {
+                int lineTerminatorIndex = index - 1;
+                int searchFromIndex = lineTerminatorIndex - 1;
+                int previousNewLineIndex = searchFromIndex < 0 ? -1 : source.LastIndexOf('\n', searchFromIndex);
+                int previousLineStartIndex = previousNewLineIndex < 0 ? 0 : previousNewLineIndex + 1;
+                string previousLine = source.Substring(
+                    previousLineStartIndex,
+                    lineTerminatorIndex - previousLineStartIndex + 1);
+                if (!previousLine.TrimStart().StartsWith("///", StringComparison.Ordinal))
+                {
+                    return index;
+                }
+
+                index = previousLineStartIndex;
+            }
+
+            return index;
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationSuccessPropertyRules.cs.meta
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationSuccessPropertyRules.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c3daafec6da4492cbb218b89ed879d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFastSourceTargetDetector.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFastSourceTargetDetector.cs
@@ -20,8 +20,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(source != null, "source must not be null");
 
-            return ThirdPartyToolMigrationRules.ContainsLegacyMigrationCandidateText(source) &&
-                ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source);
+            return (ThirdPartyToolMigrationRules.ContainsLegacyMigrationCandidateText(source) &&
+                ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source)) ||
+                ThirdPartyToolMigrationRules.ContainsSuccessPropertyHidingUnityCliLoopToolResponse(source);
         }
 
         internal static async Task<bool> ContainsFastCSharpSourceMigrationTargetAsync(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationPlanBuilder.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationPlanBuilder.cs
@@ -187,6 +187,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return null;
             }
 
+            if (ThirdPartyToolMigrationRules.ContainsNonAutoPropertySuccessHidingUnityCliLoopToolResponse(source))
+            {
+                // why: a getter with logic can't be auto-rewritten safely, so surface it instead of migrating silently.
+                UnityEngine.Debug.LogWarning(
+                    $"[UnityCliLoop] {csharpFilePath} declares its own non-auto-property Success member that " +
+                    "hides UnityCliLoopToolResponse.Success. Migration cannot rewrite it automatically; " +
+                    "resolve the member-hiding manually.");
+            }
+
             string assemblyDirectory = FindNearestAssemblyDirectory(
                 csharpFilePath,
                 assemblyUsage.AsmdefDirectories,

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -242,6 +242,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return ThirdPartyToolMigrationSourceDetectionRules.ContainsLegacyAssemblyScopedApi(source, legacyAssemblyAliases);
         }
 
+        internal static bool ContainsSuccessPropertyHidingUnityCliLoopToolResponse(string source)
+        {
+            return ThirdPartyToolMigrationSuccessPropertyRules.ContainsSuccessPropertyHidingUnityCliLoopToolResponse(source);
+        }
+
+        internal static bool ContainsNonAutoPropertySuccessHidingUnityCliLoopToolResponse(string source)
+        {
+            return ThirdPartyToolMigrationSuccessPropertyRules.ContainsNonAutoPropertySuccessHidingUnityCliLoopToolResponse(source);
+        }
+
         internal static bool ContainsLegacyGlobalUsing(string source)
         {
             return ThirdPartyToolMigrationSourceDetectionRules.ContainsLegacyGlobalUsing(source);


### PR DESCRIPTION
## Summary
- The V2→V3 custom-tool migration now removes a derived tool's own `Success` property declaration when it hides `UnityCliLoopToolResponse.Success` — including for tools that were already fully migrated to V3 but still carry this leftover declaration.
- A getter with actual logic (not a plain auto-property) is left untouched and instead surfaced with a Console warning, since it cannot be safely rewritten automatically.

## User Impact
- Before: a migrated custom tool response class that redeclared `public bool Success { get; set; }` compiled with a `CS0108` member-hiding warning and risked breaking Newtonsoft.Json serialization of the `Success` field, and files that had no other legacy API left were not even recognized as migration targets for this issue.
- After: migration detects and removes the redundant `Success` declaration (including its attributes and XML doc comment) whether or not any other legacy API remains in the file, so the response class cleanly inherits `Success` from the base type. Non-auto-property `Success` declarations are never silently rewritten; a warning is logged so the user can resolve them manually.

## Changes
- Added `ThirdPartyToolMigrationSuccessPropertyRules` (Domain layer): detects and removes a class's own `Success` auto-property when its base type is `UnityCliLoopToolResponse` (or the legacy `BaseToolResponse`), and separately detects non-auto-property `Success` declarations that hide the base member without rewriting them.
- Wired the new rule into `ThirdPartyToolMigrationCSharpLegacyAssemblyMigrationContext`/`ThirdPartyToolMigrationCSharpRules` so the removal runs unconditionally, independent of whether the file's assembly is otherwise flagged as needing legacy migration.
- Extended `ThirdPartyToolMigrationFastSourceTargetDetector.ContainsFastCSharpMigrationTarget` so an already-fully-migrated V3 file with only a hiding `Success` declaration is still recognized as a migration target.
- `ThirdPartyToolMigrationPlanBuilder` now logs a Console warning when a file has a non-auto-property `Success` declaration that hides the base member, instead of migrating it silently or leaving it unmentioned.

## Schema base-class collision inventory
- `UnityCliLoopToolSchema` (the schema base class) declares zero members, so no member-hiding collision is possible there.
- `UnityCliLoopToolResponse` declares exactly one member, `Success` — the collision this PR fixes.
- Checked every class deriving from `UnityCliLoopToolResponse` across `Packages/src` and `Assets` (first-party tools, Infrastructure API responses, custom-command samples): none redeclare `Success` or any other base member.
- Same-named-but-unrelated `Success` properties exist on internal result DTOs (e.g. `ServiceResult<T>`, `ExecutionResult`, `CompilationResult`) that do not derive from `UnityCliLoopToolResponse` — explicitly ruled out as not being hiding collisions.
- Conclusion: `Success` was the only base-class member collision; no further schema/response base-class collisions exist.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo root>` — 0 errors, 0 warnings.
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "ThirdPartyToolMigration"` — 436 tests, 432 passed, 4 skipped (Windows-only), 0 failed.
- New characterization tests cover: removal of a hiding auto-property (with attributes + XML doc) while preserving constructor assignment; full V2→V3 pipeline rewriting the base type and removing the hiding declaration together; a logic-getter `Success` staying untouched but detectable; and detection on an already-fully-migrated file with no other legacy API remaining.
- New integration tests in `ThirdPartyToolMigrationFileServiceTests` confirm `HasMigrationTargetsAsync` and `ApplyMigration` both handle the already-migrated-file-only-has-Success-hiding scenario end to end.

**Note:** this PR is intentionally left unmerged — the requester will merge only after manually verifying the migration fix against a real production V2→V3 project.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


