### PR TITLE
feat: Log physics dispatch diagnostics on any zero-hit clear

### DIFF
--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -744,6 +744,72 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task Clear_WhenPhysicsFlaggedMarkerClearedWhileEnabled_EmitsClearedWithoutHitPhysicsDiagnostics()
+        {
+            // Verifies a physics-flagged marker cleared with HitCount==0 while still Enabled
+            // (the CLI await timeout expiring before the marker's own longer expiry, the actual
+            // 2026-07-22 Block.cs:29 field incident) still emits the physics dispatch diagnostics,
+            // not just the Expired case.
+            PausePointResponse enableResponse = await EnablePausePointByFileLineAsync(PhysicsFixtureFilePath, PhysicsFixtureLine);
+            Assert.That(enableResponse.Success, Is.True);
+            VibeLogger.ClearMemoryLogs();
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["id"] = enableResponse.Id };
+            await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            string logs = VibeLogger.GetLogsForAi("pause_point_cleared_without_hit_physics");
+            Assert.That(logs, Does.Contain("pause_point_cleared_without_hit_physics"));
+            Assert.That(logs, Does.Contain($"\"Id\": \"{enableResponse.Id}\""));
+            Assert.That(logs, Does.Contain("\"StatusBeforeClear\": \"Enabled\""));
+        }
+
+        [Test]
+        public async Task Clear_WhenPhysicsFlaggedMarkerExpiredWithoutHit_EmitsClearedWithoutHitPhysicsDiagnostics()
+        {
+            // Verifies the pre-existing expired-without-hit case still fires diagnostics under the
+            // unified operation name, with StatusBeforeClear reporting Expired.
+            EnablePausePointTool enableTool = new();
+            JObject enableParameters = new()
+            {
+                ["file"] = PhysicsFixtureFilePath,
+                ["line"] = PhysicsFixtureLine,
+                ["timeoutSeconds"] = 1
+            };
+            PausePointResponse enableResponse = (PausePointResponse)await enableTool.ExecuteAsync(enableParameters, CancellationToken.None);
+            Assert.That(enableResponse.Success, Is.True);
+            _nowUtc = _nowUtc.AddSeconds(2);
+            VibeLogger.ClearMemoryLogs();
+
+            ClearPausePointTool clearTool = new();
+            JObject clearParameters = new() { ["id"] = enableResponse.Id };
+            await clearTool.ExecuteAsync(clearParameters, CancellationToken.None);
+
+            string logs = VibeLogger.GetLogsForAi("pause_point_cleared_without_hit_physics");
+            Assert.That(logs, Does.Contain("pause_point_cleared_without_hit_physics"));
+            Assert.That(logs, Does.Contain($"\"Id\": \"{enableResponse.Id}\""));
+            Assert.That(logs, Does.Contain("\"StatusBeforeClear\": \"Expired\""));
+        }
+
+        [Test]
+        public async Task ClearAll_WhenPhysicsFlaggedMarkerEnabledWithoutHit_EmitsClearedWithoutHitPhysicsDiagnostics()
+        {
+            // Verifies the --all clear path also broadens the diagnostics condition beyond Expired.
+            PausePointResponse enableResponse = await EnablePausePointByFileLineAsync(PhysicsFixtureFilePath, PhysicsFixtureLine);
+            Assert.That(enableResponse.Success, Is.True);
+            VibeLogger.ClearMemoryLogs();
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["all"] = true };
+            await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            string logs = VibeLogger.GetLogsForAi("pause_point_cleared_without_hit_physics");
+            Assert.That(logs, Does.Contain("pause_point_cleared_without_hit_physics"));
+            Assert.That(logs, Does.Contain($"\"Id\": \"{enableResponse.Id}\""));
+            Assert.That(logs, Does.Contain("\"StatusBeforeClear\": \"Enabled\""));
+        }
+
+        [Test]
         public void PausePointStatusBridge_WhenMarkerExpired_ReturnsRecoveryAction()
         {
             // Verifies pause-point-status exposes enough data to re-arm an expired marker without guesswork.
@@ -1291,6 +1357,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private const string FixtureFilePath = "Assets/Tests/Editor/PausePointToolsFixture.cs";
         private const int FixtureLine = 12;
+        private const string PhysicsFixtureFilePath = "Assets/Tests/Editor/PausePointToolsPhysicsFixture.cs";
+        private const int PhysicsFixtureLine = 11;
 
         private static SourcePausePointResolution WithStaleMvid(SourcePausePointResolution resolution)
         {

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -810,6 +810,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task ClearAll_WhenPhysicsFlaggedMarkerAlreadyClearedViaStatusBridge_DoesNotLogStaleDiagnostics()
+        {
+            // Verifies ClearAll does not re-log physics diagnostics for a marker that was already
+            // cleared through PausePointStatusBridgeCommand.Clear (the CLI's own polling clear
+            // path). That path clears the registry entry directly without going through
+            // PausePointUseCase, so it cannot remove the id from PhysicsFlaggedDeclaringTypesById;
+            // a later clear --all must not treat the resulting Cleared-status leftover entry as a
+            // fresh zero-hit miss.
+            PausePointResponse enableResponse = await EnablePausePointByFileLineAsync(PhysicsFixtureFilePath, PhysicsFixtureLine);
+            Assert.That(enableResponse.Success, Is.True);
+
+            JObject bridgeParameters = new() { ["Id"] = enableResponse.Id };
+            PausePointStatusBridgeCommand.Clear(bridgeParameters);
+            VibeLogger.ClearMemoryLogs();
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["all"] = true };
+            await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            string logs = VibeLogger.GetLogsForAi("pause_point_cleared_without_hit_physics");
+            Assert.That(logs, Does.Not.Contain("pause_point_cleared_without_hit_physics"));
+        }
+
+        [Test]
         public void PausePointStatusBridge_WhenMarkerExpired_ReturnsRecoveryAction()
         {
             // Verifies pause-point-status exposes enough data to re-arm an expired marker without guesswork.

--- a/Assets/Tests/Editor/PausePointToolsPhysicsFixture.cs
+++ b/Assets/Tests/Editor/PausePointToolsPhysicsFixture.cs
@@ -6,9 +6,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PausePointToolsFixtures
 {
     internal sealed class EnableBySourceLocationPhysicsFixture : MonoBehaviour
     {
+        public int HitCount;
+
         private void OnCollisionEnter2D(Collision2D collision)
         {
-            int unused = 1;
+            HitCount++;
         }
     }
 }

--- a/Assets/Tests/Editor/PausePointToolsPhysicsFixture.cs
+++ b/Assets/Tests/Editor/PausePointToolsPhysicsFixture.cs
@@ -1,0 +1,14 @@
+// FROZEN FIXTURE: content and line numbers are asserted by PausePointTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.PausePointToolsFixtures
+{
+    internal sealed class EnableBySourceLocationPhysicsFixture : MonoBehaviour
+    {
+        private void OnCollisionEnter2D(Collision2D collision)
+        {
+            int unused = 1;
+        }
+    }
+}

--- a/Assets/Tests/Editor/PausePointToolsPhysicsFixture.cs.meta
+++ b/Assets/Tests/Editor/PausePointToolsPhysicsFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7b9d5b120a4f4bb8bfb317cd16ac243
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -323,10 +323,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // regardless of whether it had already expired or was still Enabled. This is
                 // the dominant field path (await timeout -> agent cleans up with --all), so
                 // skipping it here would lose the primary evidence in the common case.
+                //
+                // The Status check (not just HitCount==0) matters because
+                // PausePointStatusBridgeCommand.Clear (the CLI's own polling clear path) clears a
+                // marker via the registry directly without going through this use case, so it
+                // never removes the id from PhysicsFlaggedDeclaringTypesById. A later clear --all
+                // would otherwise re-log stale diagnostics for an id that was already Cleared
+                // through that other path.
                 foreach (KeyValuePair<string, Type> tracked in PhysicsFlaggedDeclaringTypesById)
                 {
                     UloopPausePointSnapshot trackedSnapshot = UloopPausePointRegistry.GetStatus(tracked.Key);
-                    if (trackedSnapshot.HitCount == 0)
+                    bool wasStillArmed = trackedSnapshot.Status == UloopPausePointStatus.Enabled ||
+                                         trackedSnapshot.Status == UloopPausePointStatus.Expired;
+                    if (trackedSnapshot.HitCount == 0 && wasStillArmed)
                     {
                         LogPhysicsDispatchDiagnostics(
                             "pause_point_cleared_without_hit_physics", tracked.Key, tracked.Value, trackedSnapshot.Status);

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -319,15 +319,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (parameters.All)
             {
                 // Snapshot each physics-flagged marker before ClearAll resolves it away, so a
-                // marker that expired without a hit still gets its diagnostics logged. This is
+                // marker cleared without ever being hit still gets its diagnostics logged
+                // regardless of whether it had already expired or was still Enabled. This is
                 // the dominant field path (await timeout -> agent cleans up with --all), so
                 // skipping it here would lose the primary evidence in the common case.
                 foreach (KeyValuePair<string, Type> tracked in PhysicsFlaggedDeclaringTypesById)
                 {
                     UloopPausePointSnapshot trackedSnapshot = UloopPausePointRegistry.GetStatus(tracked.Key);
-                    if (trackedSnapshot.Status == UloopPausePointStatus.Expired && trackedSnapshot.HitCount == 0)
+                    if (trackedSnapshot.HitCount == 0)
                     {
-                        LogPhysicsDispatchDiagnostics("pause_point_expired_without_hit_physics", tracked.Key, tracked.Value);
+                        LogPhysicsDispatchDiagnostics(
+                            "pause_point_cleared_without_hit_physics", tracked.Key, tracked.Value, trackedSnapshot.Status);
                     }
                 }
 
@@ -351,10 +353,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (snapshot.StatusBeforeClear == UloopPausePointStatus.Expired)
             {
                 LogExpired(snapshot.Id, snapshot.ElapsedSinceEnabledMilliseconds);
-                if (snapshot.HitCount == 0 && PhysicsFlaggedDeclaringTypesById.TryGetValue(snapshot.Id, out Type declaringType))
-                {
-                    LogPhysicsDispatchDiagnostics("pause_point_expired_without_hit_physics", snapshot.Id, declaringType);
-                }
+            }
+
+            // Fires for any zero-hit clear of a physics-flagged marker, not just an expired one:
+            // the field incident that motivated this diagnostic (Block.cs:29, 2026-07-22) cleared
+            // while still Enabled because the CLI's await timeout is shorter than the marker's own
+            // expiry, so StatusBeforeClear was Enabled rather than Expired.
+            if (snapshot.HitCount == 0 && PhysicsFlaggedDeclaringTypesById.TryGetValue(snapshot.Id, out Type declaringType))
+            {
+                LogPhysicsDispatchDiagnostics(
+                    "pause_point_cleared_without_hit_physics", snapshot.Id, declaringType, snapshot.StatusBeforeClear);
             }
             PhysicsFlaggedDeclaringTypesById.Remove(snapshot.Id);
 
@@ -432,7 +440,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (patchResult.HasPhysicsCallbackWarning)
             {
                 PhysicsFlaggedDeclaringTypesById[id] = patchResult.DeclaringType;
-                LogPhysicsDispatchDiagnostics("pause_point_physics_dispatch_diagnostics", id, patchResult.DeclaringType);
+                LogPhysicsDispatchDiagnostics(
+                    "pause_point_physics_dispatch_diagnostics", id, patchResult.DeclaringType, statusBeforeClear: string.Empty);
             }
 
             return response;
@@ -450,8 +459,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // whether Play Mode is running, how long the current domain has been alive without a
         // reload (a suspected factor -- see docs/regression-harness.md), the declaring type, and
         // (for MonoBehaviour-derived types only) how many instances currently exist in the loaded
-        // scenes.
-        private static void LogPhysicsDispatchDiagnostics(string operation, string id, Type declaringType)
+        // scenes. statusBeforeClear is empty at enable time (no clear has happened yet) and
+        // Enabled/Expired at clear time.
+        private static void LogPhysicsDispatchDiagnostics(string operation, string id, Type declaringType, string statusBeforeClear)
         {
             // Only reachable via PhysicsFlaggedDeclaringTypesById, which is populated solely from
             // a successful patch's method.DeclaringType -- a C#-sourced method always has one.
@@ -481,7 +491,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     IsPaused = EditorApplication.isPaused,
                     SecondsSinceLastDomainReload = PausePointDomainReloadTracker.SecondsSinceLoad(),
                     DeclaringType = declaringType.FullName,
-                    InstanceCount = instanceCount
+                    InstanceCount = instanceCount,
+                    StatusBeforeClear = statusBeforeClear
                 });
         }
 

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -66,7 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         // Why: PausePointTools.LogExpired duplicates this instead of sharing it, since this
         // bridge must not reference that Editor-only tool assembly. Keep both in sync if the
         // log shape or wording changes. The physics-callback dispatch diagnostics
-        // (pause_point_physics_dispatch_diagnostics / pause_point_expired_without_hit_physics)
+        // (pause_point_physics_dispatch_diagnostics / pause_point_cleared_without_hit_physics)
         // are NOT duplicated here -- they are tool-side only, since this bridge has no access to
         // the declaring-type/patch state PausePointUseCase tracks for that purpose.
         private static void LogExpired(string id, long elapsedSinceEnabledMilliseconds)

--- a/docs/regression-harness.md
+++ b/docs/regression-harness.md
@@ -54,7 +54,7 @@ real projects), but no deterministic reproduction recipe is known, and no lighte
 destroying and recreating the GameObject (or a manual `UloopPausePoint.Pause` marker) has been
 validated -- see `SourcePausePointConstants.PhysicalCallbackMayMissExistingInstanceWarning`.
 `PausePointTools` logs a `pause_point_physics_dispatch_diagnostics` VibeLogger entry whenever a
-physics-flagged pause point is enabled (and a `pause_point_expired_without_hit_physics` entry if
-it later expires without ever hitting), capturing Play Mode state, seconds since the last domain
-reload, the declaring type, and its current instance count -- if the miss recurs, this is the
-primary evidence to work from.
+physics-flagged pause point is enabled (and a `pause_point_cleared_without_hit_physics` entry if
+it is later cleared without ever hitting, whether it had expired or was still Enabled at that
+point), capturing Play Mode state, seconds since the last domain reload, the declaring type, and
+its current instance count -- if the miss recurs, this is the primary evidence to work from.


### PR DESCRIPTION
## Summary
- Physics-callback pause point diagnostics now fire whenever a marker is cleared without ever being hit, not only when it had already expired

## User Impact
- Before: if an agent's own await timeout was shorter than the marker's expiry, a physics-flagged marker (`OnCollisionEnter2D`, `OnTriggerEnter2D`, etc.) that missed a hit could be cleared while still `Enabled` — and no diagnostic evidence was recorded for that miss, even though the marker was patched and armed correctly
- After: any zero-hit clear of a physics-flagged marker logs the same diagnostics snapshot (Play Mode state, seconds since last domain reload, declaring type, instance count), now tagged with whether the marker was `Enabled` or `Expired` at clear time, so the dominant real-world path is no longer a silent gap in observability

## Changes
- Broadened the diagnostics firing condition in `PausePointUseCase.Clear`/`ClearAll` from `StatusBeforeClear == Expired` to any `HitCount == 0` clear
- Unified the previously separate operation name into a single `pause_point_cleared_without_hit_physics`, with `StatusBeforeClear` added to the logged context
- Updated `docs/regression-harness.md` and a stale code comment referencing the old operation name

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo>` — 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "PausePointTests" --test-mode EditMode` — 80/80 passed, including 3 new tests covering the Enabled-clear, Expired-clear, and `--all` paths


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

