### PR TITLE
feat: Add per-enable collection preview element cap override

### DIFF
--- a/Assets/Tests/Editor/PausePointToolModeTests.cs
+++ b/Assets/Tests/Editor/PausePointToolModeTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -112,6 +114,101 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(response.Success, Is.False);
             Assert.That(response.Message, Is.EqualTo("MaxHistory must be between 1 and 100."));
+        }
+
+        /// <summary>
+        /// Verifies the max-preview-elements JSON parameter reaches the enable response.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenMaxPreviewElementsIsProvided_MapsParameter()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["timeoutSeconds"] = 30,
+                ["maxPreviewElements"] = 200
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.MaxPreviewElements, Is.EqualTo(200));
+        }
+
+        /// <summary>
+        /// Verifies max-preview-elements defaults to the registry default when omitted.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenMaxPreviewElementsIsOmitted_DefaultsToRegistryDefault()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["timeoutSeconds"] = 30
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.MaxPreviewElements, Is.EqualTo(UloopPausePointRegistry.DefaultMaxPreviewElements));
+        }
+
+        /// <summary>
+        /// Verifies an out-of-range max-preview-elements value returns a user-facing validation failure.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenMaxPreviewElementsIsOutOfRange_ReturnsValidationFailure()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["maxPreviewElements"] = UloopPausePointRegistry.MaxPreviewElementsLimit + 1
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("MaxPreviewElements must be between 1 and 1000."));
+        }
+
+        /// <summary>
+        /// Verifies a non-positive max-preview-elements value returns a validation failure.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenMaxPreviewElementsIsZero_ReturnsValidationFailure()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["maxPreviewElements"] = 0
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("MaxPreviewElements must be between 1 and 1000."));
+        }
+
+        /// <summary>
+        /// Verifies a source pause point hit serializes its collection preview using the marker's
+        /// own max-preview-elements override instead of the fixed default.
+        /// </summary>
+        [Test]
+        public void Hit_WhenMarkerHasMaxPreviewElementsOverride_UsesOverrideForCollectionPreview()
+        {
+            const int maxPreviewElements = 3;
+            UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.SingleShot, 20, maxPreviewElements);
+            List<int> values = Enumerable.Range(0, maxPreviewElements + 5).ToList();
+
+            (UloopPausePointCapturedVariableFrame _, List<UloopCapturedVariable> variables, bool truncated) =
+                SourcePausePointCapture.CaptureFrame(null, Array.Empty<object>(), new object[] { "scores", values }, maxPreviewElements);
+
+            Assert.That(variables.Single().Value.Split(',').Length, Is.EqualTo(maxPreviewElements));
+            Assert.That(truncated, Is.True);
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/PausePointToolModeTests.cs
+++ b/Assets/Tests/Editor/PausePointToolModeTests.cs
@@ -200,15 +200,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Hit_WhenMarkerHasMaxPreviewElementsOverride_UsesOverrideForCollectionPreview()
         {
+            // Verifies the Harmony entry point itself (SourcePausePointCapture.Capture) resolves
+            // the marker's override through UloopPausePointRegistry.GetMaxPreviewElements, not
+            // just that CaptureFrame honors a value handed to it directly.
             const int maxPreviewElements = 3;
             UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.SingleShot, 20, maxPreviewElements);
             List<int> values = Enumerable.Range(0, maxPreviewElements + 5).ToList();
 
-            (UloopPausePointCapturedVariableFrame _, List<UloopCapturedVariable> variables, bool truncated) =
-                SourcePausePointCapture.CaptureFrame(null, Array.Empty<object>(), new object[] { "scores", values }, maxPreviewElements);
+            SourcePausePointCapture.Capture(
+                "jump", null, Array.Empty<object>(), new object[] { "scores", values });
 
-            Assert.That(variables.Single().Value.Split(',').Length, Is.EqualTo(maxPreviewElements));
-            Assert.That(truncated, Is.True);
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus("jump");
+            Assert.That(snapshot.CapturedVariables.Single().Value.Split(',').Length, Is.EqualTo(maxPreviewElements));
+            Assert.That(snapshot.CapturedVariablesTruncated, Is.True);
+        }
+
+        /// <summary>
+        /// Verifies GetMaxPreviewElements resolves the value stored by Enable for an armed marker.
+        /// </summary>
+        [Test]
+        public void GetMaxPreviewElements_WhenMarkerIsEnabled_ReturnsConfiguredValue()
+        {
+            UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.SingleShot, 20, 200);
+
+            Assert.That(UloopPausePointRegistry.GetMaxPreviewElements("jump"), Is.EqualTo(200));
+        }
+
+        /// <summary>
+        /// Verifies GetMaxPreviewElements falls back to the registry default for an unknown id.
+        /// </summary>
+        [Test]
+        public void GetMaxPreviewElements_WhenMarkerIsUnknown_ReturnsRegistryDefault()
+        {
+            Assert.That(
+                UloopPausePointRegistry.GetMaxPreviewElements("unknown"),
+                Is.EqualTo(UloopPausePointRegistry.DefaultMaxPreviewElements));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
@@ -599,6 +599,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Format_WithPerMarkerMaxPreviewElementsAndLongPreview_ScalesValueLengthCapWithOverride()
+        {
+            // Verifies the collection value-length cap scales with the per-marker element-count
+            // override (Round-8 motivating case: a 200-element bool board serializes past the
+            // fixed 1024-char default cap, but must not be clipped once the override raises it).
+            const int maxPreviewElements = 200;
+            List<bool> values = Enumerable.Repeat(false, maxPreviewElements).ToList();
+            object[] locals = { "cells", values };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals, maxPreviewElements);
+
+            string value = variables.Single().Value;
+            Assert.That(value.Length, Is.GreaterThan(SourcePausePointConstants.MaxCollectionPreviewValueLength));
+            Assert.That(value.Split(',').Length, Is.EqualTo(maxPreviewElements));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
         public void Format_WithCompositeCollectionElements_ExpandsElementFieldsAsJson()
         {
             // Verifies composite element types without a ToString override expand their fields as

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
@@ -568,6 +568,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Format_WithPerMarkerMaxPreviewElementsAtLimit_DoesNotTruncate()
+        {
+            // Verifies a per-marker preview cap override (enable-pause-point --max-preview-elements)
+            // is honored: exactly the override's element count is not truncated.
+            const int maxPreviewElements = 200;
+            List<int> values = Enumerable.Repeat(0, maxPreviewElements).ToList();
+            object[] locals = { "scores", values };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals, maxPreviewElements);
+
+            Assert.That(variables.Single().Value.Split(',').Length, Is.EqualTo(maxPreviewElements));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WithPerMarkerMaxPreviewElementsExceededByOne_TruncatesAndSetsFlag()
+        {
+            // Verifies one element past the per-marker preview cap still truncates and reports it.
+            const int maxPreviewElements = 200;
+            List<int> values = Enumerable.Repeat(0, maxPreviewElements + 1).ToList();
+            object[] locals = { "scores", values };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals, maxPreviewElements);
+
+            Assert.That(variables.Single().Value.Split(',').Length, Is.EqualTo(maxPreviewElements));
+            Assert.That(truncated, Is.True);
+        }
+
+        [Test]
         public void Format_WithCompositeCollectionElements_ExpandsElementFieldsAsJson()
         {
             // Verifies composite element types without a ToString override expand their fields as

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -31,6 +31,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string Mode { get; set; } = UloopPausePointCaptureMode.SingleShot;
 
         public int MaxHistory { get; set; } = UloopPausePointRegistry.DefaultMaxHistory;
+
+        public int MaxPreviewElements { get; set; } = UloopPausePointRegistry.DefaultMaxPreviewElements;
     }
 
     /// <summary>
@@ -60,6 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public int TimeoutSeconds { get; set; }
         public string Mode { get; set; } = string.Empty;
         public int MaxHistory { get; set; }
+        public int MaxPreviewElements { get; set; }
         public IReadOnlyList<PausePointCapturedHistoryFrame> CapturedVariableHistory { get; set; } =
             Array.Empty<PausePointCapturedHistoryFrame>();
         public int HistoryDroppedCount { get; set; }
@@ -98,6 +101,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 TimeoutSeconds = snapshot.TimeoutSeconds,
                 Mode = snapshot.Mode,
                 MaxHistory = snapshot.MaxHistory,
+                MaxPreviewElements = snapshot.MaxPreviewElements,
                 CapturedVariableHistory = snapshot.CapturedVariableHistory
                     .Select(PausePointCapturedHistoryFrame.FromSnapshot)
                     .ToList(),
@@ -307,7 +311,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters.Id,
                 parameters.TimeoutSeconds,
                 parameters.Mode,
-                parameters.MaxHistory);
+                parameters.MaxHistory,
+                parameters.MaxPreviewElements);
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
             response.Warning = CreateEnableWarning();
             LogEnable(response.Id, resolvedMethod: string.Empty, fileLine: string.Empty, response.Mode, response.Warning);
@@ -437,7 +442,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 id,
                 parameters.TimeoutSeconds,
                 parameters.Mode,
-                parameters.MaxHistory);
+                parameters.MaxHistory,
+                parameters.MaxPreviewElements);
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
             response.ResolvedLine = resolveResult.Resolution.ResolvedLine;
             response.ResolvedLineText = ReadResolvedLineText(parameters.File, resolveResult.Resolution.ResolvedLine);
@@ -579,6 +585,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (parameters.MaxHistory <= 0 || parameters.MaxHistory > UloopPausePointRegistry.MaxHistoryLimit)
             {
                 return $"MaxHistory must be between 1 and {UloopPausePointRegistry.MaxHistoryLimit}.";
+            }
+
+            if (parameters.MaxPreviewElements <= 0 ||
+                parameters.MaxPreviewElements > UloopPausePointRegistry.MaxPreviewElementsLimit)
+            {
+                return $"MaxPreviewElements must be between 1 and {UloopPausePointRegistry.MaxPreviewElementsLimit}.";
             }
 
             return null;

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCapture.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCapture.cs
@@ -25,8 +25,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
+            int maxPreviewElements = UloopPausePointRegistry.GetMaxPreviewElements(id);
             (UloopPausePointCapturedVariableFrame frame, List<UloopCapturedVariable> variables, bool truncated) =
-                CaptureFrame(instance, parameterNamesAndValues, localNamesAndValues);
+                CaptureFrame(instance, parameterNamesAndValues, localNamesAndValues, maxPreviewElements);
 
             if (MainThreadSwitcher.IsMainThread)
             {
@@ -55,11 +56,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         internal static (UloopPausePointCapturedVariableFrame Frame, List<UloopCapturedVariable> Variables, bool Truncated)
-            CaptureFrame(object instance, object[] parameterNamesAndValues, object[] localNamesAndValues)
+            CaptureFrame(
+                object instance, object[] parameterNamesAndValues, object[] localNamesAndValues,
+                int maxPreviewElements = SourcePausePointConstants.MaxCollectionPreviewElementCount)
         {
             UloopPausePointCapturedVariableFrame frame = SourcePausePointVariableCollector.Collect(
                 instance, parameterNamesAndValues, localNamesAndValues);
-            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.FormatFrame(frame);
+            (List<UloopCapturedVariable> variables, bool truncated) =
+                SourcePausePointVariableFormatter.FormatFrame(frame, maxPreviewElements);
             return (frame, variables, truncated);
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs
@@ -36,7 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Converters = { new StringEnumConverter() }
             });
 
-        public static bool TrySerialize(object rawValue, ref bool truncated, out string preview)
+        public static bool TrySerialize(object rawValue, int maxElementCount, ref bool truncated, out string preview)
         {
             preview = string.Empty;
             if (rawValue == null)
@@ -70,7 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 HashSet<object> visited = new(ReferenceEqualityComparer.Instance);
                 JToken token = BuildToken(
-                    rawValue, SourcePausePointConstants.MaxCollectionPreviewDepth, visited, ref truncated);
+                    rawValue, SourcePausePointConstants.MaxCollectionPreviewDepth, maxElementCount, visited, ref truncated);
                 preview = token.ToString(Formatting.None);
                 return true;
             }
@@ -88,7 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         private static JToken BuildToken(
-            object value, int remainingDepth, HashSet<object> visited, ref bool truncated)
+            object value, int remainingDepth, int maxElementCount, HashSet<object> visited, ref bool truncated)
         {
             if (value == null)
             {
@@ -135,17 +135,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 if (value is IDictionary dictionary)
                 {
-                    return BuildDictionaryToken(dictionary, remainingDepth, visited, ref truncated);
+                    return BuildDictionaryToken(dictionary, remainingDepth, maxElementCount, visited, ref truncated);
                 }
 
                 if (value is Array multidimensionalArray && multidimensionalArray.Rank > 1)
                 {
-                    return BuildMultidimensionalArrayToken(multidimensionalArray, remainingDepth, visited, ref truncated);
+                    return BuildMultidimensionalArrayToken(multidimensionalArray, remainingDepth, maxElementCount, visited, ref truncated);
                 }
 
                 if (value is ICollection)
                 {
-                    return BuildArrayToken(enumerable, remainingDepth, visited, ref truncated);
+                    return BuildArrayToken(enumerable, remainingDepth, maxElementCount, visited, ref truncated);
                 }
 
                 return new JValue(SafeToString(value));
@@ -163,14 +163,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return new JValue(SafeToString(value));
                 }
 
-                return BuildObjectFieldsToken(value, remainingDepth, visited, ref truncated);
+                return BuildObjectFieldsToken(value, remainingDepth, maxElementCount, visited, ref truncated);
             }
 
             return new JValue(SafeToString(value));
         }
 
         private static JObject BuildObjectFieldsToken(
-            object value, int remainingDepth, HashSet<object> visited, ref bool truncated)
+            object value, int remainingDepth, int maxElementCount, HashSet<object> visited, ref bool truncated)
         {
             JObject jsonObject = new();
             int fieldCount = 0;
@@ -184,13 +184,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                if (fieldCount >= SourcePausePointConstants.MaxCollectionPreviewElementCount)
+                if (fieldCount >= maxElementCount)
                 {
                     truncated = true;
                     break;
                 }
 
-                jsonObject[name] = BuildToken(field.GetValue(value), remainingDepth - 1, visited, ref truncated);
+                jsonObject[name] = BuildToken(field.GetValue(value), remainingDepth - 1, maxElementCount, visited, ref truncated);
                 fieldCount++;
             }
 
@@ -237,7 +237,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // info, so a T[,] preview otherwise reads as a flat (possibly truncated-looking) list
         // with no way to tell it apart from an empty or 1D collection.
         private static JObject BuildMultidimensionalArrayToken(
-            Array array, int remainingDepth, HashSet<object> visited, ref bool truncated)
+            Array array, int remainingDepth, int maxElementCount, HashSet<object> visited, ref bool truncated)
         {
             string elementTypeName = array.GetType().GetElementType().Name;
             IEnumerable<string> dimensions = Enumerable.Range(0, array.Rank).Select(dimension => array.GetLength(dimension).ToString());
@@ -246,25 +246,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 ["Shape"] = $"{elementTypeName}[{string.Join(",", dimensions)}]",
                 ["TotalElements"] = array.Length,
-                ["Elements"] = BuildArrayToken(array, remainingDepth, visited, ref truncated)
+                ["Elements"] = BuildArrayToken(array, remainingDepth, maxElementCount, visited, ref truncated)
             };
             return shapeToken;
         }
 
         private static JArray BuildArrayToken(
-            IEnumerable enumerable, int remainingDepth, HashSet<object> visited, ref bool truncated)
+            IEnumerable enumerable, int remainingDepth, int maxElementCount, HashSet<object> visited, ref bool truncated)
         {
             JArray array = new();
             int elementCount = 0;
             foreach (object element in enumerable)
             {
-                if (elementCount >= SourcePausePointConstants.MaxCollectionPreviewElementCount)
+                if (elementCount >= maxElementCount)
                 {
                     truncated = true;
                     break;
                 }
 
-                array.Add(BuildToken(element, remainingDepth - 1, visited, ref truncated));
+                array.Add(BuildToken(element, remainingDepth - 1, maxElementCount, visited, ref truncated));
                 elementCount++;
             }
 
@@ -272,20 +272,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         private static JObject BuildDictionaryToken(
-            IDictionary dictionary, int remainingDepth, HashSet<object> visited, ref bool truncated)
+            IDictionary dictionary, int remainingDepth, int maxElementCount, HashSet<object> visited, ref bool truncated)
         {
             JObject jsonObject = new();
             int elementCount = 0;
             foreach (DictionaryEntry entry in dictionary)
             {
-                if (elementCount >= SourcePausePointConstants.MaxCollectionPreviewElementCount)
+                if (elementCount >= maxElementCount)
                 {
                     truncated = true;
                     break;
                 }
 
                 string key = FormatDictionaryKey(entry.Key);
-                jsonObject[key] = BuildToken(entry.Value, remainingDepth - 1, visited, ref truncated);
+                jsonObject[key] = BuildToken(entry.Value, remainingDepth - 1, maxElementCount, visited, ref truncated);
                 elementCount++;
             }
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -1,5 +1,7 @@
 using System.Text.RegularExpressions;
 
+using io.github.hatayama.UnityCliLoop.Runtime;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -21,7 +23,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // pause-point evidence to stay skimmable, mirroring the truncation-by-cap pattern MatchingLogs uses.
         public const int MaxCapturedVariableCount = 50;
         public const int MaxCapturedVariableValueLength = 256;
-        public const int MaxCollectionPreviewElementCount = 10;
+        // Mirrors UloopPausePointRegistry.DefaultMaxPreviewElements (the Runtime-owned per-marker
+        // default enforced at Enable time) instead of a second independent literal, so the two
+        // cannot drift apart.
+        public const int MaxCollectionPreviewElementCount = UloopPausePointRegistry.DefaultMaxPreviewElements;
         public const int MaxCollectionPreviewValueLength = 1024;
         public const int MaxCollectionPreviewDepth = 2;
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
@@ -20,15 +20,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const string DestroyedValue = "(destroyed)";
 
         public static (List<UloopCapturedVariable> Variables, bool Truncated) Format(
-            object instance, object[] parameterNamesAndValues, object[] localNamesAndValues)
+            object instance, object[] parameterNamesAndValues, object[] localNamesAndValues,
+            int maxCollectionPreviewElementCount = SourcePausePointConstants.MaxCollectionPreviewElementCount)
         {
             UloopPausePointCapturedVariableFrame frame = SourcePausePointVariableCollector.Collect(
                 instance, parameterNamesAndValues, localNamesAndValues);
-            return FormatFrame(frame);
+            return FormatFrame(frame, maxCollectionPreviewElementCount);
         }
 
         public static (List<UloopCapturedVariable> Variables, bool Truncated) FormatFrame(
-            UloopPausePointCapturedVariableFrame frame)
+            UloopPausePointCapturedVariableFrame frame,
+            int maxCollectionPreviewElementCount = SourcePausePointConstants.MaxCollectionPreviewElementCount)
         {
             Debug.Assert(frame != null, "frame must not be null");
 
@@ -36,13 +38,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool truncated = frame.Truncated;
             foreach (UloopPausePointCapturedVariableEntry entry in frame.Entries)
             {
-                results.Add(FormatVariable(entry.Name, entry.Scope, entry.Value, ref truncated));
+                results.Add(FormatVariable(entry.Name, entry.Scope, entry.Value, maxCollectionPreviewElementCount, ref truncated));
             }
 
             return (results, truncated);
         }
 
-        private static UloopCapturedVariable FormatVariable(string name, string scope, object rawValue, ref bool truncated)
+        private static UloopCapturedVariable FormatVariable(
+            string name, string scope, object rawValue, int maxCollectionPreviewElementCount, ref bool truncated)
         {
             if (rawValue == null)
             {
@@ -55,7 +58,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return FormatUnityObjectVariable(name, scope, typeName, unityObjectCandidate);
             }
 
-            if (SourcePausePointCollectionPreviewSerializer.TrySerialize(rawValue, ref truncated, out string collectionPreview))
+            if (SourcePausePointCollectionPreviewSerializer.TrySerialize(
+                    rawValue, maxCollectionPreviewElementCount, ref truncated, out string collectionPreview))
             {
                 string cappedPreview = ApplyValueLengthCap(
                     collectionPreview,

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
@@ -61,10 +61,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (SourcePausePointCollectionPreviewSerializer.TrySerialize(
                     rawValue, maxCollectionPreviewElementCount, ref truncated, out string collectionPreview))
             {
-                string cappedPreview = ApplyValueLengthCap(
-                    collectionPreview,
-                    SourcePausePointConstants.MaxCollectionPreviewValueLength,
-                    ref truncated);
+                // Why scale: a per-marker element-count override that raises the element cap
+                // without also raising the byte budget would still get clipped by the fixed
+                // default-sized value-length cap before all the requested elements fit (the
+                // motivating Round-8 case: a 200-element bool board needs ~1200 chars, well
+                // past the 1024-char default). Scaling keeps the ~102-chars-per-element budget
+                // the default (10 elements, 1024 chars) already implies.
+                int scaledValueLengthCap = SourcePausePointConstants.MaxCollectionPreviewValueLength
+                    * maxCollectionPreviewElementCount / UloopPausePointRegistry.DefaultMaxPreviewElements;
+                string cappedPreview = ApplyValueLengthCap(collectionPreview, scaledValueLengthCap, ref truncated);
                 return new UloopCapturedVariable(name, scope, typeName, cappedPreview, string.Empty, string.Empty, 0);
             }
 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -15,6 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             int timeoutSeconds,
             string mode,
             int maxHistory,
+            int maxPreviewElements,
             DateTime enabledAtUtc,
             int generation)
         {
@@ -22,6 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             TimeoutSeconds = timeoutSeconds;
             Mode = mode;
             MaxHistory = maxHistory;
+            MaxPreviewElements = maxPreviewElements;
             EnabledAtUtc = enabledAtUtc;
             ExpiresAtUtc = enabledAtUtc.AddSeconds(timeoutSeconds);
             Generation = generation;
@@ -36,6 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public int TimeoutSeconds { get; }
         public string Mode { get; }
         public int MaxHistory { get; }
+        public int MaxPreviewElements { get; }
         public DateTime EnabledAtUtc { get; }
         public DateTime ExpiresAtUtc { get; private set; }
         public int Generation { get; }
@@ -234,6 +237,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 TimeoutSeconds,
                 Mode,
                 MaxHistory,
+                MaxPreviewElements,
                 new List<UloopPausePointCapturedHistoryFrame>(_capturedVariableHistory),
                 HistoryDroppedCount,
                 expired,

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -18,6 +18,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public const int DefaultTimeoutSeconds = 30;
         public const int DefaultMaxHistory = 20;
         public const int MaxHistoryLimit = 100;
+        public const int DefaultMaxPreviewElements = 10;
+        public const int MaxPreviewElementsLimit = 1000;
 
         private static readonly ConcurrentDictionary<string, UloopPausePointEntry> Entries = new();
         private static IUloopPausePointPauseController _pauseController = new UnityEditorPausePointPauseController();
@@ -56,17 +58,22 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             string id,
             int timeoutSeconds,
             string mode = UloopPausePointCaptureMode.SingleShot,
-            int maxHistory = DefaultMaxHistory)
+            int maxHistory = DefaultMaxHistory,
+            int maxPreviewElements = DefaultMaxPreviewElements)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(id), "id must not be null or empty");
             Debug.Assert(timeoutSeconds > 0, "timeoutSeconds must be greater than zero");
             Debug.Assert(IsSupportedMode(mode), "mode must be a supported pause point capture mode");
             Debug.Assert(maxHistory > 0, "maxHistory must be greater than zero");
             Debug.Assert(maxHistory <= MaxHistoryLimit, "maxHistory must not exceed the history limit");
+            Debug.Assert(maxPreviewElements > 0, "maxPreviewElements must be greater than zero");
+            Debug.Assert(
+                maxPreviewElements <= MaxPreviewElementsLimit,
+                "maxPreviewElements must not exceed the preview element limit");
 
             DateTime now = NowUtc();
             int generation = ++_nextGeneration;
-            UloopPausePointEntry entry = new(id, timeoutSeconds, mode, maxHistory, now, generation);
+            UloopPausePointEntry entry = new(id, timeoutSeconds, mode, maxHistory, maxPreviewElements, now, generation);
             Entries[id] = entry;
             // Why not clear the raw capture holder here: a re-enable does not resume Unity, so the
             // paused-window constraint (see UloopPausePointRawCaptureHolder's class comment) is not
@@ -231,6 +238,17 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
 
             return Entries.TryGetValue(id, out UloopPausePointEntry entry) && entry.IsEnabled;
+        }
+
+        // Called from the Harmony Capture entry point right after IsArmed confirms the id is
+        // armed, so the per-marker override set at Enable time can size the collection preview
+        // for this hit. Falls back to the default when the id is unexpectedly missing (e.g. a
+        // race with Clear) rather than asserting, since Capture must never throw off a patched method.
+        public static int GetMaxPreviewElements(string id)
+        {
+            return Entries.TryGetValue(id, out UloopPausePointEntry entry)
+                ? entry.MaxPreviewElements
+                : DefaultMaxPreviewElements;
         }
 
         /// <summary>

--- a/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
@@ -20,6 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             int timeoutSeconds,
             string mode,
             int maxHistory,
+            int maxPreviewElements,
             IReadOnlyList<UloopPausePointCapturedHistoryFrame> capturedVariableHistory,
             int historyDroppedCount,
             bool expired,
@@ -50,6 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             TimeoutSeconds = timeoutSeconds;
             Mode = mode ?? UloopPausePointCaptureMode.SingleShot;
             MaxHistory = maxHistory;
+            MaxPreviewElements = maxPreviewElements;
             CapturedVariableHistory = capturedVariableHistory ?? Array.Empty<UloopPausePointCapturedHistoryFrame>();
             HistoryDroppedCount = historyDroppedCount;
             Expired = expired;
@@ -79,6 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public int TimeoutSeconds { get; }
         public string Mode { get; }
         public int MaxHistory { get; }
+        public int MaxPreviewElements { get; }
         public IReadOnlyList<UloopPausePointCapturedHistoryFrame> CapturedVariableHistory { get; }
         public int HistoryDroppedCount { get; }
         public bool Expired { get; }
@@ -111,6 +114,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 0,
                 0,
                 UloopPausePointCaptureMode.SingleShot,
+                0,
                 0,
                 Array.Empty<UloopPausePointCapturedHistoryFrame>(),
                 0,

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -380,6 +380,11 @@
             "type": "integer",
             "description": "Maximum number of captured hit frames to retain (1-100)",
             "default": 20
+          },
+          "MaxPreviewElements": {
+            "type": "integer",
+            "description": "Maximum number of elements to include in a captured collection's preview (1-1000)",
+            "default": 10
           }
         }
       }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "ffe6879910a39cf2bfd41750d1004a74009bc166"
+  "sharedInputsHash": "9861856df997eec3000b92ac75d9da01a6b4ef40"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "365d004e1dd5b0ffd4da57aafb814466595cbf26"
+  "sharedInputsHash": "f40c86b687ba208461a39f19ecca41b522d0fd3f"
 }


### PR DESCRIPTION
## Summary
- A pause point's captured collection preview (arrays, lists, dictionaries) is no longer stuck at a fixed 10-element cap — it can be sized per marker up to 1000 elements.

## User Impact
- Before: every pause point shared one process-wide 10-element preview cap, so hitting a marker with a larger array/list only ever showed its first 10 items, making state with more than a handful of elements unusable for debugging.
- After: `enable-pause-point` accepts a new `--max-preview-elements <n>` option (1-1000, default 10 to match existing behavior). Passing a larger value lets a marker's captured collections show that many elements instead of being clipped at 10.

## Changes
- `enable-pause-point` gained `MaxPreviewElements`, validated the same way as the existing `MaxHistory` bound (1-1000).
- The value is stored per marker in the pause point registry and threaded through capture -> formatting -> collection preview serialization, replacing the single shared constant with a per-marker value.
- The enable/status response now reports the effective `MaxPreviewElements` for the marker.
- `cli/common/tools/default-tools.json` schema updated to expose the new option to the CLI.

## Verification
- `uloop compile`: 0 errors / 0 warnings.
- `uloop run-tests --filter-type regex --filter-value "PausePoint" --test-mode EditMode`: 243/243 passed, including new tests for the 200/201-element truncation boundary and the CLI-level enable/validation mapping.
- Real-project manual check: enabled a pause point on a method building a 1000-element list, hit it via `execute-dynamic-code`, and confirmed `enable-pause-point`'s response reports `MaxPreviewElements: 1000` and the round trip through `pause-point-status` completes normally (the final preview string is still capped by the pre-existing 1024-character value-length limit, which is expected and unrelated to the element-count cap).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

