### PR TITLE
fix: Keep execute-dynamic-code waiting through self-induced main-thread stalls

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -37,8 +37,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 object[] parametersArray = ConvertParameters(parameters.Parameters);
                 string originalCode = parameters.Code ?? string.Empty;
+                string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
 
-                LogExecutionStart(parameters, UnityCliLoopConstants.GenerateCorrelationId());
+                LogExecutionStart(parameters, correlationId);
 
                 DynamicCodeExecutionRequest request = CreateExecutionRequest(
                     originalCode,
@@ -65,6 +66,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     DynamicCodeForegroundWarmupState.MarkCompletedBySuccessfulExecution();
                 }
+
+                LogExecutionComplete(finalResult, correlationId);
 
                 if (DynamicCodeExecutionResponseFactory.IsCancelledResult(finalResult))
                 {
@@ -153,6 +156,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 },
                 correlationId,
                 "Dynamic code execution request received (return is optional)",
+                "Monitor execution flow and performance");
+        }
+
+        // Why this exists: execute_dynamic_code_start had no matching completion log, so a
+        // client-side stall diagnosis (e.g. EditorUnresponsiveError) could not be correlated
+        // against whether Unity had actually finished the snippet by the time the CLI gave up.
+        private static void LogExecutionComplete(ExecutionResult finalResult, string correlationId)
+        {
+            VibeLogger.LogInfo(
+                "execute_dynamic_code_complete",
+                "Dynamic code execution completed",
+                new
+                {
+                    correlationId,
+                    success = finalResult.Success,
+                    cancelled = DynamicCodeExecutionResponseFactory.IsCancelledResult(finalResult),
+                    runtimeRestarting = DynamicCodeExecutionResponseFactory.IsRuntimeRestartingResult(finalResult),
+                    executionTimeMs = finalResult.ExecutionTime.TotalMilliseconds
+                },
+                correlationId,
+                "Dynamic code execution finished; correlate against execute_dynamic_code_start by correlationId",
                 "Monitor execution flow and performance");
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -32,12 +32,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             using DynamicCodeDomainReloadWaitSignal domainReloadWaitSignal =
                 DynamicCodeDomainReloadWaitSignal.Start(parameters);
+            // Declared outside the try so the catch below can still correlate a cancellation
+            // against this same execute_dynamic_code_start entry, and so it can tell whether the
+            // finalResult path below already logged completion before a later await in that same
+            // path (e.g. ApplyPauseStateAsync) throws OperationCanceledException.
+            string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
+            bool completionLogged = false;
 
             try
             {
                 object[] parametersArray = ConvertParameters(parameters.Parameters);
                 string originalCode = parameters.Code ?? string.Empty;
-                string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
 
                 LogExecutionStart(parameters, correlationId);
 
@@ -68,6 +73,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 LogExecutionComplete(finalResult, correlationId);
+                completionLogged = true;
 
                 if (DynamicCodeExecutionResponseFactory.IsCancelledResult(finalResult))
                 {
@@ -111,6 +117,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             catch (OperationCanceledException)
             {
+                if (!completionLogged)
+                {
+                    LogExecutionCancelledBeforeResult(correlationId);
+                }
                 ExecuteDynamicCodeResponse response = DynamicCodeExecutionResponseFactory.CreateCancelledResponse();
                 response.EmitTimingsInJsonResponse = parameters?.IncludeTimings ?? false;
                 // Why CancellationToken.None: cancellationToken is already cancelled on this path,
@@ -164,16 +174,38 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // against whether Unity had actually finished the snippet by the time the CLI gave up.
         private static void LogExecutionComplete(ExecutionResult finalResult, string correlationId)
         {
+            LogExecutionCompleteEntry(
+                finalResult.Success,
+                DynamicCodeExecutionResponseFactory.IsCancelledResult(finalResult),
+                DynamicCodeExecutionResponseFactory.IsRuntimeRestartingResult(finalResult),
+                finalResult.ExecutionTime.TotalMilliseconds,
+                correlationId);
+        }
+
+        // Covers cancellation paths that throw before a final ExecutionResult exists (e.g. during
+        // foreground warmup), which LogExecutionComplete above cannot reach.
+        private static void LogExecutionCancelledBeforeResult(string correlationId)
+        {
+            LogExecutionCompleteEntry(success: false, cancelled: true, runtimeRestarting: false, executionTimeMs: 0, correlationId);
+        }
+
+        private static void LogExecutionCompleteEntry(
+            bool success,
+            bool cancelled,
+            bool runtimeRestarting,
+            double executionTimeMs,
+            string correlationId)
+        {
             VibeLogger.LogInfo(
                 "execute_dynamic_code_complete",
                 "Dynamic code execution completed",
                 new
                 {
                     correlationId,
-                    success = finalResult.Success,
-                    cancelled = DynamicCodeExecutionResponseFactory.IsCancelledResult(finalResult),
-                    runtimeRestarting = DynamicCodeExecutionResponseFactory.IsRuntimeRestartingResult(finalResult),
-                    executionTimeMs = finalResult.ExecutionTime.TotalMilliseconds
+                    success,
+                    cancelled,
+                    runtimeRestarting,
+                    executionTimeMs
                 },
                 correlationId,
                 "Dynamic code execution finished; correlate against execute_dynamic_code_start by correlationId",

--- a/cli/common/unityipc/client.go
+++ b/cli/common/unityipc/client.go
@@ -352,10 +352,11 @@ func (client *Client) handleHeartbeatResponse(
 	acceptedAt time.Time,
 ) error {
 	stallSeconds := response.ULoop.MainThreadStallSeconds
+	selfInducedStall := client.isSelfInducedStall(stallSeconds, acceptedAt)
 	if stallSeconds >= mainThreadStallProgressThresholdSeconds {
-		client.reportMainThreadStall(stallSeconds, progress)
+		client.reportMainThreadStall(stallSeconds, selfInducedStall, progress)
 	}
-	if stallSeconds >= client.getMainThreadStallLimit().Seconds() && !client.isSelfInducedStall(stallSeconds, acceptedAt) {
+	if stallSeconds >= client.getMainThreadStallLimit().Seconds() && !selfInducedStall {
 		return &EditorUnresponsiveError{StallSeconds: stallSeconds}
 	}
 	if heartbeatSilence > 0 {
@@ -364,15 +365,19 @@ func (client *Client) handleHeartbeatResponse(
 	return nil
 }
 
-func (client *Client) reportMainThreadStall(stallSeconds float64, progress ProgressFunc) {
+func (client *Client) reportMainThreadStall(stallSeconds float64, selfInducedStall bool, progress ProgressFunc) {
 	if client.options.mainThreadStallHandler != nil {
 		client.options.mainThreadStallHandler(stallSeconds)
 	}
 	if progress == nil {
 		return
 	}
+	// Why classify rather than just check the option: a stall that predates this request's
+	// accept is a genuine freeze even on a self-induced-stall-tolerant client (it is about to
+	// fail with EditorUnresponsiveError below), so it must keep the "stuck" wording instead of
+	// wrongly implying the command itself is the cause.
 	message := fmt.Sprintf("Unity main thread stuck %.0fs; check modal/long operation...", stallSeconds)
-	if client.options.selfInducedStallTolerant {
+	if selfInducedStall {
 		message = fmt.Sprintf("Unity main thread busy executing this command for %.0fs; still waiting...", stallSeconds)
 	}
 	progress(cliprogress.Event{Stage: cliprogress.StageMessage, Message: message})

--- a/cli/common/unityipc/client.go
+++ b/cli/common/unityipc/client.go
@@ -142,6 +142,10 @@ func (client *Client) WithMainThreadStallHandler(handler func(float64)) *Client 
 	return client.withOption(WithMainThreadStallHandler(handler))
 }
 
+func (client *Client) WithSelfInducedMainThreadStallTolerance() *Client {
+	return client.withOption(WithSelfInducedMainThreadStallTolerance())
+}
+
 func (client *Client) withOption(option ClientOption) *Client {
 	clientOptions := client.options
 	option(&clientOptions)
@@ -235,6 +239,7 @@ func (client *Client) SendWithProgressOutcomeAcceptContext(
 
 	if response.ULoop.Phase == rpcResponsePhaseAccepted {
 		outcome.RequestAccepted = true
+		acceptedAt := time.Now()
 		if progress != nil {
 			progress(cliprogress.Event{Stage: cliprogress.StageAccepted})
 		}
@@ -246,6 +251,7 @@ func (client *Client) SendWithProgressOutcomeAcceptContext(
 			progress,
 			cancelAccept,
 			startedAt,
+			acceptedAt,
 			timing,
 			outcome,
 			response,
@@ -262,6 +268,7 @@ func (client *Client) readAcceptedResponse(
 	progress ProgressFunc,
 	cancelAccept context.CancelFunc,
 	startedAt time.Time,
+	acceptedAt time.Time,
 	timing UnitySendTiming,
 	outcome UnitySendOutcome,
 	response rpcResponse,
@@ -301,6 +308,7 @@ func (client *Client) readAcceptedResponse(
 			progress,
 			heartbeatSilence,
 			absoluteDeadline,
+			acceptedAt,
 		); err != nil {
 			return finishOutcomeWithError(outcome, timing, startedAt, err)
 		}
@@ -341,12 +349,13 @@ func (client *Client) handleHeartbeatResponse(
 	progress ProgressFunc,
 	heartbeatSilence time.Duration,
 	absoluteDeadline time.Time,
+	acceptedAt time.Time,
 ) error {
 	stallSeconds := response.ULoop.MainThreadStallSeconds
 	if stallSeconds >= mainThreadStallProgressThresholdSeconds {
 		client.reportMainThreadStall(stallSeconds, progress)
 	}
-	if stallSeconds >= client.getMainThreadStallLimit().Seconds() {
+	if stallSeconds >= client.getMainThreadStallLimit().Seconds() && !client.isSelfInducedStall(stallSeconds, acceptedAt) {
 		return &EditorUnresponsiveError{StallSeconds: stallSeconds}
 	}
 	if heartbeatSilence > 0 {
@@ -359,14 +368,14 @@ func (client *Client) reportMainThreadStall(stallSeconds float64, progress Progr
 	if client.options.mainThreadStallHandler != nil {
 		client.options.mainThreadStallHandler(stallSeconds)
 	}
-	if progress != nil {
-		progress(cliprogress.Event{
-			Stage: cliprogress.StageMessage,
-			Message: fmt.Sprintf(
-				"Unity main thread stuck %.0fs; check modal/long operation...",
-				stallSeconds),
-		})
+	if progress == nil {
+		return
 	}
+	message := fmt.Sprintf("Unity main thread stuck %.0fs; check modal/long operation...", stallSeconds)
+	if client.options.selfInducedStallTolerant {
+		message = fmt.Sprintf("Unity main thread busy executing this command for %.0fs; still waiting...", stallSeconds)
+	}
+	progress(cliprogress.Event{Stage: cliprogress.StageMessage, Message: message})
 }
 
 func finishRPCResponse(

--- a/cli/common/unityipc/client_heartbeat_test.go
+++ b/cli/common/unityipc/client_heartbeat_test.go
@@ -265,6 +265,65 @@ func TestSendFailsWhenMainThreadStallExceedsLimit(t *testing.T) {
 	}
 }
 
+// Verifies that a self-induced-stall-tolerant client keeps waiting through a main-thread
+// stall reported shortly after this request's own accept, instead of failing with
+// EditorUnresponsiveError: a command that itself blocks the main thread synchronously
+// (e.g. a long execute-dynamic-code snippet) must not be treated as a frozen editor.
+func TestSendKeepsWaitingThroughSelfInducedMainThreadStall(t *testing.T) {
+	stalledHeartbeat := `{"jsonrpc":"2.0","id":1,"result":{"alive":true},"uloop":{"phase":"heartbeat","mainThreadStallSeconds":3}}`
+	connection := startHeartbeatTestServer(t, func(conn net.Conn) {
+		writeFrame(t, conn, heartbeatAck)
+		writeFrame(t, conn, stalledHeartbeat)
+		writeFrame(t, conn, `{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`)
+	})
+
+	client := NewClient(
+		connection,
+		"9.9.9",
+		WithSelfInducedMainThreadStallTolerance(),
+		withHeartbeatSilenceOverrideForTest(5*time.Second),
+		withMainThreadStallLimitForTest(2*time.Second),
+	)
+
+	outcome, err := client.SendWithProgressOutcome(context.Background(), "execute-dynamic-code", map[string]any{}, nil)
+	if err != nil {
+		t.Fatalf("expected success through a self-induced stall, got %v", err)
+	}
+	if len(outcome.Result) == 0 {
+		t.Fatal("expected final result")
+	}
+}
+
+// Verifies that self-induced-stall tolerance does not mask a genuine freeze: a stall that
+// already exceeds the time elapsed since this request's own accept (plus margin) predates
+// the request and must still fail with EditorUnresponsiveError.
+func TestSendFailsWhenMainThreadStallPredatesAcceptDespiteTolerance(t *testing.T) {
+	// Why 40s: exceeds the elapsed-since-accept time (a few ms in this test) plus the
+	// self-induced-stall margin (30s), so this stall could not have started after accept.
+	stalledHeartbeat := `{"jsonrpc":"2.0","id":1,"result":{"alive":true},"uloop":{"phase":"heartbeat","mainThreadStallSeconds":40}}`
+	done := make(chan struct{})
+	connection := startHeartbeatTestServer(t, func(conn net.Conn) {
+		writeFrame(t, conn, heartbeatAck)
+		writeFrame(t, conn, stalledHeartbeat)
+		<-done
+	})
+	defer close(done)
+
+	client := NewClient(
+		connection,
+		"9.9.9",
+		WithSelfInducedMainThreadStallTolerance(),
+		withHeartbeatSilenceOverrideForTest(5*time.Second),
+		withMainThreadStallLimitForTest(2*time.Second),
+	)
+
+	_, err := client.SendWithProgressOutcome(context.Background(), "execute-dynamic-code", map[string]any{}, nil)
+	var unresponsiveErr *EditorUnresponsiveError
+	if !errors.As(err, &unresponsiveErr) {
+		t.Fatalf("expected EditorUnresponsiveError for a stall predating accept, got %v", err)
+	}
+}
+
 // Verifies that an explicit response timeout stays an absolute deadline: heartbeats
 // are skipped but must not extend it (compile relies on this to fall back to polling).
 func TestSendKeepsExplicitResponseTimeoutDespiteHeartbeats(t *testing.T) {

--- a/cli/common/unityipc/client_heartbeat_test.go
+++ b/cli/common/unityipc/client_heartbeat_test.go
@@ -324,6 +324,51 @@ func TestSendFailsWhenMainThreadStallPredatesAcceptDespiteTolerance(t *testing.T
 	}
 }
 
+// Verifies that a self-induced-stall-tolerant client still reports the "stuck" wording
+// (not the "busy executing" wording) for a stall that predates this request's accept: it
+// is a genuine freeze, and the progress message must not imply the command itself caused
+// it right before failing with EditorUnresponsiveError.
+func TestSendReportsStuckMessageForStallPredatingAcceptDespiteTolerance(t *testing.T) {
+	stalledHeartbeat := `{"jsonrpc":"2.0","id":1,"result":{"alive":true},"uloop":{"phase":"heartbeat","mainThreadStallSeconds":40}}`
+	done := make(chan struct{})
+	connection := startHeartbeatTestServer(t, func(conn net.Conn) {
+		writeFrame(t, conn, heartbeatAck)
+		writeFrame(t, conn, stalledHeartbeat)
+		<-done
+	})
+	defer close(done)
+
+	client := NewClient(
+		connection,
+		"9.9.9",
+		WithSelfInducedMainThreadStallTolerance(),
+		withHeartbeatSilenceOverrideForTest(5*time.Second),
+		withMainThreadStallLimitForTest(2*time.Second),
+	)
+
+	progressMessages := []string{}
+	_, err := client.SendWithProgressOutcome(
+		context.Background(),
+		"execute-dynamic-code",
+		map[string]any{},
+		func(event progress.Event) {
+			progressMessages = append(progressMessages, event.Message)
+		},
+	)
+	var unresponsiveErr *EditorUnresponsiveError
+	if !errors.As(err, &unresponsiveErr) {
+		t.Fatalf("expected EditorUnresponsiveError for a stall predating accept, got %v", err)
+	}
+
+	joinedMessages := strings.Join(progressMessages, "\n")
+	if !strings.Contains(joinedMessages, "stuck") {
+		t.Fatalf("progress should still say stuck for a genuine freeze: %#v", progressMessages)
+	}
+	if strings.Contains(joinedMessages, "busy executing") {
+		t.Fatalf("progress must not say busy executing for a stall predating accept: %#v", progressMessages)
+	}
+}
+
 // Verifies that an explicit response timeout stays an absolute deadline: heartbeats
 // are skipped but must not extend it (compile relies on this to fall back to polling).
 func TestSendKeepsExplicitResponseTimeoutDespiteHeartbeats(t *testing.T) {

--- a/cli/common/unityipc/client_options.go
+++ b/cli/common/unityipc/client_options.go
@@ -9,6 +9,7 @@ type ClientOptions struct {
 	heartbeatSilenceOverride time.Duration
 	mainThreadStallLimit     time.Duration
 	mainThreadStallHandler   func(float64)
+	selfInducedStallTolerant bool
 }
 
 // ClientOption applies one optional IPC client setting.
@@ -25,6 +26,18 @@ func WithResponseTimeout(timeout time.Duration) ClientOption {
 func WithMainThreadStallHandler(handler func(float64)) ClientOption {
 	return func(options *ClientOptions) {
 		options.mainThreadStallHandler = handler
+	}
+}
+
+// WithSelfInducedMainThreadStallTolerance exempts a heartbeat's main-thread stall from
+// EditorUnresponsiveError when the stall cannot predate this request's own accept (within a
+// margin): a command that itself blocks the main thread synchronously (e.g. a long
+// execute-dynamic-code snippet) looks identical to a frozen editor on the stall counter alone.
+// A stall that already exceeds the elapsed-since-accept time was running before this request
+// started and still fails as a genuine freeze.
+func WithSelfInducedMainThreadStallTolerance() ClientOption {
+	return func(options *ClientOptions) {
+		options.selfInducedStallTolerant = true
 	}
 }
 
@@ -82,6 +95,19 @@ func (client *Client) getMainThreadStallLimit() time.Duration {
 		return client.options.mainThreadStallLimit
 	}
 	return defaultMainThreadStallLimit
+}
+
+// Why margin: heartbeat delivery and clock skew between accept and the first stall report
+// add slack; a stall a few seconds beyond elapsed-since-accept is still self-induced, not
+// evidence the freeze predates this request.
+const selfInducedStallMargin = 30 * time.Second
+
+func (client *Client) isSelfInducedStall(stallSeconds float64, acceptedAt time.Time) bool {
+	if !client.options.selfInducedStallTolerant {
+		return false
+	}
+	elapsedSinceAccept := time.Since(acceptedAt) + selfInducedStallMargin
+	return stallSeconds <= elapsedSinceAccept.Seconds()
 }
 
 func (client *Client) nextRequestID() int {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "9861856df997eec3000b92ac75d9da01a6b4ef40"
+  "sharedInputsHash": "e9449b2ff1773625d43f39e1d71cab7440bb70ca"
 }

--- a/cli/project-runner/internal/projectrunner/connection_retry.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry.go
@@ -210,7 +210,7 @@ func sendWithTransientConnectionRetryWithDeps(
 	retryTicker := time.NewTicker(deps.retryPoll)
 	defer retryTicker.Stop()
 	for {
-		client := newConnectionRetryClient(connection, responseTimeout, func(stallSeconds float64) {
+		client := newConnectionRetryClient(connection, method, responseTimeout, func(stallSeconds float64) {
 			focusController.handleMainThreadStall(ctx, stallSeconds)
 		})
 		// Each attempt keeps the base accept bound: a dispatched request that never gets

--- a/cli/project-runner/internal/projectrunner/connection_retry_flow.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_flow.go
@@ -7,12 +7,14 @@ import (
 	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 
 	"github.com/hatayama/unity-cli-loop/common/clicontract"
+	"github.com/hatayama/unity-cli-loop/common/clicore"
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 	"github.com/hatayama/unity-cli-loop/common/unityprocess"
 )
 
 func newConnectionRetryClient(
 	connection unityipc.Connection,
+	method string,
 	responseTimeout time.Duration,
 	mainThreadStallHandler func(float64),
 ) *unityipc.Client {
@@ -20,7 +22,18 @@ func newConnectionRetryClient(
 	if responseTimeout > 0 {
 		client = client.WithResponseTimeout(responseTimeout)
 	}
-	return client.WithMainThreadStallHandler(mainThreadStallHandler)
+	client = client.WithMainThreadStallHandler(mainThreadStallHandler)
+	if commandNeedsSelfInducedStallTolerance(method) {
+		client = client.WithSelfInducedMainThreadStallTolerance()
+	}
+	return client
+}
+
+// Why only execute-dynamic-code: a long synchronous snippet blocks Unity's main thread
+// from pumping update ticks by design, which looks identical to a frozen editor on the
+// stall counter alone. Other commands' stalls stay a genuine freeze signal.
+func commandNeedsSelfInducedStallTolerance(method string) bool {
+	return method == clicore.ExecuteDynamicCodeCommandName
 }
 
 func finishBusyRetry(

--- a/cli/project-runner/internal/projectrunner/connection_retry_flow_test.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_flow_test.go
@@ -1,0 +1,21 @@
+package projectrunner
+
+import (
+	"testing"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+)
+
+// Verifies only execute-dynamic-code gets main-thread stall tolerance: other commands'
+// stalls must keep failing as a genuine freeze signal.
+func TestCommandNeedsSelfInducedStallToleranceOnlyForExecuteDynamicCode(t *testing.T) {
+	if !commandNeedsSelfInducedStallTolerance(clicore.ExecuteDynamicCodeCommandName) {
+		t.Fatal("expected execute-dynamic-code to need self-induced stall tolerance")
+	}
+	if commandNeedsSelfInducedStallTolerance("compile") {
+		t.Fatal("expected compile to not need self-induced stall tolerance")
+	}
+	if commandNeedsSelfInducedStallTolerance("run-tests") {
+		t.Fatal("expected run-tests to not need self-induced stall tolerance")
+	}
+}

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "f40c86b687ba208461a39f19ecca41b522d0fd3f"
+  "sharedInputsHash": "15c05452ea2fa09b729ea0916c41f168ce5d4c8f"
 }


### PR DESCRIPTION
## Summary
- `execute-dynamic-code` no longer fails with a false "editor unresponsive" error while a long-running snippet is still legitimately executing.

## User Impact
- Before: a long-running `execute-dynamic-code` snippet (observed with a ~150-line scene-construction script, ~6 minutes) could make the CLI report `unity editor main thread has been unresponsive` and suggest restarting the editor, even though Unity was alive and finished the snippet normally seconds later. The false report came from a heuristic that cannot tell "this command is busy running" apart from "the editor is frozen," because both look identical on the main-thread stall counter.
- After: `execute-dynamic-code` keeps waiting through a stall that started no earlier than the request's own acceptance (i.e. it's this command keeping the main thread busy). A stall that already predates the request — meaning the editor was frozen before this command ever started — still fails with the same diagnosis as before, so a genuine freeze is still caught.

## Changes
- `cli/common/unityipc`: added `WithSelfInducedMainThreadStallTolerance`, which exempts a heartbeat stall from `EditorUnresponsiveError` only while `stallSeconds` cannot exceed the time elapsed since this request's own accept (plus a margin for heartbeat/clock slack). The progress message while exempted is reworded to describe busyness instead of implying a freeze.
- `cli/project-runner`: applies the new option only for the `execute-dynamic-code` command; every other command's stall handling is unchanged.
- `Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode`: added a completion VibeLog entry (`execute_dynamic_code_complete`) alongside the existing start entry, so a future stall report can be correlated against whether Unity actually finished — the gap that made this investigation harder than necessary.

## Verification
- Root-caused via a read-only VibeLog analysis of a real false-stall session: Unity's logs showed the snippet finishing normally about 353-364s after `execute_dynamic_code_start`, while the CLI's heartbeat-driven stall heuristic (`cli/common/unityipc/client.go`) gave up unconditionally at the fixed 300s limit.
- TDD: wrote a failing test (`TestSendKeepsWaitingThroughSelfInducedMainThreadStall`) reproducing the false failure against the pre-fix code, confirmed it failed with `EditorUnresponsiveError`, then implemented the fix to make it pass. Also added `TestSendFailsWhenMainThreadStallPredatesAcceptDespiteTolerance` to confirm the exemption does not mask a stall that predates the request's accept.
- `sh scripts/check-go-cli.sh`: format/vet/lint 0 issues, all Go packages pass (including the new tests).
- `go test -run TestProductionGoFilesStayFocused ./...` (release-automation): pass.
- `sh scripts/stamp-release-inputs.sh`: re-run and committed, since `cli/common` changed.
- `dist/darwin-arm64/uloop compile`: 0 errors / 0 warnings after the C# completion-log addition.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

