### PR TITLE
fix: Fail control-play-mode fast when unsaved changes cannot be quietly saved

### DIFF
--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -283,6 +283,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(EditorApplication.isPlaying, Is.False);
             Assert.That(response.Changed, Is.False);
             Assert.That(response.IsPlaying, Is.False);
+            Assert.That(response.BlockedByUnsavedChanges, Is.True);
             Assert.That(response.Message, Does.Contain("could not be saved"));
             Assert.That(response.Message, Does.Contain("Scene: Assets/Scenes/Sample.unity"));
         }
@@ -310,6 +311,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(quietSaver.DetectCallCount, Is.EqualTo(1));
             Assert.That(EditorApplication.isPlaying, Is.False);
             Assert.That(response.Changed, Is.False);
+            Assert.That(response.BlockedByUnsavedChanges, Is.True);
             Assert.That(response.Message, Does.Contain("unsaved scene or prefab changes"));
             Assert.That(response.Message, Does.Contain("Prefab Stage: Assets/Prefabs/Hud.prefab"));
         }

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeResponse.cs
@@ -13,6 +13,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool WasAlreadyStopped { get; set; }
         public bool ResumedFromPause { get; set; }
         public bool BlockedByCompileErrors { get; set; }
+        public bool BlockedByUnsavedChanges { get; set; }
         public int CompileErrorCount { get; set; }
         public ControlPlayModeCompileError[] CompileErrors { get; set; }
         public string Message { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -246,7 +246,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(failedChanges.Length > 0, "failedChanges must not be empty");
 
             string message = messagePrefix + " Unsaved changes: " + string.Join(", ", failedChanges);
-            return CreateResponse(message, false, false);
+            ControlPlayModeResponse response = CreateResponse(message, false, false);
+            response.BlockedByUnsavedChanges = true;
+            return response;
         }
 
         private ControlPlayModeResponse CreateCompileErrorBlockedResponse(

--- a/cli/common/errors/error_envelope.go
+++ b/cli/common/errors/error_envelope.go
@@ -28,6 +28,7 @@ const (
 	ErrorCodeCompileWaitTimeout              = "COMPILE_WAIT_TIMEOUT"
 	ErrorCodeControlPlayModeWaitTimeout      = "CONTROL_PLAY_MODE_WAIT_TIMEOUT"
 	ErrorCodeControlPlayModeCompileErrors    = "CONTROL_PLAY_MODE_COMPILE_ERRORS"
+	ErrorCodeControlPlayModeUnsavedChanges   = "CONTROL_PLAY_MODE_UNSAVED_CHANGES"
 	ErrorCodePausePointNotEnabled            = "PAUSE_POINT_NOT_ENABLED"
 	ErrorCodePausePointWaitTimeout           = "PAUSE_POINT_WAIT_TIMEOUT"
 	ErrorCodePausePointExpired               = "PAUSE_POINT_EXPIRED"

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "e9449b2ff1773625d43f39e1d71cab7440bb70ca"
+  "sharedInputsHash": "94226bfd226cb7dae313f0f318b920d8835c0254"
 }

--- a/cli/project-runner/internal/projectrunner/control_play_mode_wait.go
+++ b/cli/project-runner/internal/projectrunner/control_play_mode_wait.go
@@ -28,16 +28,17 @@ const (
 var controlPlayModeStatePoll = 50 * time.Millisecond
 
 type controlPlayModeResponse struct {
-	IsPlaying              bool                          `json:"IsPlaying"`
-	IsPaused               bool                          `json:"IsPaused"`
-	Changed                bool                          `json:"Changed"`
-	WasAlreadyStopped      bool                          `json:"WasAlreadyStopped"`
-	ResumedFromPause       bool                          `json:"ResumedFromPause"`
-	BlockedByCompileErrors bool                          `json:"BlockedByCompileErrors"`
-	CompileErrorCount      int                           `json:"CompileErrorCount"`
-	CompileErrors          []controlPlayModeCompileError `json:"CompileErrors"`
-	Message                string                        `json:"Message"`
-	Warning                string                        `json:"Warning"`
+	IsPlaying               bool                          `json:"IsPlaying"`
+	IsPaused                bool                          `json:"IsPaused"`
+	Changed                 bool                          `json:"Changed"`
+	WasAlreadyStopped       bool                          `json:"WasAlreadyStopped"`
+	ResumedFromPause        bool                          `json:"ResumedFromPause"`
+	BlockedByCompileErrors  bool                          `json:"BlockedByCompileErrors"`
+	BlockedByUnsavedChanges bool                          `json:"BlockedByUnsavedChanges"`
+	CompileErrorCount       int                           `json:"CompileErrorCount"`
+	CompileErrors           []controlPlayModeCompileError `json:"CompileErrors"`
+	Message                 string                        `json:"Message"`
+	Warning                 string                        `json:"Warning"`
 }
 
 type controlPlayModeCompileError struct {
@@ -90,6 +91,12 @@ func runControlPlayModeWithStateWait(
 			spinner.Stop()
 			writeDebugTiming(stderr, controlPlayModeCommandName, time.Since(startedAt), outcome)
 			clierrors.WriteErrorEnvelope(stderr, controlPlayModeCompileErrorsError(connection.ProjectRoot, action, initialResponse))
+			return 1
+		}
+		if initialResponse.BlockedByUnsavedChanges {
+			spinner.Stop()
+			writeDebugTiming(stderr, controlPlayModeCommandName, time.Since(startedAt), outcome)
+			clierrors.WriteErrorEnvelope(stderr, controlPlayModeUnsavedChangesError(connection.ProjectRoot, action, initialResponse))
 			return 1
 		}
 		if controlPlayModeStateMatches(action, initialResponse) {
@@ -375,6 +382,29 @@ func controlPlayModeCompileErrorsError(
 			"CompileErrorCount": compileErrorCount,
 			"CompileErrors":     response.CompileErrors,
 			"Message":           response.Message,
+		},
+	}
+}
+
+func controlPlayModeUnsavedChangesError(
+	projectRoot string,
+	action string,
+	response controlPlayModeResponse,
+) clierrors.CLIError {
+	return clierrors.CLIError{
+		ErrorCode:   clierrors.ErrorCodeControlPlayModeUnsavedChanges,
+		Phase:       clierrors.ErrorPhaseExecution,
+		Message:     response.Message,
+		Retryable:   true,
+		SafeToRetry: true,
+		ProjectRoot: projectRoot,
+		Command:     controlPlayModeCommandName,
+		NextActions: []string{
+			"Save or discard the unsaved scene or prefab changes listed in the message, then retry.",
+			"If the active scene has no path (an Untitled scene), give it a path by saving it explicitly before retrying `uloop control-play-mode --action Play`.",
+		},
+		Details: map[string]any{
+			"RequestedAction": action,
 		},
 	}
 }

--- a/cli/project-runner/internal/projectrunner/control_play_mode_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/control_play_mode_wait_test.go
@@ -441,6 +441,80 @@ func TestRunControlPlayModeWithStateWaitFailsWhenCompileErrorsAppearDuringPollin
 	}
 }
 
+// Verifies that an unsaved-changes save failure on the initial Play response fails immediately
+// instead of falling through to the state-wait poll loop (Round-8: Untitled dirty scenes made
+// this timeout after 180s even though Unity had already given up synchronously).
+func TestRunControlPlayModeWithStateWaitFailsImmediatelyWhenUnsavedChangesBlockPlay(t *testing.T) {
+	originalPoll := controlPlayModeStatePoll
+	controlPlayModeStatePoll = time.Millisecond
+	t.Cleanup(func() {
+		controlPlayModeStatePoll = originalPoll
+	})
+
+	listener := newLoopbackIpcListener(t)
+
+	requests := make(chan map[string]any, 2)
+	serverErr := make(chan error, 1)
+	go serveControlPlayModeResponses(
+		listener,
+		requests,
+		serverErr,
+		[]string{
+			`{"IsPlaying":false,"IsPaused":false,"BlockedByUnsavedChanges":true,"Message":"Play mode could not start because unsaved scene or prefab changes could not be saved. Unsaved changes: Untitled scene"}`,
+		})
+
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: listener.Addr().Network(),
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runControlPlayModeWithStateWait(
+		context.Background(),
+		connection,
+		map[string]any{
+			controlPlayModeActionParam:  "Play",
+			controlPlayModeTimeoutParam: 1,
+		},
+		&stdout,
+		&stderr)
+
+	if code != 1 {
+		t.Fatalf("expected unsaved-changes failure, got %d with stdout %s stderr %s", code, stdout.String(), stderr.String())
+	}
+
+	var envelope clierrors.CLIErrorEnvelope
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\n%s", err, stderr.String())
+	}
+	if envelope.Error.ErrorCode != clierrors.ErrorCodeControlPlayModeUnsavedChanges {
+		t.Fatalf("error code mismatch: %#v", envelope.Error)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("Untitled scene")) {
+		t.Fatalf("save-failure message missing from stderr: %s", stderr.String())
+	}
+
+	firstRequest := readControlPlayModeRequest(t, requests)
+	if _, ok := firstRequest[controlPlayModeStatusOnlyParam]; ok {
+		t.Fatalf("initial request should not be status-only: %#v", firstRequest)
+	}
+	select {
+	case secondRequest := <-requests:
+		t.Fatalf("blocked unsaved changes should not trigger status polling: %#v", secondRequest)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed: %v", err)
+	default:
+	}
+}
+
 // Verifies that live Unity tool caches using number schemas still drive integer wait budgets.
 func TestControlPlayModeTimeoutSecondsAcceptsFloatSchemaValue(t *testing.T) {
 	params := map[string]any{controlPlayModeTimeoutParam: 12.0}

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "15c05452ea2fa09b729ea0916c41f168ce5d4c8f"
+  "sharedInputsHash": "5faa8097cbbd0ba6991962f620fd18a68fbb2168"
 }


### PR DESCRIPTION
## Summary
- `control-play-mode --action Play` no longer waits the full timeout (up to 180s) when Play mode cannot start because unsaved editor changes could not be quietly saved (for example, an Untitled scene).

## User Impact
- Before: if the active scene had no path (an Untitled scene) or otherwise could not be saved, Unity's synchronous handler gave up in milliseconds, but the response looked identical on the wire to "no state change yet." The CLI then polled Unity's status for the full wait timeout before finally reporting a generic "did not complete" error, hiding the real cause.
- After: the CLI recognizes this failure immediately and returns an actionable error listing exactly which scene/prefab changes could not be saved, with guidance to save or discard them (or give an Untitled scene a path) before retrying.

## Changes
- `Packages/src/Editor/FirstPartyTools/ControlPlayMode`: added a `BlockedByUnsavedChanges` response field, set when `SaveDirtyEditorChangesBeforePlayStart` fails, mirroring the existing `BlockedByCompileErrors` field.
- `cli/project-runner`: `runControlPlayModeWithStateWait` now checks `BlockedByUnsavedChanges` on the initial response and fails fast with a new `CONTROL_PLAY_MODE_UNSAVED_CHANGES` error instead of entering the state-wait poll loop.

## Verification
- Root-caused via a live reproduction in this checkout: created an Untitled dirty scene with `execute-dynamic-code`, then ran `control-play-mode --action Play`, which hung for the full timeout before this fix (`EditorApplication.isPlaying` stayed `false` throughout, confirming Unity had already given up).
- TDD: added a failing Go test (`TestRunControlPlayModeWithStateWaitFailsImmediatelyWhenUnsavedChangesBlockPlay`) reproducing the fall-through-to-polling bug against the pre-fix code, confirmed it failed with a generic timeout, then implemented the fix. Added assertions to the existing C# unit tests (`ExecuteAsync_WhenPlayStartSaveFails_DoesNotEnterPlayMode`, `ExecuteAsync_WhenPlayStartLeavesUnsavedChanges_DoesNotEnterPlayMode`) confirming `BlockedByUnsavedChanges` is set; confirmed both failed (`Expected: True / But was: False`) before the fix.
- Re-ran the live repro after the fix: `control-play-mode --action Play` against the same Untitled dirty scene now returns the new error in well under a second instead of hanging.
- `sh scripts/check-go-cli.sh`: format/vet/lint 0 issues, all Go packages pass (including the new test).
- `go test -run TestProductionGoFilesStayFocused ./...` (release-automation): pass.
- `sh scripts/stamp-release-inputs.sh`: re-run and committed, since `cli/common` changed.
- `dist/darwin-arm64/uloop compile`: 0 errors / 0 warnings.
- `uloop run-tests` (EditMode, `ControlPlayModeUseCaseTests`): 18/18 passed after the fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

