### PR TITLE
feat: Add key-state diagnostics to simulate-keyboard rejection responses

### DIFF
--- a/Assets/Tests/PlayMode/KeyboardInputSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/PlayMode/KeyboardInputSimulationResponseFactoryTests.cs
@@ -113,6 +113,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         }
 
         /// <summary>
+        /// Verifies the KeyDown "already held" rejection reports the tracker/device key-state
+        /// diagnostics without changing the existing rejection message or Success=false outcome.
+        /// </summary>
+        [TestCase(true)]
+        [TestCase(false)]
+        public void AlreadyHeldRejection_WithDeviceState_MapsRejectionAndKeyStateDiagnostics(
+            bool deviceIsPressed)
+        {
+            SimulateKeyboardResponse response = KeyboardInputSimulationResponseFactory.AlreadyHeldRejection(
+                "W",
+                deviceIsPressed);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("Key 'W' is already held down. Call KeyUp first."));
+            Assert.That(response.Action, Is.EqualTo(UnityCliLoopKeyboardAction.KeyDown.ToString()));
+            Assert.That(response.KeyName, Is.EqualTo("W"));
+            Assert.That(response.KeyStateTrackedHeld, Is.True);
+            Assert.That(response.KeyStateDeviceIsPressed, Is.EqualTo(deviceIsPressed));
+        }
+
+        /// <summary>
+        /// Verifies the KeyUp "not currently held" rejection reports the tracker/device key-state
+        /// diagnostics without changing the existing rejection message or Success=false outcome.
+        /// </summary>
+        [TestCase(true)]
+        [TestCase(false)]
+        public void NotHeldRejection_WithDeviceState_MapsRejectionAndKeyStateDiagnostics(
+            bool deviceIsPressed)
+        {
+            SimulateKeyboardResponse response = KeyboardInputSimulationResponseFactory.NotHeldRejection(
+                "W",
+                deviceIsPressed);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("Key 'W' is not currently held. Call KeyDown first."));
+            Assert.That(response.Action, Is.EqualTo(UnityCliLoopKeyboardAction.KeyUp.ToString()));
+            Assert.That(response.KeyName, Is.EqualTo("W"));
+            Assert.That(response.KeyStateTrackedHeld, Is.False);
+            Assert.That(response.KeyStateDeviceIsPressed, Is.EqualTo(deviceIsPressed));
+        }
+
+        /// <summary>
         /// Test double that records Pause Point state without pausing the Unity Editor.
         /// </summary>
         private sealed class FakePauseController : IUloopPausePointPauseController

--- a/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
+++ b/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
@@ -727,6 +727,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             });
             Assert.IsFalse(lastResponse.Success);
             StringAssert.Contains("already held", lastResponse.Message);
+            Assert.That(lastResponse.KeyStateTrackedHeld, Is.True);
+            Assert.That(lastResponse.KeyStateDeviceIsPressed, Is.Not.Null);
         }
 
         [UnityTest]
@@ -742,6 +744,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
 
             Assert.IsFalse(lastResponse.Success);
             StringAssert.Contains("not currently held", lastResponse.Message);
+            Assert.That(lastResponse.KeyStateTrackedHeld, Is.False);
+            Assert.That(lastResponse.KeyStateDeviceIsPressed, Is.Not.Null);
         }
 
         [UnityTest]

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs
@@ -182,13 +182,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (KeyboardKeyState.IsKeyHeld(key))
             {
-                return new SimulateKeyboardResponse
-                {
-                    Success = false,
-                    Message = $"Key '{keyName}' is already held down. Call KeyUp first.",
-                    Action = UnityCliLoopKeyboardAction.KeyDown.ToString(),
-                    KeyName = keyName
-                };
+                return KeyboardInputSimulationResponseFactory.AlreadyHeldRejection(keyName, keyboard[key].isPressed);
             }
 
             bool keyDownApplied = false;
@@ -296,13 +290,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (!KeyboardKeyState.IsKeyHeld(key))
             {
-                return new SimulateKeyboardResponse
-                {
-                    Success = false,
-                    Message = $"Key '{keyName}' is not currently held. Call KeyDown first.",
-                    Action = UnityCliLoopKeyboardAction.KeyUp.ToString(),
-                    KeyName = keyName
-                };
+                return KeyboardInputSimulationResponseFactory.NotHeldRejection(keyName, keyboard[key].isPressed);
             }
 
             InputSimulationWaitOutcome releaseOutcome =

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputSimulationResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputSimulationResponseFactory.cs
@@ -34,6 +34,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return result;
         }
 
+        internal static SimulateKeyboardResponse AlreadyHeldRejection(string keyName, bool deviceIsPressed)
+        {
+            return new SimulateKeyboardResponse
+            {
+                Success = false,
+                Message = $"Key '{keyName}' is already held down. Call KeyUp first.",
+                Action = UnityCliLoopKeyboardAction.KeyDown.ToString(),
+                KeyName = keyName,
+                KeyStateTrackedHeld = true,
+                KeyStateDeviceIsPressed = deviceIsPressed
+            };
+        }
+
+        internal static SimulateKeyboardResponse NotHeldRejection(string keyName, bool deviceIsPressed)
+        {
+            return new SimulateKeyboardResponse
+            {
+                Success = false,
+                Message = $"Key '{keyName}' is not currently held. Call KeyDown first.",
+                Action = UnityCliLoopKeyboardAction.KeyUp.ToString(),
+                KeyName = keyName,
+                KeyStateTrackedHeld = false,
+                KeyStateDeviceIsPressed = deviceIsPressed
+            };
+        }
+
         internal static SimulateKeyboardResponse TimedOutKeyResult(
             UnityCliLoopKeyboardAction action,
             string keyName)

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
@@ -47,6 +47,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public bool? PressEdgeKeyAlreadyPressedBeforeQueue { get; set; }
 
+        // The following two KeyState* fields are set only on the KeyDown "already held down"
+        // and KeyUp "not currently held" rejections, to help diagnose whether the uloop-side
+        // tracker and the Input System device actually agree, without changing whether the
+        // action is accepted or rejected.
+
+        /// <summary>
+        /// Whether Unity CLI Loop's own key-hold tracker (not the Input System device) considered
+        /// the key held at the moment of rejection.
+        /// </summary>
+        public bool? KeyStateTrackedHeld { get; set; }
+
+        /// <summary>
+        /// Whether the Input System device (<c>keyboard[key].isPressed</c>) reported the key as
+        /// pressed at the moment of rejection.
+        /// </summary>
+        public bool? KeyStateDeviceIsPressed { get; set; }
+
         public SimulateKeyboardResponse()
         {
         }


### PR DESCRIPTION
## Summary
- `simulate-keyboard`'s `KeyDown`/`KeyUp` rejection responses now carry key-state diagnostics, so a rejection can be diagnosed from the response alone instead of requiring a fresh repro.

## User Impact
- Before: when `KeyDown` rejected with "already held down" or `KeyUp` rejected with "not currently held," the response gave no way to tell whether uloop's own key-hold tracker and the actual Input System device state agreed with each other.
- After: both rejections include `KeyStateTrackedHeld` (uloop's own tracker) and `KeyStateDeviceIsPressed` (the live Input System device state) at the moment of rejection. This is diagnostics-only — whether the action is accepted or rejected is unchanged.

## Changes
- `Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs`: added the two nullable diagnostic fields, following the existing `PressEdge*` field convention.
- `Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputSimulationResponseFactory.cs`: added `AlreadyHeldRejection`/`NotHeldRejection` factory methods that build these rejection responses, keeping the diagnostic-field construction unit-testable without a live Input System device.
- `Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs`: both rejection sites now call the new factory methods instead of constructing the response inline.

## Verification
- TDD: wrote tests for the new factory methods first, confirmed they failed to compile (the methods did not exist yet), then implemented the methods to pass.
- `dist/darwin-arm64/uloop compile`: 0 errors / 0 warnings.
- `uloop run-tests` (PlayMode): `KeyboardInputSimulationResponseFactoryTests` 8/8 passed; full `SimulateKeyboardTests` suite 37/37 passed (including the extended `KeyDown_WhenAlreadyHeld_Should_ReturnFailure` / `KeyUp_WhenNotHeld_Should_ReturnFailure` assertions on the new fields).
- Regression harness `scripts/regression-harness-key-state-after-pause-interruption.sh`: fails identically with and without this change (confirmed by stashing this PR's diff and re-running against the unmodified base) — a pre-existing pause-point marker-miss flake unrelated to this PR, not a regression it introduces.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

