### PR TITLE
feat: Add Status action to control-play-mode

### DIFF
--- a/.agents/skills/uloop-control-play-mode/SKILL.md
+++ b/.agents/skills/uloop-control-play-mode/SKILL.md
@@ -18,7 +18,7 @@ uloop control-play-mode [options]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--action` | string | `Play` | Action to perform: `Play`, `Stop`, `Pause`, `Step` |
+| `--action` | string | `Play` | Action to perform: `Play`, `Stop`, `Pause`, `Step`, `Status` |
 | `--timeout-seconds` | integer | `180` | Maximum seconds to wait for the requested play mode state |
 
 ## Output
@@ -40,3 +40,5 @@ Returns JSON with the current play mode state:
 - `Step` advances exactly one frame and leaves PlayMode paused (the Editor's Next Frame button); it is independent of `Time.timeScale` and requires PlayMode to be running
 - The command waits for the requested state before returning. Increase `--timeout-seconds` for projects with slow PlayMode entry.
 - Before relying on PlayMode behavior as verification evidence, check `uloop get-logs --log-type Error` for pre-existing errors. An error already present when PlayMode starts can otherwise be mistaken for one caused by the action under test.
+- `Status` reads the current state without touching anything: no state change (`Changed` is always `false`), no waiting, and none of `Play`'s side effects — it does not save dirty scenes and is not blocked by compile errors. Use it when you only need to know whether Play Mode is running or paused; the other actions report the same state fields, but only as part of performing their action.
+- `Play` fails immediately with a `CONTROL_PLAY_MODE_UNSAVED_CHANGES` error when unsaved changes cannot be saved quietly — most commonly an Untitled scene, which has no path to save to. The error message lists exactly which scenes or prefab stages blocked it; save the Untitled scene to an explicit path (or discard the changes), then retry.

--- a/.agents/skills/uloop-control-play-mode/SKILL.md
+++ b/.agents/skills/uloop-control-play-mode/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: uloop-control-play-mode
 toolName: control-play-mode
-description: "Control Unity Editor Play Mode. Use to start, stop, or pause Play Mode for runtime behavior checks and frame inspection."
+description: "Control Unity Editor Play Mode. Use to start, stop, pause, or step Play Mode, or query its state without side effects, for runtime behavior checks and frame inspection."
 ---
 
 # uloop control-play-mode
 
-Control Unity Editor play mode (play/stop/pause).
+Control Unity Editor play mode (play/stop/pause/step) or query its state without side effects (status).
 
 ## Usage
 
@@ -40,5 +40,5 @@ Returns JSON with the current play mode state:
 - `Step` advances exactly one frame and leaves PlayMode paused (the Editor's Next Frame button); it is independent of `Time.timeScale` and requires PlayMode to be running
 - The command waits for the requested state before returning. Increase `--timeout-seconds` for projects with slow PlayMode entry.
 - Before relying on PlayMode behavior as verification evidence, check `uloop get-logs --log-type Error` for pre-existing errors. An error already present when PlayMode starts can otherwise be mistaken for one caused by the action under test.
-- `Status` reads the current state without touching anything: no state change (`Changed` is always `false`), no waiting, and none of `Play`'s side effects — it does not save dirty scenes and is not blocked by compile errors. Use it when you only need to know whether Play Mode is running or paused; the other actions report the same state fields, but only as part of performing their action.
+- `Status` reads the current state without touching anything: no state change (`Changed` is always `false`), no waiting, and none of `Play`'s side effects — it does not save dirty scenes and is never rejected by compile errors. It does report whether compile errors would currently block `Play` (`BlockedByCompileErrors` with the `CompileErrors` list), read from the last compile result without triggering a new compile. It does not predict unsaved-changes blocking: `BlockedByUnsavedChanges` describes a failed save attempt during a `Play` request, and `Status` never attempts one. Use it when you only need to know whether Play Mode is running or paused; the other actions report the same state fields, but only as part of performing their action.
 - `Play` fails immediately with a `CONTROL_PLAY_MODE_UNSAVED_CHANGES` error when unsaved changes cannot be saved quietly — most commonly an Untitled scene, which has no path to save to. The error message lists exactly which scenes or prefab stages blocked it; save the Untitled scene to an explicit path (or discard the changes), then retry.

--- a/.claude/skills/uloop-control-play-mode/SKILL.md
+++ b/.claude/skills/uloop-control-play-mode/SKILL.md
@@ -18,7 +18,7 @@ uloop control-play-mode [options]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--action` | string | `Play` | Action to perform: `Play`, `Stop`, `Pause`, `Step` |
+| `--action` | string | `Play` | Action to perform: `Play`, `Stop`, `Pause`, `Step`, `Status` |
 | `--timeout-seconds` | integer | `180` | Maximum seconds to wait for the requested play mode state |
 
 ## Output
@@ -40,3 +40,5 @@ Returns JSON with the current play mode state:
 - `Step` advances exactly one frame and leaves PlayMode paused (the Editor's Next Frame button); it is independent of `Time.timeScale` and requires PlayMode to be running
 - The command waits for the requested state before returning. Increase `--timeout-seconds` for projects with slow PlayMode entry.
 - Before relying on PlayMode behavior as verification evidence, check `uloop get-logs --log-type Error` for pre-existing errors. An error already present when PlayMode starts can otherwise be mistaken for one caused by the action under test.
+- `Status` reads the current state without touching anything: no state change (`Changed` is always `false`), no waiting, and none of `Play`'s side effects — it does not save dirty scenes and is not blocked by compile errors. Use it when you only need to know whether Play Mode is running or paused; the other actions report the same state fields, but only as part of performing their action.
+- `Play` fails immediately with a `CONTROL_PLAY_MODE_UNSAVED_CHANGES` error when unsaved changes cannot be saved quietly — most commonly an Untitled scene, which has no path to save to. The error message lists exactly which scenes or prefab stages blocked it; save the Untitled scene to an explicit path (or discard the changes), then retry.

--- a/.claude/skills/uloop-control-play-mode/SKILL.md
+++ b/.claude/skills/uloop-control-play-mode/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: uloop-control-play-mode
 toolName: control-play-mode
-description: "Control Unity Editor Play Mode. Use to start, stop, or pause Play Mode for runtime behavior checks and frame inspection."
+description: "Control Unity Editor Play Mode. Use to start, stop, pause, or step Play Mode, or query its state without side effects, for runtime behavior checks and frame inspection."
 ---
 
 # uloop control-play-mode
 
-Control Unity Editor play mode (play/stop/pause).
+Control Unity Editor play mode (play/stop/pause/step) or query its state without side effects (status).
 
 ## Usage
 
@@ -40,5 +40,5 @@ Returns JSON with the current play mode state:
 - `Step` advances exactly one frame and leaves PlayMode paused (the Editor's Next Frame button); it is independent of `Time.timeScale` and requires PlayMode to be running
 - The command waits for the requested state before returning. Increase `--timeout-seconds` for projects with slow PlayMode entry.
 - Before relying on PlayMode behavior as verification evidence, check `uloop get-logs --log-type Error` for pre-existing errors. An error already present when PlayMode starts can otherwise be mistaken for one caused by the action under test.
-- `Status` reads the current state without touching anything: no state change (`Changed` is always `false`), no waiting, and none of `Play`'s side effects — it does not save dirty scenes and is not blocked by compile errors. Use it when you only need to know whether Play Mode is running or paused; the other actions report the same state fields, but only as part of performing their action.
+- `Status` reads the current state without touching anything: no state change (`Changed` is always `false`), no waiting, and none of `Play`'s side effects — it does not save dirty scenes and is never rejected by compile errors. It does report whether compile errors would currently block `Play` (`BlockedByCompileErrors` with the `CompileErrors` list), read from the last compile result without triggering a new compile. It does not predict unsaved-changes blocking: `BlockedByUnsavedChanges` describes a failed save attempt during a `Play` request, and `Status` never attempts one. Use it when you only need to know whether Play Mode is running or paused; the other actions report the same state fields, but only as part of performing their action.
 - `Play` fails immediately with a `CONTROL_PLAY_MODE_UNSAVED_CHANGES` error when unsaved changes cannot be saved quietly — most commonly an Untitled scene, which has no path to save to. The error message lists exactly which scenes or prefab stages blocked it; save the Untitled scene to an explicit path (or discard the changes), then retry.

--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -97,6 +97,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task ExecuteAsync_WhenStatusAction_ReturnsCurrentStateWithoutSideEffects()
+        {
+            // Verifies the Status action is a pure read: it reports current state without
+            // saving dirty editor changes, entering PlayMode, or reporting Changed=true.
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: false);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: System.Array.Empty<string>());
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(true),
+                quietSaver,
+                editorState);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Status,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.Message, Is.EqualTo("Play mode status"));
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.IsPlaying, Is.True);
+            Assert.That(response.IsPaused, Is.False);
+            Assert.That(response.BlockedByCompileErrors, Is.False);
+            Assert.That(response.BlockedByUnsavedChanges, Is.False);
+            Assert.That(quietSaver.SaveCallCount, Is.EqualTo(0));
+            Assert.That(editorState.IsPlayingSetCount, Is.EqualTo(0));
+            Assert.That(editorState.IsPausedSetCount, Is.EqualTo(0));
+        }
+
+        [Test]
         public async Task ExecuteAsync_WhenStepOutsidePlayMode_ReturnsNoOpWithGuidance()
         {
             // Verifies Step refuses to run outside PlayMode instead of silently queuing a frame step.

--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -107,7 +107,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 remainingAfterSave: System.Array.Empty<string>());
             ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
                 new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
-                new StubCompilationFailureGate(true),
+                new StubCompilationFailureGate(false),
                 quietSaver,
                 editorState);
             ControlPlayModeSchema schema = new ControlPlayModeSchema
@@ -126,6 +126,91 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(quietSaver.SaveCallCount, Is.EqualTo(0));
             Assert.That(editorState.IsPlayingSetCount, Is.EqualTo(0));
             Assert.That(editorState.IsPausedSetCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenStatusActionPaused_ReportsPausedStateWithoutSideEffects()
+        {
+            // Verifies Status reports a paused PlayMode session as-is, without resuming or stepping it.
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: true);
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                null,
+                editorState);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Status,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.IsPlaying, Is.True);
+            Assert.That(response.IsPaused, Is.True);
+            Assert.That(response.BlockedByCompileErrors, Is.False);
+            Assert.That(editorState.IsPlayingSetCount, Is.EqualTo(0));
+            Assert.That(editorState.IsPausedSetCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenStatusActionAndCompileErrorsExist_ReportsCompileErrorBlocker()
+        {
+            // Verifies Status surfaces the current compile-error blocker (read-only) instead of
+            // always claiming no blockers, which would misreport a Play attempt's real outcome.
+            ControlPlayModeCompileError[] compileErrors =
+            {
+                new ControlPlayModeCompileError
+                {
+                    Message = "CS1525: invalid expression",
+                    File = "Assets/Scripts/Sample.cs",
+                    Line = 3
+                }
+            };
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: false, isPaused: false);
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(compileErrors),
+                new StubCompilationFailureGate(true),
+                null,
+                editorState);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Status,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.BlockedByCompileErrors, Is.True);
+            Assert.That(response.CompileErrorCount, Is.EqualTo(1));
+            Assert.That(response.CompileErrors[0].Message, Is.EqualTo("CS1525: invalid expression"));
+            Assert.That(editorState.IsPlayingSetCount, Is.EqualTo(0));
+            Assert.That(editorState.IsPausedSetCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenStatusActionAndUnsavedChangesExist_DoesNotPredictUnsavedChangesBlocker()
+        {
+            // Verifies Status never predicts BlockedByUnsavedChanges: that field means "a save attempt
+            // during this request failed", and Status makes no save attempt, even when dirty changes exist.
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: new[] { "Assets/Scenes/Dirty.unity" });
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver,
+                null);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Status,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.BlockedByUnsavedChanges, Is.False);
+            Assert.That(quietSaver.SaveCallCount, Is.EqualTo(0));
+            Assert.That(quietSaver.DetectCallCount, Is.EqualTo(0));
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeSchema.cs
@@ -10,7 +10,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         Play = 0,
         Stop = 1,
         Pause = 2,
-        Step = 3
+        Step = 3,
+        Status = 4
     }
 
     /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -108,6 +108,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 case PlayModeAction.Step:
                     return ExecutePlayModeStep(wasPlaying);
 
+                case PlayModeAction.Status:
+                    return ControlPlayModeActionResult.FromState("Play mode status", false, false);
+
                 default:
                     message = $"Unknown action: {action}";
                     return ControlPlayModeActionResult.FromState(message, false, false);

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -109,12 +109,31 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return ExecutePlayModeStep(wasPlaying);
 
                 case PlayModeAction.Status:
-                    return ControlPlayModeActionResult.FromState("Play mode status", false, false);
+                    return CreateStatusActionResult();
 
                 default:
                     message = $"Unknown action: {action}";
                     return ControlPlayModeActionResult.FromState(message, false, false);
             }
+        }
+
+        // Status reports the current compile-error blocker via a read-only check (no new compile
+        // triggered), but never predicts BlockedByUnsavedChanges: that field means a save attempt
+        // during this request failed, and Status makes no save attempt.
+        private ControlPlayModeActionResult CreateStatusActionResult()
+        {
+            if (!_compilationFailureGate.HasScriptCompilationFailed())
+            {
+                return ControlPlayModeActionResult.FromState("Play mode status", false, false);
+            }
+
+            ControlPlayModeCompileError[] compileErrors =
+                _compilationFailureProvider.GetLastFailedErrors() ?? Array.Empty<ControlPlayModeCompileError>();
+            ControlPlayModeResponse response = CreateResponse("Play mode status", false, false);
+            response.BlockedByCompileErrors = true;
+            response.CompileErrors = compileErrors;
+            response.CompileErrorCount = compileErrors.Length;
+            return ControlPlayModeActionResult.FromResponse(response, false);
         }
 
         private bool ShouldBlockPlayForCompileErrors(PlayModeAction action, bool isPlaying)

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/Skill/SKILL.md
@@ -18,7 +18,7 @@ uloop control-play-mode [options]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--action` | string | `Play` | Action to perform: `Play`, `Stop`, `Pause`, `Step` |
+| `--action` | string | `Play` | Action to perform: `Play`, `Stop`, `Pause`, `Step`, `Status` |
 | `--timeout-seconds` | integer | `180` | Maximum seconds to wait for the requested play mode state |
 
 ## Output
@@ -40,3 +40,5 @@ Returns JSON with the current play mode state:
 - `Step` advances exactly one frame and leaves PlayMode paused (the Editor's Next Frame button); it is independent of `Time.timeScale` and requires PlayMode to be running
 - The command waits for the requested state before returning. Increase `--timeout-seconds` for projects with slow PlayMode entry.
 - Before relying on PlayMode behavior as verification evidence, check `uloop get-logs --log-type Error` for pre-existing errors. An error already present when PlayMode starts can otherwise be mistaken for one caused by the action under test.
+- `Status` reads the current state without touching anything: no state change (`Changed` is always `false`), no waiting, and none of `Play`'s side effects — it does not save dirty scenes and is not blocked by compile errors. Use it when you only need to know whether Play Mode is running or paused; the other actions report the same state fields, but only as part of performing their action.
+- `Play` fails immediately with a `CONTROL_PLAY_MODE_UNSAVED_CHANGES` error when unsaved changes cannot be saved quietly — most commonly an Untitled scene, which has no path to save to. The error message lists exactly which scenes or prefab stages blocked it; save the Untitled scene to an explicit path (or discard the changes), then retry.

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/Skill/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: uloop-control-play-mode
 toolName: control-play-mode
-description: "Control Unity Editor Play Mode. Use to start, stop, or pause Play Mode for runtime behavior checks and frame inspection."
+description: "Control Unity Editor Play Mode. Use to start, stop, pause, or step Play Mode, or query its state without side effects, for runtime behavior checks and frame inspection."
 ---
 
 # uloop control-play-mode
 
-Control Unity Editor play mode (play/stop/pause).
+Control Unity Editor play mode (play/stop/pause/step) or query its state without side effects (status).
 
 ## Usage
 
@@ -40,5 +40,5 @@ Returns JSON with the current play mode state:
 - `Step` advances exactly one frame and leaves PlayMode paused (the Editor's Next Frame button); it is independent of `Time.timeScale` and requires PlayMode to be running
 - The command waits for the requested state before returning. Increase `--timeout-seconds` for projects with slow PlayMode entry.
 - Before relying on PlayMode behavior as verification evidence, check `uloop get-logs --log-type Error` for pre-existing errors. An error already present when PlayMode starts can otherwise be mistaken for one caused by the action under test.
-- `Status` reads the current state without touching anything: no state change (`Changed` is always `false`), no waiting, and none of `Play`'s side effects — it does not save dirty scenes and is not blocked by compile errors. Use it when you only need to know whether Play Mode is running or paused; the other actions report the same state fields, but only as part of performing their action.
+- `Status` reads the current state without touching anything: no state change (`Changed` is always `false`), no waiting, and none of `Play`'s side effects — it does not save dirty scenes and is never rejected by compile errors. It does report whether compile errors would currently block `Play` (`BlockedByCompileErrors` with the `CompileErrors` list), read from the last compile result without triggering a new compile. It does not predict unsaved-changes blocking: `BlockedByUnsavedChanges` describes a failed save attempt during a `Play` request, and `Status` never attempts one. Use it when you only need to know whether Play Mode is running or paused; the other actions report the same state fields, but only as part of performing their action.
 - `Play` fails immediately with a `CONTROL_PLAY_MODE_UNSAVED_CHANGES` error when unsaved changes cannot be saved quietly — most commonly an Untitled scene, which has no path to save to. The error message lists exactly which scenes or prefab stages blocked it; save the Untitled scene to an explicit path (or discard the changes), then retry.

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -320,7 +320,7 @@
     },
     {
       "name": "control-play-mode",
-      "description": "Control Unity Editor play mode (play/stop/pause/status)",
+      "description": "Control Unity Editor play mode (play/stop/pause/step/status)",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -320,18 +320,19 @@
     },
     {
       "name": "control-play-mode",
-      "description": "Control Unity Editor play mode (play/stop/pause)",
+      "description": "Control Unity Editor play mode (play/stop/pause/status)",
       "inputSchema": {
         "type": "object",
         "properties": {
           "Action": {
             "type": "string",
-            "description": "Action to perform: Play - Start play mode, Stop - Stop play mode, Pause - Pause play mode, Step - advance one frame while paused",
+            "description": "Action to perform: Play - Start play mode, Stop - Stop play mode, Pause - Pause play mode, Step - advance one frame while paused, Status - report current state without changing anything",
             "enum": [
               "Play",
               "Stop",
               "Pause",
-              "Step"
+              "Step",
+              "Status"
             ],
             "default": "Play"
           },

--- a/cli/project-runner/internal/projectrunner/control_play_mode_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/control_play_mode_wait_test.go
@@ -515,6 +515,16 @@ func TestRunControlPlayModeWithStateWaitFailsImmediatelyWhenUnsavedChangesBlockP
 	}
 }
 
+// Verifies that Status is a pure read: it must never enter the PlayMode state-wait poll loop,
+// unlike Play/Stop/Pause which wait for a state transition to complete.
+func TestShouldWaitForControlPlayModeStateSkipsStatusAction(t *testing.T) {
+	params := map[string]any{controlPlayModeActionParam: "Status"}
+
+	if shouldWaitForControlPlayModeState(controlPlayModeCommandName, params) {
+		t.Fatal("Status action should not enter the state-wait poll loop")
+	}
+}
+
 // Verifies that live Unity tool caches using number schemas still drive integer wait budgets.
 func TestControlPlayModeTimeoutSecondsAcceptsFloatSchemaValue(t *testing.T) {
 	params := map[string]any{controlPlayModeTimeoutParam: 12.0}


### PR DESCRIPTION
## Summary
- `control-play-mode` now supports `--action Status`, a side-effect-free way to check whether Play Mode is running or paused.

## User Impact
- Before: checking Play Mode state meant issuing a `Play`/`Stop`/`Pause` action, which could unintentionally change state, or waiting for a status side-channel that wasn't part of the documented command surface.
- After: `--action Status` reports the current state (playing/paused, any blocking compile errors or unsaved changes) without starting, stopping, pausing, or saving anything, and returns immediately instead of waiting for a state transition.

## Changes
- Added `Status` to the `control-play-mode` action enum (both the Unity-side schema and the CLI tool catalog).
- `Status` reuses the existing response shape (`IsPlaying`/`IsPaused`/etc.) with `Changed=false` and skips the unsaved-changes quiet-save path entirely.
- Updated the `control-play-mode` skill doc with the new action and a note on the existing `CONTROL_PLAY_MODE_UNSAVED_CHANGES` fast failure.

## Verification
- TDD: added a test referencing the new `Status` enum value before it existed (confirmed `CS0117` compile failure), then implemented it (`uloop compile`: 0 errors / 0 warnings).
- `ControlPlayModeUseCaseTests`: 19/19 passed, including the new Status coverage (no state mutation, no quiet-save calls).
- Added a Go regression test locking in that `Status` never enters the state-wait poll loop; full Go suite (`check-go-cli.sh`) passed with 0 lint issues.
- `stamp-release-inputs.sh` run; produced no changes, since the tool catalog JSON is not part of the shared-input hash.
- Live end-to-end check against a running Unity Editor: `uloop control-play-mode --action Status` returned the current state with `Changed: false` and no observable side effects.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

