### PR TITLE
docs: Document ULOOP_PROJECT_RUNNER_PATH project runner override

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,10 @@ When changing Go source files under any Go module (`cli/common`, `cli/dispatcher
 equivalent of Go CLI CI (format, vet, lint, tests, binary rebuild). Use `scripts/build-go-cli.sh`
 to refresh `dist` binaries; they are git-ignored and must not be committed.
 
+To validate an unreleased project runner from an external Unity project, set the
+`ULOOP_PROJECT_RUNNER_PATH` environment variable to a locally built binary — it overrides the
+pin-based resolution entirely (see `docs/project-runner-pin.md`).
+
 ## Unity Freeze Prevention
 
 Unity EditMode tests can freeze the Editor. Never run multiple `uloop run-tests` commands in

--- a/docs/project-runner-pin.md
+++ b/docs/project-runner-pin.md
@@ -21,6 +21,27 @@ There is no dispatcher⇄package integer contract generation; the pin's semver
 floor is the only dispatcher gate. The IPC `protocolVersion` pair (see
 `docs/protocol-version.md`) is the only integer generation in the system.
 
+## Local override: `ULOOP_PROJECT_RUNNER_PATH`
+
+The environment variable `ULOOP_PROJECT_RUNNER_PATH` (defined in
+`cli/dispatcher/internal/nativepath/path.go`) makes the dispatcher run the
+project runner binary at that path instead of resolving one from the pin.
+`resolveDispatcherRealCLI` checks it before everything else — pin validation,
+the sibling binary next to the dispatcher, the version cache, and the GitHub
+release download are all skipped. The path must point at an existing executable
+file, or the dispatcher fails with an explicit error rather than falling back.
+
+This override exists for dogfooding checkouts: release-please stamps
+`projectRunnerVersion` ahead of the matching GitHub release, so the normal
+download path 404s until the release is published. Pointing the variable at a
+locally built binary (e.g. `dist/darwin-arm64/uloop-project-runner`, refreshed
+via `scripts/build-go-cli.sh`) lets you exercise unreleased project-runner and
+`cli/common` changes against real Unity projects before merge. Unset the
+variable to return to normal pin-resolved behavior.
+
+Related overrides in the same file: `ULOOP_INSTALL_DIR` (dispatcher install
+directory) and `ULOOP_CACHE_DIR` (project runner download cache).
+
 ## Pin format discipline
 
 The pin evolves additively only — never delete or rename an existing field.


### PR DESCRIPTION
## Summary

`ULOOP_PROJECT_RUNNER_PATH` (defined in `cli/dispatcher/internal/nativepath/path.go`, consumed first in `resolveDispatcherRealCLI`) lets the dispatcher run a locally built project runner instead of resolving one from the pin. It is essential for dogfooding checkouts — release-please stamps `projectRunnerVersion` ahead of the published GitHub release, so the normal download path 404s — yet no document in the repository mentioned it.

## Changes

- `docs/project-runner-pin.md`: new "Local override: `ULOOP_PROJECT_RUNNER_PATH`" section describing precedence (checked before pin validation, sibling binary, cache, and download), the executable-file requirement, the dogfooding rationale, and the sibling `ULOOP_INSTALL_DIR` / `ULOOP_CACHE_DIR` overrides.
- `AGENTS.md` (Native Go CLI Validation): one-paragraph pointer for validating unreleased Go changes from an external Unity project.

Docs-only change; no code, scripts, or shared release inputs touched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

