### PR TITLE
ci: Add release approval pending notify workflow to default branch

### DIFF
--- a/.github/workflows/release-approval-pending-notify.yml
+++ b/.github/workflows/release-approval-pending-notify.yml
@@ -1,0 +1,47 @@
+name: Release Approval Pending Notify
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - native-cli-publish
+      - dispatcher-publish
+    types:
+      - completed
+
+permissions:
+  actions: read
+  issues: write
+  contents: read
+
+concurrency:
+  group: release-approval-pending-notify
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      # schedule/workflow_run only fire from workflow files on the default branch (main), which
+      # has no cli/ directory; the reconcile implementation lives on v3-beta, so this checkout
+      # must pin ref explicitly instead of using the triggering event's ref.
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: v3-beta
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: cli/.go-version
+          cache: false
+
+      - name: Reconcile pending release approval issue
+        working-directory: cli/release-automation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: go run ./cmd/notify-pending-release-approvals


### PR DESCRIPTION
## Summary
- The scheduled release-approval-pending check (added on `v3-beta` in #1950) will now actually run — GitHub only fires `schedule` and `workflow_run` triggers from workflow files that live on the default branch.

## User Impact
- `schedule`/`workflow_run` events only ever trigger from a workflow definition on the repository's default branch (`main`), no matter which branch owns the implementation the workflow calls into. Without this file present here too, the notify workflow added in #1950 would sit dormant except when manually run via `workflow_dispatch`.
- This file is byte-identical to the one on `v3-beta`. Its checkout step pins `ref: v3-beta`, since that's where the reconcile command (`cli/release-automation/cmd/notify-pending-release-approvals`) actually lives — `main` has no `cli/` directory.

## Changes
- Add `.github/workflows/release-approval-pending-notify.yml` (identical to the `v3-beta` copy in #1950).

## Verification
- Diffed against the `v3-beta` copy in #1950: byte-identical.
- No Go source changed in this PR, so `scripts/check-go-cli.sh` is not applicable here; it was run and green for the underlying implementation in #1950.

Companion to #1950.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

