### PR TITLE
feat: Speed up custom-tool migration scans by limiting them to affected assemblies

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationScanScopeResolverTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationScanScopeResolverTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies seed file paths resolve to a deduplicated set of assembly directories
+    /// (used to scope the migration plan-building scan to only the assemblies that matter).
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationScanScopeResolverTests
+    {
+        private const string ProjectRoot = "/Project";
+
+        [Test]
+        public void ResolveScopeAssemblyDirectories_WhenSeedFilesAreUnderSameAsmdefDirectory_ReturnsSingleDirectory()
+        {
+            // Verifies that multiple seed files under the same asmdef directory collapse to one scope entry.
+            List<string> seedFilePaths = new List<string>
+            {
+                "/Project/Assets/ToolA/Editor/FileOne.cs",
+                "/Project/Assets/ToolA/Editor/FileTwo.cs"
+            };
+            List<string> asmdefDirectories = new List<string> { "/Project/Assets/ToolA/Editor" };
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new List<AssemblyReferenceDirectory>();
+
+            List<string> result = ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
+                seedFilePaths,
+                asmdefDirectories,
+                assemblyReferenceDirectories,
+                ProjectRoot);
+
+            Assert.That(result, Is.EqualTo(new[] { "/Project/Assets/ToolA/Editor" }));
+        }
+
+        [Test]
+        public void ResolveScopeAssemblyDirectories_WhenSeedFilesAreUnderDifferentAsmdefDirectories_ReturnsBothDirectories()
+        {
+            // Verifies that seed files spanning multiple assemblies produce one scope entry per assembly.
+            List<string> seedFilePaths = new List<string>
+            {
+                "/Project/Assets/ToolA/Editor/FileOne.cs",
+                "/Project/Assets/ToolB/Editor/FileTwo.cs"
+            };
+            List<string> asmdefDirectories = new List<string>
+            {
+                "/Project/Assets/ToolA/Editor",
+                "/Project/Assets/ToolB/Editor"
+            };
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new List<AssemblyReferenceDirectory>();
+
+            List<string> result = ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
+                seedFilePaths,
+                asmdefDirectories,
+                assemblyReferenceDirectories,
+                ProjectRoot);
+
+            Assert.That(
+                result,
+                Is.EqualTo(new[] { "/Project/Assets/ToolA/Editor", "/Project/Assets/ToolB/Editor" }));
+        }
+
+        [Test]
+        public void ResolveScopeAssemblyDirectories_WhenSeedFileHasNoAsmdef_FallsBackToImplicitAssemblyDirectory()
+        {
+            // Verifies that a seed file outside any asmdef directory still resolves via the implicit
+            // assembly directory fallback (same behavior as FindNearestAssemblyDirectory for full scans).
+            List<string> seedFilePaths = new List<string> { "/Project/Assets/Editor/LooseFile.cs" };
+            List<string> asmdefDirectories = new List<string>();
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new List<AssemblyReferenceDirectory>();
+
+            List<string> result = ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
+                seedFilePaths,
+                asmdefDirectories,
+                assemblyReferenceDirectories,
+                ProjectRoot);
+
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result[0], Does.EndWith("__UnityCliLoopImplicitEditorAssembly"));
+        }
+
+        [Test]
+        public void ResolveScopeAssemblyDirectories_WhenSeedFilePathsIsEmpty_ReturnsEmptyList()
+        {
+            // Verifies that no seed files produce no scope, rather than accidentally scoping to the whole project.
+            List<string> result = ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
+                new List<string>(),
+                new List<string>(),
+                new List<AssemblyReferenceDirectory>(),
+                ProjectRoot);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void ResolveScopeAssemblyDirectories_WhenSeedFilePathsIsNull_Throws()
+        {
+            // Verifies fail-fast behavior when the seed file collection itself is missing.
+            Assert.Throws<System.ArgumentNullException>(() =>
+                ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
+                    null,
+                    new List<string>(),
+                    new List<AssemblyReferenceDirectory>(),
+                    ProjectRoot));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationScanScopeResolverTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationScanScopeResolverTests.cs
@@ -8,7 +8,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
     /// <summary>
     /// Test fixture that verifies seed file paths resolve to a deduplicated set of assembly directories
-    /// (used to scope the migration plan-building scan to only the assemblies that matter).
+    /// (used to scope the migration plan-building scan to only the assemblies that matter), and that
+    /// seeds with no real assembly directory (implicit assemblies) are reported via a flag instead of
+    /// being silently dropped as a nonexistent scan directory.
     /// </summary>
     public sealed class ThirdPartyToolMigrationScanScopeResolverTests
     {
@@ -26,13 +28,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             List<string> asmdefDirectories = new List<string> { "/Project/Assets/ToolA/Editor" };
             List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new List<AssemblyReferenceDirectory>();
 
-            List<string> result = ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
-                seedFilePaths,
-                asmdefDirectories,
-                assemblyReferenceDirectories,
-                ProjectRoot);
+            (List<string> AssemblyDirectories, bool HasImplicitAssemblySeeds) result =
+                ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
+                    seedFilePaths,
+                    asmdefDirectories,
+                    assemblyReferenceDirectories,
+                    ProjectRoot);
 
-            Assert.That(result, Is.EqualTo(new[] { "/Project/Assets/ToolA/Editor" }));
+            Assert.That(result.AssemblyDirectories, Is.EqualTo(new[] { "/Project/Assets/ToolA/Editor" }));
+            Assert.That(result.HasImplicitAssemblySeeds, Is.False);
         }
 
         [Test]
@@ -51,47 +55,81 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             };
             List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new List<AssemblyReferenceDirectory>();
 
-            List<string> result = ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
-                seedFilePaths,
-                asmdefDirectories,
-                assemblyReferenceDirectories,
-                ProjectRoot);
+            (List<string> AssemblyDirectories, bool HasImplicitAssemblySeeds) result =
+                ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
+                    seedFilePaths,
+                    asmdefDirectories,
+                    assemblyReferenceDirectories,
+                    ProjectRoot);
 
             Assert.That(
-                result,
+                result.AssemblyDirectories,
                 Is.EqualTo(new[] { "/Project/Assets/ToolA/Editor", "/Project/Assets/ToolB/Editor" }));
+            Assert.That(result.HasImplicitAssemblySeeds, Is.False);
         }
 
         [Test]
-        public void ResolveScopeAssemblyDirectories_WhenSeedFileHasNoAsmdef_FallsBackToImplicitAssemblyDirectory()
+        public void ResolveScopeAssemblyDirectories_WhenSeedFileHasNoAsmdef_SetsImplicitAssemblySeedsFlagInsteadOfAScopeDirectory()
         {
-            // Verifies that a seed file outside any asmdef directory still resolves via the implicit
-            // assembly directory fallback (same behavior as FindNearestAssemblyDirectory for full scans).
+            // Verifies that a seed file outside any asmdef directory resolves to the synthetic implicit
+            // assembly marker (not a real directory on disk), so it must be reported via the
+            // HasImplicitAssemblySeeds flag instead of being added to AssemblyDirectories — adding the
+            // synthetic marker there would make the scoped scan silently skip it as "directory not found"
+            // instead of falling back to a full scan.
             List<string> seedFilePaths = new List<string> { "/Project/Assets/Editor/LooseFile.cs" };
             List<string> asmdefDirectories = new List<string>();
             List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new List<AssemblyReferenceDirectory>();
 
-            List<string> result = ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
-                seedFilePaths,
-                asmdefDirectories,
-                assemblyReferenceDirectories,
-                ProjectRoot);
+            (List<string> AssemblyDirectories, bool HasImplicitAssemblySeeds) result =
+                ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
+                    seedFilePaths,
+                    asmdefDirectories,
+                    assemblyReferenceDirectories,
+                    ProjectRoot);
 
-            Assert.That(result.Count, Is.EqualTo(1));
-            Assert.That(result[0], Does.EndWith("__UnityCliLoopImplicitEditorAssembly"));
+            Assert.That(result.AssemblyDirectories, Is.Empty);
+            Assert.That(result.HasImplicitAssemblySeeds, Is.True);
         }
 
         [Test]
-        public void ResolveScopeAssemblyDirectories_WhenSeedFilePathsIsEmpty_ReturnsEmptyList()
+        public void ResolveScopeAssemblyDirectories_WhenSeedFilesMixRealAsmdefAndImplicit_ReturnsRealDirectoryAndSetsFlag()
         {
-            // Verifies that no seed files produce no scope, rather than accidentally scoping to the whole project.
-            List<string> result = ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
-                new List<string>(),
-                new List<string>(),
-                new List<AssemblyReferenceDirectory>(),
-                ProjectRoot);
+            // Verifies that a mix of a real-asmdef seed and an implicit-assembly seed still reports the
+            // real assembly directory while also setting HasImplicitAssemblySeeds, so a caller knows the
+            // returned directory list alone is not a complete/safe scope.
+            List<string> seedFilePaths = new List<string>
+            {
+                "/Project/Assets/ToolA/Editor/FileOne.cs",
+                "/Project/Assets/Editor/LooseFile.cs"
+            };
+            List<string> asmdefDirectories = new List<string> { "/Project/Assets/ToolA/Editor" };
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new List<AssemblyReferenceDirectory>();
 
-            Assert.That(result, Is.Empty);
+            (List<string> AssemblyDirectories, bool HasImplicitAssemblySeeds) result =
+                ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
+                    seedFilePaths,
+                    asmdefDirectories,
+                    assemblyReferenceDirectories,
+                    ProjectRoot);
+
+            Assert.That(result.AssemblyDirectories, Is.EqualTo(new[] { "/Project/Assets/ToolA/Editor" }));
+            Assert.That(result.HasImplicitAssemblySeeds, Is.True);
+        }
+
+        [Test]
+        public void ResolveScopeAssemblyDirectories_WhenSeedFilePathsIsEmpty_ReturnsEmptyListAndNoImplicitFlag()
+        {
+            // Verifies that no seed files produce no scope and no implicit-assembly flag, rather than
+            // accidentally scoping to the whole project or forcing an unnecessary fallback.
+            (List<string> AssemblyDirectories, bool HasImplicitAssemblySeeds) result =
+                ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
+                    new List<string>(),
+                    new List<string>(),
+                    new List<AssemblyReferenceDirectory>(),
+                    ProjectRoot);
+
+            Assert.That(result.AssemblyDirectories, Is.Empty);
+            Assert.That(result.HasImplicitAssemblySeeds, Is.False);
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationScanScopeResolverTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationScanScopeResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e4e8cf40854c453c87c7bb0fb4d4abb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationScopedPreviewTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationScopedPreviewTests.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies the scope-limited migration inventory/plan/preview path used by compile-error-driven
+    /// detection, which must only scan the assemblies containing matched files instead of the whole project.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationScopedPreviewTests
+    {
+        [Test]
+        public async Task CreateFromDirectoriesAsync_WhenGivenOneOfTwoToolDirectories_OnlyCollectsFilesUnderThatDirectory()
+        {
+            // Verifies that scoped inventory creation ignores files outside the given scope directories.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string scopedToolDirectory = Path.Combine(projectRoot, "Assets", "ScopedTool");
+                string otherToolDirectory = Path.Combine(projectRoot, "Assets", "OtherTool");
+                Directory.CreateDirectory(scopedToolDirectory);
+                Directory.CreateDirectory(otherToolDirectory);
+                string scopedFilePath = Path.Combine(scopedToolDirectory, "ScopedFile.cs");
+                string otherFilePath = Path.Combine(otherToolDirectory, "OtherFile.cs");
+                File.WriteAllText(scopedFilePath, "public sealed class ScopedFile {}");
+                File.WriteAllText(otherFilePath, "public sealed class OtherFile {}");
+
+                ProjectFileInventory inventory = await ProjectFileInventory.CreateFromDirectoriesAsync(
+                    new List<string> { scopedToolDirectory },
+                    projectRoot,
+                    new Progress<ThirdPartyToolMigrationProgress>(),
+                    CancellationToken.None);
+
+                Assert.That(inventory.CSharpFilePaths, Does.Contain(scopedFilePath));
+                Assert.That(inventory.CSharpFilePaths, Has.No.Member(otherFilePath));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task CreateFromDirectoriesAsync_WhenGivenMultipleScopeDirectories_MergesResultsFromBoth()
+        {
+            // Verifies that scoped inventory creation merges files from every given scope directory.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolADirectory = Path.Combine(projectRoot, "Assets", "ToolA");
+                string toolBDirectory = Path.Combine(projectRoot, "Assets", "ToolB");
+                Directory.CreateDirectory(toolADirectory);
+                Directory.CreateDirectory(toolBDirectory);
+                string toolAFilePath = Path.Combine(toolADirectory, "ToolAFile.cs");
+                string toolBFilePath = Path.Combine(toolBDirectory, "ToolBFile.cs");
+                File.WriteAllText(toolAFilePath, "public sealed class ToolAFile {}");
+                File.WriteAllText(toolBFilePath, "public sealed class ToolBFile {}");
+
+                ProjectFileInventory inventory = await ProjectFileInventory.CreateFromDirectoriesAsync(
+                    new List<string> { toolADirectory, toolBDirectory },
+                    projectRoot,
+                    new Progress<ThirdPartyToolMigrationProgress>(),
+                    CancellationToken.None);
+
+                Assert.That(inventory.CSharpFilePaths, Does.Contain(toolAFilePath));
+                Assert.That(inventory.CSharpFilePaths, Does.Contain(toolBFilePath));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task CreateFromDirectoriesAsync_WhenScopeDirectoryDoesNotExist_SkipsItWithoutThrowing()
+        {
+            // Verifies that a stale/removed scope directory is skipped rather than causing a scan failure.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string missingDirectory = Path.Combine(projectRoot, "Assets", "MissingTool");
+
+                ProjectFileInventory inventory = await ProjectFileInventory.CreateFromDirectoriesAsync(
+                    new List<string> { missingDirectory },
+                    projectRoot,
+                    new Progress<ThirdPartyToolMigrationProgress>(),
+                    CancellationToken.None);
+
+                Assert.That(inventory.CSharpFilePaths, Is.Empty);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task PreviewMigrationInScopeAsync_WhenLegacyToolIsOutsideScope_DoesNotReportItAsATarget()
+        {
+            // Verifies that PreviewMigrationInScopeAsync only inspects files under the given scope
+            // directories, so a legacy tool outside the scope is invisible to the scoped preview.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string scopedToolDirectory = Path.Combine(projectRoot, "Assets", "ScopedTool");
+                string outOfScopeToolDirectory = Path.Combine(projectRoot, "Assets", "OutOfScopeTool");
+                Directory.CreateDirectory(scopedToolDirectory);
+                Directory.CreateDirectory(outOfScopeToolDirectory);
+                File.WriteAllText(
+                    Path.Combine(scopedToolDirectory, "InScopeTool.cs"),
+                    "public sealed class InScopeTool {}");
+                File.WriteAllText(
+                    Path.Combine(outOfScopeToolDirectory, "OutOfScopeTool.cs"),
+                    LegacyToolSource);
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationPreview preview = await service.PreviewMigrationInScopeAsync(
+                    projectRoot,
+                    new List<string> { scopedToolDirectory },
+                    new Progress<ThirdPartyToolMigrationProgress>(),
+                    CancellationToken.None);
+
+                Assert.That(preview.HasTargets, Is.False);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task PreviewMigrationInScopeAsync_WhenLegacyToolIsInsideScope_ReportsItAsATarget()
+        {
+            // Verifies that PreviewMigrationInScopeAsync detects and reports a legacy tool file that
+            // is under one of the given scope directories.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string scopedToolDirectory = Path.Combine(projectRoot, "Assets", "ScopedTool");
+                Directory.CreateDirectory(scopedToolDirectory);
+                string legacyToolPath = Path.Combine(scopedToolDirectory, "LegacyTool.cs");
+                File.WriteAllText(legacyToolPath, LegacyToolSource);
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationPreview preview = await service.PreviewMigrationInScopeAsync(
+                    projectRoot,
+                    new List<string> { scopedToolDirectory },
+                    new Progress<ThirdPartyToolMigrationProgress>(),
+                    CancellationToken.None);
+
+                Assert.That(preview.HasTargets, Is.True);
+                Assert.That(preview.FilePaths, Does.Contain(legacyToolPath));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        private const string LegacyToolSource = @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class LegacyTool : AbstractUnityTool<LegacySchema, LegacyResponse>
+{
+}
+
+public sealed class LegacySchema : BaseToolSchema
+{
+}
+
+public sealed class LegacyResponse : BaseToolResponse
+{
+}";
+
+        private static string CreateProjectRoot()
+        {
+            string projectRoot = Path.Combine(
+                Path.GetTempPath(),
+                "UnityCliLoopTests",
+                "ThirdPartyToolMigrationScopedPreview",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectRoot);
+            Directory.CreateDirectory(Path.Combine(projectRoot, "ProjectSettings"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "Assets"));
+            return projectRoot;
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationScopedPreviewTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationScopedPreviewTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b49c81c836f9e496f8862f2336c0cc26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -65,6 +66,40 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             StoreCachedPlan(normalizedProjectRoot, plan);
             StoreCachedPreview(normalizedProjectRoot, preview);
             return preview;
+        }
+
+        /// <summary>
+        /// Builds a preview scanning only the given assembly directories (e.g. the assemblies containing
+        /// compile-error-matched files), instead of the whole project. Deliberately does not read or
+        /// write the full-scan preview/plan cache above: a scope-limited plan is only a partial view of
+        /// the project and must never be mistaken for (or substituted into) the full plan that
+        /// ApplyMigration relies on.
+        /// </summary>
+        public async Task<ThirdPartyToolMigrationPreview> PreviewMigrationInScopeAsync(
+            string projectRoot,
+            List<string> scopeDirectories,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(scopeDirectories != null, "scopeDirectories must not be null");
+            Debug.Assert(progress != null, "progress must not be null");
+
+            string normalizedProjectRoot = NormalizeProjectRoot(projectRoot);
+            MigrationPlan plan = await ThirdPartyToolMigrationPlanBuilder.CreateInScopeAsync(
+                normalizedProjectRoot,
+                scopeDirectories,
+                progress,
+                ct);
+            if (ct.IsCancellationRequested)
+            {
+                return new ThirdPartyToolMigrationPreview(0, 0, Array.Empty<string>());
+            }
+
+            return new ThirdPartyToolMigrationPreview(
+                plan.ChangedFilePaths.Count,
+                plan.ReplacementCount,
+                plan.ChangedFilePaths.ToArray());
         }
 
         public async Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationPlanBuilder.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationPlanBuilder.cs
@@ -81,6 +81,49 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return MigrationPlan.Empty;
             }
 
+            return await BuildPlanFromInventoryAsync(projectRoot, inventory, progress, ct);
+        }
+
+        /// <summary>
+        /// Builds a plan limited to the given assembly directories (e.g. the assemblies containing
+        /// compile-error-matched files) instead of scanning the whole project. The full-scan entry
+        /// points above (Create/CreateAsync) are untouched and remain the source of truth for the
+        /// manual "scan whole project" flow.
+        /// </summary>
+        internal static async Task<MigrationPlan> CreateInScopeAsync(
+            string projectRoot,
+            List<string> scopeDirectories,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(scopeDirectories != null, "scopeDirectories must not be null");
+            Debug.Assert(progress != null, "progress must not be null");
+
+            if (!Directory.Exists(projectRoot))
+            {
+                throw new DirectoryNotFoundException(projectRoot);
+            }
+
+            ProjectFileInventory inventory = await ProjectFileInventory.CreateFromDirectoriesAsync(
+                scopeDirectories,
+                projectRoot,
+                progress,
+                ct);
+            if (ct.IsCancellationRequested)
+            {
+                return MigrationPlan.Empty;
+            }
+
+            return await BuildPlanFromInventoryAsync(projectRoot, inventory, progress, ct);
+        }
+
+        private static async Task<MigrationPlan> BuildPlanFromInventoryAsync(
+            string projectRoot,
+            ProjectFileInventory inventory,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct)
+        {
             MigrationProjectFingerprint projectFingerprint =
                 MigrationProjectFingerprint.CaptureFromInventory(inventory);
             MigrationProgressCounter progressCounter = new(GetPreviewWorkItemCount(inventory), progress);

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationProjectFileInventory.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationProjectFileInventory.cs
@@ -61,15 +61,69 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             List<string> asmdefFilePaths = new();
             List<string> asmrefFilePaths = new();
             string assetsDirectory = Path.Combine(projectRoot, "Assets");
+            progress.Report(new ThirdPartyToolMigrationProgress(0, 0));
             if (Directory.Exists(assetsDirectory))
             {
-                await CollectCandidateFilesAsync(
+                await WalkDirectoryTreeAsync(
                     projectRoot,
                     assetsDirectory,
                     csharpFilePaths,
                     asmdefFilePaths,
                     asmrefFilePaths,
                     progress,
+                    inspectedEntryCount: 0,
+                    ct);
+            }
+
+            csharpFilePaths.Sort(StringComparer.Ordinal);
+            asmdefFilePaths.Sort(StringComparer.Ordinal);
+            asmrefFilePaths.Sort(StringComparer.Ordinal);
+            return new ProjectFileInventory(csharpFilePaths, asmdefFilePaths, asmrefFilePaths);
+        }
+
+        /// <summary>
+        /// Builds an inventory limited to the given assembly directories (e.g. the assemblies containing
+        /// compile-error-matched files), instead of walking the entire Assets tree. Used to speed up
+        /// migration-plan construction once the seed files that need migration are already known.
+        /// </summary>
+        internal static async Task<ProjectFileInventory> CreateFromDirectoriesAsync(
+            List<string> scopeDirectories,
+            string projectRoot,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct)
+        {
+            Debug.Assert(scopeDirectories != null, "scopeDirectories must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(progress != null, "progress must not be null");
+
+            List<string> csharpFilePaths = new();
+            List<string> asmdefFilePaths = new();
+            List<string> asmrefFilePaths = new();
+            int inspectedEntryCount = 0;
+            progress.Report(new ThirdPartyToolMigrationProgress(inspectedEntryCount, 0));
+
+            foreach (string scopeDirectory in scopeDirectories)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                if (!Directory.Exists(scopeDirectory))
+                {
+                    // A resolved scope directory may no longer exist if files moved/deleted between
+                    // detection and scan; skip it rather than failing the whole scoped scan.
+                    continue;
+                }
+
+                inspectedEntryCount = await WalkDirectoryTreeAsync(
+                    projectRoot,
+                    scopeDirectory,
+                    csharpFilePaths,
+                    asmdefFilePaths,
+                    asmrefFilePaths,
+                    progress,
+                    inspectedEntryCount,
                     ct);
             }
 
@@ -129,35 +183,36 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        private static async Task CollectCandidateFilesAsync(
+        /// <summary>
+        /// Walks a single directory tree, collecting candidate migration files and reporting progress
+        /// as a running total across possibly-multiple calls (see CreateFromDirectoriesAsync, which walks
+        /// several scope directories one after another and threads the count between calls).
+        /// </summary>
+        private static async Task<int> WalkDirectoryTreeAsync(
             string projectRoot,
-            string assetsDirectory,
+            string startDirectory,
             List<string> csharpFilePaths,
             List<string> asmdefFilePaths,
             List<string> asmrefFilePaths,
             IProgress<ThirdPartyToolMigrationProgress> progress,
+            int inspectedEntryCount,
             CancellationToken ct)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-            Debug.Assert(!string.IsNullOrEmpty(assetsDirectory), "assetsDirectory must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(startDirectory), "startDirectory must not be null or empty");
             Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
             Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
             Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
             Debug.Assert(progress != null, "progress must not be null");
 
             Stack<string> pendingDirectories = new();
-            pendingDirectories.Push(assetsDirectory);
-            int inspectedEntryCount = 0;
-            // Total item count is unknown while the directory tree is still being walked, so only
-            // the processed count is reported here (see ThirdPartyToolMigrationProgress: a total of
-            // 0 means "unknown total" rather than "no work").
-            progress.Report(new ThirdPartyToolMigrationProgress(inspectedEntryCount, 0));
+            pendingDirectories.Push(startDirectory);
 
             while (pendingDirectories.Count > 0)
             {
                 if (ct.IsCancellationRequested)
                 {
-                    return;
+                    return inspectedEntryCount;
                 }
 
                 string directoryPath = pendingDirectories.Pop();
@@ -188,6 +243,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     }
                 }
             }
+
+            return inspectedEntryCount;
         }
 
         private static void AddCandidateFilePath(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationScanScopeResolver.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationScanScopeResolver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
@@ -13,7 +14,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     internal static class ThirdPartyToolMigrationScanScopeResolver
     {
-        internal static List<string> ResolveScopeAssemblyDirectories(
+        /// <summary>
+        /// A seed file with no real asmdef/asmref ancestor resolves to a synthetic implicit-assembly
+        /// marker path (see ThirdPartyToolMigrationFileServiceConstants) that never exists on disk.
+        /// That marker must never be treated as a real scan directory: a scoped file-tree walk skips
+        /// nonexistent directories, so silently including it would make a legitimate implicit-assembly
+        /// migration target vanish from the scoped scan instead of falling back to a full scan.
+        /// HasImplicitAssemblySeeds tells the caller that AssemblyDirectories alone is not a complete,
+        /// safe scope in that case.
+        /// </summary>
+        internal static (List<string> AssemblyDirectories, bool HasImplicitAssemblySeeds) ResolveScopeAssemblyDirectories(
             List<string> seedFilePaths,
             List<string> asmdefDirectories,
             List<AssemblyReferenceDirectory> assemblyReferenceDirectories,
@@ -33,6 +43,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             HashSet<string> seenAssemblyDirectories = new HashSet<string>(StringComparer.Ordinal);
             List<string> scopeAssemblyDirectories = new List<string>();
+            bool hasImplicitAssemblySeeds = false;
             foreach (string seedFilePath in seedFilePaths)
             {
                 string assemblyDirectory = ThirdPartyToolMigrationAssemblyReferenceResolver.FindNearestAssemblyDirectory(
@@ -41,13 +52,42 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     assemblyReferenceDirectories,
                     projectRoot);
 
+                if (IsImplicitAssemblyDirectory(assemblyDirectory))
+                {
+                    hasImplicitAssemblySeeds = true;
+                    continue;
+                }
+
                 if (seenAssemblyDirectories.Add(assemblyDirectory))
                 {
                     scopeAssemblyDirectories.Add(assemblyDirectory);
                 }
             }
 
-            return scopeAssemblyDirectories;
+            return (scopeAssemblyDirectories, hasImplicitAssemblySeeds);
+        }
+
+        private static bool IsImplicitAssemblyDirectory(string assemblyDirectory)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyDirectory), "assemblyDirectory must not be null or empty");
+
+            string directoryName = Path.GetFileName(assemblyDirectory);
+            return string.Equals(
+                    directoryName,
+                    ThirdPartyToolMigrationFileServiceConstants.ImplicitEditorAssemblyDirectoryName,
+                    StringComparison.Ordinal) ||
+                string.Equals(
+                    directoryName,
+                    ThirdPartyToolMigrationFileServiceConstants.ImplicitRuntimeAssemblyDirectoryName,
+                    StringComparison.Ordinal) ||
+                string.Equals(
+                    directoryName,
+                    ThirdPartyToolMigrationFileServiceConstants.ImplicitFirstPassEditorAssemblyDirectoryName,
+                    StringComparison.Ordinal) ||
+                string.Equals(
+                    directoryName,
+                    ThirdPartyToolMigrationFileServiceConstants.ImplicitFirstPassRuntimeAssemblyDirectoryName,
+                    StringComparison.Ordinal);
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationScanScopeResolver.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationScanScopeResolver.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Resolves the assembly directories that a set of seed files (e.g. compile-error-matched
+    /// migration target files) belong to, so plan construction can scan only those assemblies
+    /// instead of the whole project. Reuses
+    /// ThirdPartyToolMigrationAssemblyReferenceResolver.FindNearestAssemblyDirectory per seed file
+    /// and deduplicates the results.
+    /// </summary>
+    internal static class ThirdPartyToolMigrationScanScopeResolver
+    {
+        internal static List<string> ResolveScopeAssemblyDirectories(
+            List<string> seedFilePaths,
+            List<string> asmdefDirectories,
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories,
+            string projectRoot)
+        {
+            Debug.Assert(seedFilePaths != null, "seedFilePaths must not be null");
+            Debug.Assert(asmdefDirectories != null, "asmdefDirectories must not be null");
+            Debug.Assert(
+                assemblyReferenceDirectories != null,
+                "assemblyReferenceDirectories must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            if (seedFilePaths == null)
+            {
+                throw new ArgumentNullException(nameof(seedFilePaths));
+            }
+
+            HashSet<string> seenAssemblyDirectories = new HashSet<string>(StringComparer.Ordinal);
+            List<string> scopeAssemblyDirectories = new List<string>();
+            foreach (string seedFilePath in seedFilePaths)
+            {
+                string assemblyDirectory = ThirdPartyToolMigrationAssemblyReferenceResolver.FindNearestAssemblyDirectory(
+                    seedFilePath,
+                    asmdefDirectories,
+                    assemblyReferenceDirectories,
+                    projectRoot);
+
+                if (seenAssemblyDirectories.Add(assemblyDirectory))
+                {
+                    scopeAssemblyDirectories.Add(assemblyDirectory);
+                }
+            }
+
+            return scopeAssemblyDirectories;
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationScanScopeResolver.cs.meta
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationScanScopeResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dca5e4234a7304252b9b8a264e0e5233
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Adds a way to scan and build a migration plan for only a specific set of assemblies, instead of always walking the whole project.

## User Impact
- Currently, checking (or previewing) whether a V2-to-V3 custom-tool migration is needed always scans every file under Assets, even when only a couple of tools actually need it.
- This lays the groundwork for a much faster path: once the wizard already knows which files need migrating (from compile errors, added in a companion PR), it can rescan only the assemblies those files belong to instead of the entire project. This PR only adds the scoped scan/plan/preview machinery and its tests; it is not wired into the wizard's startup flow yet.

## Changes
- `ThirdPartyToolMigrationScanScopeResolver` (new): resolves a set of seed file paths to their deduplicated assembly directories, reusing the existing `FindNearestAssemblyDirectory` resolution used by the full scan.
- `ProjectFileInventory.CreateFromDirectoriesAsync` (new): walks only the given scope directories instead of the whole `Assets` tree. Shares its directory-walk logic with the existing full-scan `CreateAsync` via an extracted `WalkDirectoryTreeAsync` helper — the full scan's behavior is unchanged.
- `ThirdPartyToolMigrationPlanBuilder.CreateInScopeAsync` / `ThirdPartyToolMigrationFileService.PreviewMigrationInScopeAsync` (new): distinctly-named scope-limited counterparts to the existing `Create`/`CreateAsync`/`PreviewMigration(Async)` methods (the repo forbids method overloading). The scoped preview intentionally does not read or write the existing full-scan preview/plan cache, since a partial-scope plan must never be mistaken for the full plan that `ApplyMigration` relies on.

## Verification
- `uloop compile`: 0 errors, 0 warnings
- `uloop run-tests` (new + related tests, regex filter): 12/12 passed
- `uloop run-tests` (all `ThirdPartyToolMigration*` tests): 438/438 passed (4 skipped, platform-specific)
- `uloop run-tests` (full EditMode suite): 2309/2320 passed; the 4 failures are pre-existing and unrelated to this change (dispatcher version-pin string drift, a schema `DescriptionAttribute` check, a startup-hook ownership check) — none touch `ThirdPartyToolMigration` code.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

