### PR TITLE
Speed up custom-tool migration detection using compile errors instead of always scanning

### DIFF
--- a/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
+++ b/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
@@ -325,6 +325,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 _shouldAutoScanThirdPartyToolMigration = shouldAutoScanThirdPartyToolMigration;
             }
 
+            public bool GetShouldAutoScanThirdPartyToolMigration()
+            {
+                return _shouldAutoScanThirdPartyToolMigration;
+            }
+
             public bool ConsumeShouldAutoScanThirdPartyToolMigration()
             {
                 if (!_shouldAutoScanThirdPartyToolMigration)

--- a/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
+++ b/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
@@ -325,11 +325,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 _shouldAutoScanThirdPartyToolMigration = shouldAutoScanThirdPartyToolMigration;
             }
 
-            public bool GetShouldAutoScanThirdPartyToolMigration()
-            {
-                return _shouldAutoScanThirdPartyToolMigration;
-            }
-
             public bool ConsumeShouldAutoScanThirdPartyToolMigration()
             {
                 if (!_shouldAutoScanThirdPartyToolMigration)

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -26,7 +26,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private string _settingsFileContent;
         private IUnityCliLoopEditorSettingsPort _editorSettingsPort;
         private UnityCliLoopEditorSettingsRepository _editorSettingsRepository;
-        private UnityCliLoopSessionFlagsRepository _sessionFlagsRepository;
         private UnityCliLoopEditorSessionStateSnapshot _originalSessionState;
 
         [SetUp]
@@ -43,7 +42,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             DeleteIfExists(SettingsFilePath);
             _editorSettingsPort =
                 UnityCliLoopEditorSettingsTestFactory.CreatePortWithRepository(out _editorSettingsRepository);
-            _sessionFlagsRepository = UnityCliLoopEditorSessionStateTestFactory.CreateSessionFlagsRepository();
             _originalSessionState = UnityCliLoopEditorSessionStateTestFactory.CaptureSnapshot();
             UnityCliLoopEditorSessionStateTestFactory.ClearAll();
             SetupWizardWindow.InitializeEditorServices(
@@ -181,24 +179,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 SetupWizardStartupFlow.ShouldAutoScanThirdPartyToolMigration(currentVersion, lastSeenVersion);
 
             Assert.That(shouldAutoScan, Is.EqualTo(expected));
-        }
-
-        [Test]
-        public void MaybeMarkThirdPartyToolMigrationAutoScan_WhenEnabled_SetsSessionFlag()
-        {
-            // Verifies that the V2-to-V3 upgrade signal is stored only in the current Editor session.
-            SetupWizardStartupFlow.MaybeMarkThirdPartyToolMigrationAutoScan(_sessionFlagsRepository, true);
-
-            Assert.That(_sessionFlagsRepository.GetShouldAutoScanThirdPartyToolMigration(), Is.True);
-        }
-
-        [Test]
-        public void MaybeMarkThirdPartyToolMigrationAutoScan_WhenDisabled_KeepsSessionFlagFalse()
-        {
-            // Verifies that non-upgrade version checks do not request migration scans.
-            SetupWizardStartupFlow.MaybeMarkThirdPartyToolMigrationAutoScan(_sessionFlagsRepository, false);
-
-            Assert.That(_sessionFlagsRepository.GetShouldAutoScanThirdPartyToolMigration(), Is.False);
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationConsoleErrorParserTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationConsoleErrorParserTests.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies that raw Unity Console error text is parsed back into structured
+    /// CompileErrorLogEntry values, including Windows-style paths (backslashes, drive letters,
+    /// spaces) that must parse correctly regardless of the host OS running the test.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationConsoleErrorParserTests
+    {
+        private const string ProjectRoot = "/Users/dev/Project";
+
+        [Test]
+        public void Parse_WithProjectRelativeUnixPath_ReturnsEntryWithAbsolutePath()
+        {
+            // Verifies a standard csc/Roslyn diagnostic line with a project-relative Unix-style path
+            // is parsed into an absolute file path, line number, and code-prefixed message.
+            List<string> rawMessages = new List<string>
+            {
+                "Assets/Editor/Foo.cs(3,25): error CS0246: The type or namespace name 'Bar' could not be found"
+            };
+
+            List<CompileErrorLogEntry> entries = ThirdPartyToolMigrationConsoleErrorParser.Parse(
+                rawMessages,
+                ProjectRoot);
+
+            Assert.That(entries.Count, Is.EqualTo(1));
+            Assert.That(entries[0].FilePath, Is.EqualTo("/Users/dev/Project/Assets/Editor/Foo.cs"));
+            Assert.That(entries[0].LineNumber, Is.EqualTo(3));
+            Assert.That(entries[0].Message, Does.Contain("Bar"));
+        }
+
+        [Test]
+        public void Parse_WithBackslashSeparatedRelativePath_NormalizesToForwardSlashAbsolutePath()
+        {
+            // Verifies Windows-style backslash separators in a project-relative path are normalized
+            // to forward slashes and combined with the project root, without relying on the host OS's
+            // own path-separator handling.
+            List<string> rawMessages = new List<string>
+            {
+                @"Assets\Editor\Foo.cs(3,25): error CS0246: The type or namespace name 'Bar' could not be found"
+            };
+
+            List<CompileErrorLogEntry> entries = ThirdPartyToolMigrationConsoleErrorParser.Parse(
+                rawMessages,
+                ProjectRoot);
+
+            Assert.That(entries.Count, Is.EqualTo(1));
+            Assert.That(entries[0].FilePath, Is.EqualTo("/Users/dev/Project/Assets/Editor/Foo.cs"));
+        }
+
+        [Test]
+        public void Parse_WithWindowsDriveLetterAbsolutePath_KeepsPathAbsoluteWithoutProjectRoot()
+        {
+            // Verifies a Windows drive-letter absolute path is recognized as already-rooted (via an
+            // explicit drive-letter check, not Path.IsPathRooted, which is host-OS dependent) and is
+            // not incorrectly combined with the project root.
+            List<string> rawMessages = new List<string>
+            {
+                @"C:\Users\dev\Project\Assets\Editor\Foo.cs(10,1): error CS0246: The type or namespace name 'Bar' could not be found"
+            };
+
+            List<CompileErrorLogEntry> entries = ThirdPartyToolMigrationConsoleErrorParser.Parse(
+                rawMessages,
+                ProjectRoot);
+
+            Assert.That(entries.Count, Is.EqualTo(1));
+            Assert.That(entries[0].FilePath, Is.EqualTo("C:/Users/dev/Project/Assets/Editor/Foo.cs"));
+        }
+
+        [Test]
+        public void Parse_WithSpacesInPath_ParsesFullPathIncludingSpaces()
+        {
+            // Verifies a path containing spaces (e.g. a "My Tools" folder) is parsed in full, not
+            // truncated at the space.
+            List<string> rawMessages = new List<string>
+            {
+                "Assets/My Tools/Foo.cs(5,10): error CS0246: The type or namespace name 'Bar' could not be found"
+            };
+
+            List<CompileErrorLogEntry> entries = ThirdPartyToolMigrationConsoleErrorParser.Parse(
+                rawMessages,
+                ProjectRoot);
+
+            Assert.That(entries.Count, Is.EqualTo(1));
+            Assert.That(entries[0].FilePath, Is.EqualTo("/Users/dev/Project/Assets/My Tools/Foo.cs"));
+        }
+
+        [Test]
+        public void Parse_WithWarningSeverity_IsSkipped()
+        {
+            // Verifies warning-severity diagnostic lines are not treated as compile errors.
+            List<string> rawMessages = new List<string>
+            {
+                "Assets/Editor/Foo.cs(3,25): warning CS0219: The variable 'x' is never used"
+            };
+
+            List<CompileErrorLogEntry> entries = ThirdPartyToolMigrationConsoleErrorParser.Parse(
+                rawMessages,
+                ProjectRoot);
+
+            Assert.That(entries.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Parse_WithNonDiagnosticFormatLine_IsSkippedWithoutThrowing()
+        {
+            // Verifies plain (non-compiler-diagnostic) console messages are silently ignored.
+            List<string> rawMessages = new List<string>
+            {
+                "This is a regular Debug.LogError message with no file/line prefix"
+            };
+
+            List<CompileErrorLogEntry> entries = ThirdPartyToolMigrationConsoleErrorParser.Parse(
+                rawMessages,
+                ProjectRoot);
+
+            Assert.That(entries.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Parse_WithMultiLineMessage_UsesOnlyFirstLine()
+        {
+            // Verifies only the first physical line of a multi-line console message is parsed for the
+            // diagnostic file/line prefix.
+            List<string> rawMessages = new List<string>
+            {
+                "Assets/Editor/Foo.cs(3,25): error CS0246: The type or namespace name 'Bar' could not be found\nSome trailing detail line"
+            };
+
+            List<CompileErrorLogEntry> entries = ThirdPartyToolMigrationConsoleErrorParser.Parse(
+                rawMessages,
+                ProjectRoot);
+
+            Assert.That(entries.Count, Is.EqualTo(1));
+            Assert.That(entries[0].FilePath, Is.EqualTo("/Users/dev/Project/Assets/Editor/Foo.cs"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationConsoleErrorParserTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationConsoleErrorParserTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4545e0f72b321458895a76907a75784f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationLightweightAssemblyWalkerTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationLightweightAssemblyWalkerTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies that the lightweight walker discovers .asmdef/.asmref directory structure without
+    /// touching non-asmdef/asmref files, matching what the full project scan's
+    /// ThirdPartyToolMigrationAssemblyReferenceResolver expects as input.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationLightweightAssemblyWalkerTests
+    {
+        [Test]
+        public void DiscoverAssemblyStructure_WithNestedAsmdef_ReturnsItsDirectory()
+        {
+            // Verifies a single nested .asmdef file's directory is discovered.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "Editor", "Tool");
+                Directory.CreateDirectory(toolDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "Tool.asmdef"),
+                    "{\"name\": \"Tool\"}");
+
+                (List<string> asmdefDirectories, _) =
+                    ThirdPartyToolMigrationLightweightAssemblyWalker.DiscoverAssemblyStructure(projectRoot);
+
+                Assert.That(asmdefDirectories, Does.Contain(toolDirectory));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void DiscoverAssemblyStructure_WithAsmrefPointingAtAsmdef_ReturnsAssemblyReferenceDirectory()
+        {
+            // Verifies an .asmref file referencing an .asmdef by name is resolved into an
+            // AssemblyReferenceDirectory pointing at the asmdef's directory.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string asmdefDirectory = Path.Combine(projectRoot, "Assets", "Editor", "Tool");
+                string asmrefDirectory = Path.Combine(projectRoot, "Assets", "Editor", "Tool", "SubModule");
+                Directory.CreateDirectory(asmdefDirectory);
+                Directory.CreateDirectory(asmrefDirectory);
+                File.WriteAllText(
+                    Path.Combine(asmdefDirectory, "Tool.asmdef"),
+                    "{\"name\": \"Tool\"}");
+                File.WriteAllText(
+                    Path.Combine(asmrefDirectory, "SubModule.asmref"),
+                    "{\"reference\": \"Tool\"}");
+
+                (_, List<AssemblyReferenceDirectory> assemblyReferenceDirectories) =
+                    ThirdPartyToolMigrationLightweightAssemblyWalker.DiscoverAssemblyStructure(projectRoot);
+
+                Assert.That(assemblyReferenceDirectories.Count, Is.EqualTo(1));
+                Assert.That(assemblyReferenceDirectories[0].SourceDirectory, Is.EqualTo(asmrefDirectory));
+                Assert.That(assemblyReferenceDirectories[0].TargetAssemblyDirectory, Is.EqualTo(asmdefDirectory));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void DiscoverAssemblyStructure_WithNoAssetsDirectory_ReturnsEmptyResults()
+        {
+            // Verifies a project root with no Assets directory yet does not throw and returns empty
+            // results instead.
+            string projectRoot = Path.Combine(
+                Path.GetTempPath(),
+                "UnityCliLoopTests",
+                "ThirdPartyToolMigrationLightweightAssemblyWalker",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectRoot);
+            try
+            {
+                (List<string> asmdefDirectories, List<AssemblyReferenceDirectory> assemblyReferenceDirectories) =
+                    ThirdPartyToolMigrationLightweightAssemblyWalker.DiscoverAssemblyStructure(projectRoot);
+
+                Assert.That(asmdefDirectories.Count, Is.EqualTo(0));
+                Assert.That(assemblyReferenceDirectories.Count, Is.EqualTo(0));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        private static string CreateProjectRoot()
+        {
+            string projectRoot = Path.Combine(
+                Path.GetTempPath(),
+                "UnityCliLoopTests",
+                "ThirdPartyToolMigrationLightweightAssemblyWalker",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectRoot);
+            Directory.CreateDirectory(Path.Combine(projectRoot, "Assets"));
+            return projectRoot;
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationLightweightAssemblyWalkerTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationLightweightAssemblyWalkerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 383697e17ad0646eeb7ef3a5bf3de661
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationScopedPreviewTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationScopedPreviewTests.cs
@@ -165,6 +165,75 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
         }
 
+        [Test]
+        public async Task PreviewMigrationForSeedFilesAsync_WhenSeedHasNoAsmdefAncestor_FallsBackToFullProjectScan()
+        {
+            // Verifies that a seed file with no asmdef/asmref ancestor (an implicit-assembly seed)
+            // makes PreviewMigrationForSeedFilesAsync fall back to a full-project scan instead of a
+            // scope-limited one, so the legacy target is still detected.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string legacyToolPath = Path.Combine(projectRoot, "Assets", "LegacyTool.cs");
+                File.WriteAllText(legacyToolPath, LegacyToolSource);
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationPreview preview = await service.PreviewMigrationForSeedFilesAsync(
+                    projectRoot,
+                    new List<string> { legacyToolPath },
+                    new Progress<ThirdPartyToolMigrationProgress>(),
+                    CancellationToken.None);
+
+                Assert.That(preview.HasTargets, Is.True);
+                Assert.That(preview.FilePaths, Does.Contain(legacyToolPath));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task PreviewMigrationForSeedFilesAsync_WhenSeedHasAnAsmdefAncestor_ScansOnlyThatAssembly()
+        {
+            // Verifies that a seed file under a real asmdef-defined assembly makes
+            // PreviewMigrationForSeedFilesAsync use the scope-limited path, so a legacy tool in a
+            // sibling assembly (outside the scope) is not reported.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string scopedToolDirectory = Path.Combine(projectRoot, "Assets", "ScopedTool");
+                string outOfScopeToolDirectory = Path.Combine(projectRoot, "Assets", "OutOfScopeTool");
+                Directory.CreateDirectory(scopedToolDirectory);
+                Directory.CreateDirectory(outOfScopeToolDirectory);
+                string legacyToolPath = Path.Combine(scopedToolDirectory, "LegacyTool.cs");
+                File.WriteAllText(legacyToolPath, LegacyToolSource);
+                File.WriteAllText(
+                    Path.Combine(scopedToolDirectory, "ScopedTool.asmdef"),
+                    "{\"name\": \"ScopedTool\"}");
+                File.WriteAllText(
+                    Path.Combine(outOfScopeToolDirectory, "OutOfScopeTool.cs"),
+                    LegacyToolSource);
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationPreview preview = await service.PreviewMigrationForSeedFilesAsync(
+                    projectRoot,
+                    new List<string> { legacyToolPath },
+                    new Progress<ThirdPartyToolMigrationProgress>(),
+                    CancellationToken.None);
+
+                Assert.That(preview.HasTargets, Is.True);
+                Assert.That(preview.FilePaths, Does.Contain(legacyToolPath));
+                Assert.That(
+                    preview.FilePaths,
+                    Has.No.Member(Path.Combine(outOfScopeToolDirectory, "OutOfScopeTool.cs")));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
         private const string LegacyToolSource = @"using io.github.hatayama.uLoopMCP;
 
 [McpTool]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWorkflowControllerTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWorkflowControllerTests.cs
@@ -13,57 +13,46 @@ using io.github.hatayama.UnityCliLoop.Presentation;
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
     /// <summary>
-    /// Verifies that reaching a migration scan result state consumes the auto-scan SessionState
-    /// flag, instead of the flag being consumed at window-open time (which loses track of a scan
-    /// interrupted by a domain reload).
+    /// Verifies that only the first RefreshUI call after an auto-scan window-open uses the
+    /// compile-error-matched seed file paths for a scoped scan; a later manual re-check falls back
+    /// to a full-project scan (empty seed list) since the seeds are cleared after first use.
     /// </summary>
     public sealed class ThirdPartyToolMigrationWizardWorkflowControllerTests
     {
         [Test]
-        public void ShowMigrationTargetsState_WhenAutoScanFlagIsSet_ConsumesIt()
+        public async Task RefreshUI_WhenCalledFirstTime_PassesAutoScanSeedFilePathsToPreview()
         {
-            // Verifies that reaching the "targets found" result state consumes the auto-scan flag.
-            InMemorySessionFlagsRepository sessionFlagsRepository = new();
-            sessionFlagsRepository.SetShouldAutoScanThirdPartyToolMigration(true);
+            // Verifies that the first RefreshUI call after an auto-scan open scopes the scan to the
+            // seed file paths supplied by the constructor.
+            RecordingThirdPartyToolMigrationPort port = new();
             ThirdPartyToolMigrationWizardWorkflowController controller =
-                CreateController(sessionFlagsRepository);
+                CreateController(port, new List<string> { "/Project/Assets/Tool.cs" });
 
-            controller.ShowMigrationTargetsState(new[] { "/Project/Assets/Tool.cs" });
+            await controller.RefreshUI();
 
-            Assert.That(sessionFlagsRepository.GetShouldAutoScanThirdPartyToolMigration(), Is.False);
+            Assert.That(port.SeedFilePathsPerCall, Has.Count.EqualTo(1));
+            Assert.That(port.SeedFilePathsPerCall[0], Is.EqualTo(new[] { "/Project/Assets/Tool.cs" }));
         }
 
         [Test]
-        public void ShowNoMigrationTargetsState_WhenAutoScanFlagIsSet_ConsumesIt()
+        public async Task RefreshUI_WhenCalledASecondTime_PassesEmptySeedFilePaths()
         {
-            // Verifies that reaching the "no targets" result state consumes the auto-scan flag.
-            InMemorySessionFlagsRepository sessionFlagsRepository = new();
-            sessionFlagsRepository.SetShouldAutoScanThirdPartyToolMigration(true);
+            // Verifies that a manual re-check after the initial auto-scoped scan falls back to a
+            // full-project scan, since the seed file paths are cleared after their first use.
+            RecordingThirdPartyToolMigrationPort port = new();
             ThirdPartyToolMigrationWizardWorkflowController controller =
-                CreateController(sessionFlagsRepository);
+                CreateController(port, new List<string> { "/Project/Assets/Tool.cs" });
 
-            controller.ShowNoMigrationTargetsState();
+            await controller.RefreshUI();
+            await controller.RefreshUI();
 
-            Assert.That(sessionFlagsRepository.GetShouldAutoScanThirdPartyToolMigration(), Is.False);
-        }
-
-        [Test]
-        public void ShowCheckingState_WhenAutoScanFlagIsSet_DoesNotConsumeIt()
-        {
-            // Verifies that an in-progress scan (not yet a result state) leaves the flag set, so an
-            // interrupted scan can restart on the next CreateGUI.
-            InMemorySessionFlagsRepository sessionFlagsRepository = new();
-            sessionFlagsRepository.SetShouldAutoScanThirdPartyToolMigration(true);
-            ThirdPartyToolMigrationWizardWorkflowController controller =
-                CreateController(sessionFlagsRepository);
-
-            controller.ShowCheckingState(new ThirdPartyToolMigrationProgress(1, 10));
-
-            Assert.That(sessionFlagsRepository.GetShouldAutoScanThirdPartyToolMigration(), Is.True);
+            Assert.That(port.SeedFilePathsPerCall, Has.Count.EqualTo(2));
+            Assert.That(port.SeedFilePathsPerCall[1], Is.Empty);
         }
 
         private static ThirdPartyToolMigrationWizardWorkflowController CreateController(
-            ISessionFlagsRepository sessionFlagsRepository)
+            IThirdPartyToolMigrationPort port,
+            List<string> autoScanSeedFilePaths)
         {
             VisualElement root = new();
             ThirdPartyToolMigrationWizardView view = ThirdPartyToolMigrationWizardView.Create(
@@ -74,61 +63,66 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 () => { },
                 () => { });
             SkillSetupUseCase skillSetupUseCase = new(new NoOpSkillSetupPort());
-            ThirdPartyToolMigrationUseCase migrationUseCase =
-                new(new NoOpThirdPartyToolMigrationPort());
+            ThirdPartyToolMigrationUseCase migrationUseCase = new(port);
 
             return new ThirdPartyToolMigrationWizardWorkflowController(
                 view,
                 skillSetupUseCase,
                 migrationUseCase,
-                sessionFlagsRepository,
+                autoScanSeedFilePaths,
                 () => { });
         }
 
-        private sealed class InMemorySessionFlagsRepository : ISessionFlagsRepository
+        private sealed class RecordingThirdPartyToolMigrationPort : IThirdPartyToolMigrationPort
         {
-            private bool _shouldAutoScanThirdPartyToolMigration;
+            internal readonly List<List<string>> SeedFilePathsPerCall = new();
 
-            public bool GetIsServerRunning() => false;
-            public bool GetIsServerManuallyStopped() => false;
-            public bool GetIsAfterCompile() => false;
-            public bool GetIsDomainReloadInProgress() => false;
-            public bool GetShowReconnectingUI() => false;
-            public void SetIsAfterCompile(bool isAfterCompile) { }
-            public void SetIsDomainReloadInProgress(bool isDomainReloadInProgress) { }
-            public void SetIsReconnecting(bool isReconnecting) { }
-            public void SetShowReconnectingUI(bool showReconnectingUI) { }
-            public void SetShowPostCompileReconnectingUI(bool showPostCompileReconnectingUI) { }
-
-            public void SetShouldAutoScanThirdPartyToolMigration(bool shouldAutoScanThirdPartyToolMigration)
+            public ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot)
             {
-                _shouldAutoScanThirdPartyToolMigration = shouldAutoScanThirdPartyToolMigration;
+                return new ThirdPartyToolMigrationPreview(0, 0, Array.Empty<string>());
             }
 
-            public bool GetShouldAutoScanThirdPartyToolMigration()
+            public Task<ThirdPartyToolMigrationPreview> PreviewMigrationAsync(
+                string projectRoot,
+                IProgress<ThirdPartyToolMigrationProgress> progress,
+                CancellationToken ct)
             {
-                return _shouldAutoScanThirdPartyToolMigration;
+                return Task.FromResult(new ThirdPartyToolMigrationPreview(0, 0, Array.Empty<string>()));
             }
 
-            public bool ConsumeShouldAutoScanThirdPartyToolMigration()
+            public Task<ThirdPartyToolMigrationPreview> PreviewMigrationForSeedFilesAsync(
+                string projectRoot,
+                List<string> seedFilePaths,
+                IProgress<ThirdPartyToolMigrationProgress> progress,
+                CancellationToken ct)
             {
-                if (!_shouldAutoScanThirdPartyToolMigration)
-                {
-                    return false;
-                }
-
-                _shouldAutoScanThirdPartyToolMigration = false;
-                return true;
+                SeedFilePathsPerCall.Add(seedFilePaths);
+                return Task.FromResult(new ThirdPartyToolMigrationPreview(0, 0, Array.Empty<string>()));
             }
 
-            public void MarkServerStarted() { }
-            public void MarkServerManuallyStopped() { }
-            public void ClearServerSession() { }
-            public void ClearAfterCompileFlag() { }
-            public void ClearReconnectingFlags() { }
-            public void ClearPostCompileReconnectingUI() { }
-            public void ClearDomainReloadFlag() { }
-            public void ClearDomainReloadRecoveryFlags() { }
+            public (bool Found, List<string> TargetFilePaths) TryDetectAutoScanTargetsFromCompileErrors(
+                string projectRoot)
+            {
+                return (false, null);
+            }
+
+            public Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct)
+            {
+                return Task.FromResult(false);
+            }
+
+            public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)
+            {
+                return new ThirdPartyToolMigrationResult(0, 0, Array.Empty<string>());
+            }
+
+            public Task<ThirdPartyToolMigrationResult> ApplyMigrationAsync(
+                string projectRoot,
+                IProgress<ThirdPartyToolMigrationProgress> progress,
+                CancellationToken ct)
+            {
+                return Task.FromResult(new ThirdPartyToolMigrationResult(0, 0, Array.Empty<string>()));
+            }
         }
 
         private sealed class NoOpSkillSetupPort : ISkillSetupPort
@@ -196,40 +190,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 CancellationToken ct)
             {
                 return Task.CompletedTask;
-            }
-        }
-
-        private sealed class NoOpThirdPartyToolMigrationPort : IThirdPartyToolMigrationPort
-        {
-            public ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot)
-            {
-                return new ThirdPartyToolMigrationPreview(0, 0, Array.Empty<string>());
-            }
-
-            public Task<ThirdPartyToolMigrationPreview> PreviewMigrationAsync(
-                string projectRoot,
-                IProgress<ThirdPartyToolMigrationProgress> progress,
-                CancellationToken ct)
-            {
-                return Task.FromResult(new ThirdPartyToolMigrationPreview(0, 0, Array.Empty<string>()));
-            }
-
-            public Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct)
-            {
-                return Task.FromResult(false);
-            }
-
-            public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)
-            {
-                return new ThirdPartyToolMigrationResult(0, 0, Array.Empty<string>());
-            }
-
-            public Task<ThirdPartyToolMigrationResult> ApplyMigrationAsync(
-                string projectRoot,
-                IProgress<ThirdPartyToolMigrationProgress> progress,
-                CancellationToken ct)
-            {
-                return Task.FromResult(new ThirdPartyToolMigrationResult(0, 0, Array.Empty<string>()));
             }
         }
     }

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWorkflowControllerTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWorkflowControllerTests.cs
@@ -103,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public (bool Found, List<string> TargetFilePaths) TryDetectAutoScanTargetsFromCompileErrors(
                 string projectRoot)
             {
-                return (false, null);
+                return (false, new List<string>());
             }
 
             public Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct)

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWorkflowControllerTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWorkflowControllerTests.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Presentation;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies that reaching a migration scan result state consumes the auto-scan SessionState
+    /// flag, instead of the flag being consumed at window-open time (which loses track of a scan
+    /// interrupted by a domain reload).
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationWizardWorkflowControllerTests
+    {
+        [Test]
+        public void ShowMigrationTargetsState_WhenAutoScanFlagIsSet_ConsumesIt()
+        {
+            // Verifies that reaching the "targets found" result state consumes the auto-scan flag.
+            InMemorySessionFlagsRepository sessionFlagsRepository = new();
+            sessionFlagsRepository.SetShouldAutoScanThirdPartyToolMigration(true);
+            ThirdPartyToolMigrationWizardWorkflowController controller =
+                CreateController(sessionFlagsRepository);
+
+            controller.ShowMigrationTargetsState(new[] { "/Project/Assets/Tool.cs" });
+
+            Assert.That(sessionFlagsRepository.GetShouldAutoScanThirdPartyToolMigration(), Is.False);
+        }
+
+        [Test]
+        public void ShowNoMigrationTargetsState_WhenAutoScanFlagIsSet_ConsumesIt()
+        {
+            // Verifies that reaching the "no targets" result state consumes the auto-scan flag.
+            InMemorySessionFlagsRepository sessionFlagsRepository = new();
+            sessionFlagsRepository.SetShouldAutoScanThirdPartyToolMigration(true);
+            ThirdPartyToolMigrationWizardWorkflowController controller =
+                CreateController(sessionFlagsRepository);
+
+            controller.ShowNoMigrationTargetsState();
+
+            Assert.That(sessionFlagsRepository.GetShouldAutoScanThirdPartyToolMigration(), Is.False);
+        }
+
+        [Test]
+        public void ShowCheckingState_WhenAutoScanFlagIsSet_DoesNotConsumeIt()
+        {
+            // Verifies that an in-progress scan (not yet a result state) leaves the flag set, so an
+            // interrupted scan can restart on the next CreateGUI.
+            InMemorySessionFlagsRepository sessionFlagsRepository = new();
+            sessionFlagsRepository.SetShouldAutoScanThirdPartyToolMigration(true);
+            ThirdPartyToolMigrationWizardWorkflowController controller =
+                CreateController(sessionFlagsRepository);
+
+            controller.ShowCheckingState(new ThirdPartyToolMigrationProgress(1, 10));
+
+            Assert.That(sessionFlagsRepository.GetShouldAutoScanThirdPartyToolMigration(), Is.True);
+        }
+
+        private static ThirdPartyToolMigrationWizardWorkflowController CreateController(
+            ISessionFlagsRepository sessionFlagsRepository)
+        {
+            VisualElement root = new();
+            ThirdPartyToolMigrationWizardView view = ThirdPartyToolMigrationWizardView.Create(
+                root,
+                () => { },
+                () => { },
+                _ => { },
+                () => { },
+                () => { });
+            SkillSetupUseCase skillSetupUseCase = new(new NoOpSkillSetupPort());
+            ThirdPartyToolMigrationUseCase migrationUseCase =
+                new(new NoOpThirdPartyToolMigrationPort());
+
+            return new ThirdPartyToolMigrationWizardWorkflowController(
+                view,
+                skillSetupUseCase,
+                migrationUseCase,
+                sessionFlagsRepository,
+                () => { });
+        }
+
+        private sealed class InMemorySessionFlagsRepository : ISessionFlagsRepository
+        {
+            private bool _shouldAutoScanThirdPartyToolMigration;
+
+            public bool GetIsServerRunning() => false;
+            public bool GetIsServerManuallyStopped() => false;
+            public bool GetIsAfterCompile() => false;
+            public bool GetIsDomainReloadInProgress() => false;
+            public bool GetShowReconnectingUI() => false;
+            public void SetIsAfterCompile(bool isAfterCompile) { }
+            public void SetIsDomainReloadInProgress(bool isDomainReloadInProgress) { }
+            public void SetIsReconnecting(bool isReconnecting) { }
+            public void SetShowReconnectingUI(bool showReconnectingUI) { }
+            public void SetShowPostCompileReconnectingUI(bool showPostCompileReconnectingUI) { }
+
+            public void SetShouldAutoScanThirdPartyToolMigration(bool shouldAutoScanThirdPartyToolMigration)
+            {
+                _shouldAutoScanThirdPartyToolMigration = shouldAutoScanThirdPartyToolMigration;
+            }
+
+            public bool GetShouldAutoScanThirdPartyToolMigration()
+            {
+                return _shouldAutoScanThirdPartyToolMigration;
+            }
+
+            public bool ConsumeShouldAutoScanThirdPartyToolMigration()
+            {
+                if (!_shouldAutoScanThirdPartyToolMigration)
+                {
+                    return false;
+                }
+
+                _shouldAutoScanThirdPartyToolMigration = false;
+                return true;
+            }
+
+            public void MarkServerStarted() { }
+            public void MarkServerManuallyStopped() { }
+            public void ClearServerSession() { }
+            public void ClearAfterCompileFlag() { }
+            public void ClearReconnectingFlags() { }
+            public void ClearPostCompileReconnectingUI() { }
+            public void ClearDomainReloadFlag() { }
+            public void ClearDomainReloadRecoveryFlags() { }
+        }
+
+        private sealed class NoOpSkillSetupPort : ISkillSetupPort
+        {
+            public void RemoveSkillFiles(string toolName)
+            {
+            }
+
+            public bool IsSkillInstalled(string toolName)
+            {
+                return false;
+            }
+
+            public List<SkillSetupTargetInfo> DetectSkillTargetsForLayoutAtProjectRoot(
+                string projectRoot,
+                bool groupSkillsUnderUnityCliLoop)
+            {
+                return new List<SkillSetupTargetInfo>();
+            }
+
+            public List<SkillSetupTargetInfo> DetectSkillTargetsForLayoutFastAtProjectRoot(
+                string projectRoot,
+                bool groupSkillsUnderUnityCliLoop)
+            {
+                return new List<SkillSetupTargetInfo>();
+            }
+
+            public Task InstallSkillFilesAsync(
+                List<SkillSetupTargetInfo> targets,
+                bool groupSkillsUnderUnityCliLoop,
+                CancellationToken ct)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task InstallSkillFilesForToolAsync(
+                string toolName,
+                bool groupSkillsUnderUnityCliLoop,
+                CancellationToken ct)
+            {
+                return Task.CompletedTask;
+            }
+
+            public SkillInstallState GetV3MigrationSkillInstallStateAtProjectRoot(
+                string projectRoot,
+                SkillSetupTargetInfo target,
+                bool groupSkillsUnderUnityCliLoop)
+            {
+                return SkillInstallState.Missing;
+            }
+
+            public Task InstallV3MigrationSkillFilesAsync(
+                string projectRoot,
+                List<SkillSetupTargetInfo> targets,
+                bool groupSkillsUnderUnityCliLoop,
+                CancellationToken ct)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task RemoveV3MigrationSkillFilesAsync(
+                string projectRoot,
+                List<SkillSetupTargetInfo> targets,
+                bool groupSkillsUnderUnityCliLoop,
+                CancellationToken ct)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class NoOpThirdPartyToolMigrationPort : IThirdPartyToolMigrationPort
+        {
+            public ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot)
+            {
+                return new ThirdPartyToolMigrationPreview(0, 0, Array.Empty<string>());
+            }
+
+            public Task<ThirdPartyToolMigrationPreview> PreviewMigrationAsync(
+                string projectRoot,
+                IProgress<ThirdPartyToolMigrationProgress> progress,
+                CancellationToken ct)
+            {
+                return Task.FromResult(new ThirdPartyToolMigrationPreview(0, 0, Array.Empty<string>()));
+            }
+
+            public Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct)
+            {
+                return Task.FromResult(false);
+            }
+
+            public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)
+            {
+                return new ThirdPartyToolMigrationResult(0, 0, Array.Empty<string>());
+            }
+
+            public Task<ThirdPartyToolMigrationResult> ApplyMigrationAsync(
+                string projectRoot,
+                IProgress<ThirdPartyToolMigrationProgress> progress,
+                CancellationToken ct)
+            {
+                return Task.FromResult(new ThirdPartyToolMigrationResult(0, 0, Array.Empty<string>()));
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWorkflowControllerTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWorkflowControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e353471b0e034355b48b03b9fcbbc1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,6 +38,27 @@ namespace io.github.hatayama.UnityCliLoop.Application
             Debug.Assert(progress != null, "progress must not be null");
 
             return _migrationPort.PreviewMigrationAsync(projectRoot, progress, ct);
+        }
+
+        public Task<ThirdPartyToolMigrationPreview> PreviewMigrationForSeedFilesAsync(
+            string projectRoot,
+            List<string> seedFilePaths,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(seedFilePaths != null, "seedFilePaths must not be null");
+            Debug.Assert(progress != null, "progress must not be null");
+
+            return _migrationPort.PreviewMigrationForSeedFilesAsync(projectRoot, seedFilePaths, progress, ct);
+        }
+
+        public (bool Found, List<string> TargetFilePaths) TryDetectAutoScanTargetsFromCompileErrors(
+            string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            return _migrationPort.TryDetectAutoScanTargetsFromCompileErrors(projectRoot);
         }
 
         public Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct)

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -52,6 +52,8 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             SkillSetupUseCase skillSetupUseCase = new(skillSetupPort);
             ThirdPartyToolMigrationUseCase thirdPartyToolMigrationUseCase =
                 new(new ThirdPartyToolMigrationFileService());
+            IThirdPartyToolMigrationAutoScanSeedRepository thirdPartyToolMigrationAutoScanSeedRepository =
+                new UnityCliLoopThirdPartyToolMigrationAutoScanSeedRepository();
             CliPinReaderService cliPinReaderService = new();
             CliSetupApplicationService cliSetupApplicationService = new(
                 new CliInstallationDetector(cliPinReaderService),
@@ -102,6 +104,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
                 domainReloadDetectionService,
                 editorSettingsPort,
                 sessionFlagsRepository,
+                thirdPartyToolMigrationAutoScanSeedRepository,
                 applicationService,
                 cliSetupApplicationService,
                 toolSettingsUseCase,
@@ -116,6 +119,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             IDomainReloadDetectionService domainReloadDetectionService,
             IUnityCliLoopEditorSettingsPort editorSettingsPort,
             ISessionFlagsRepository sessionFlagsRepository,
+            IThirdPartyToolMigrationAutoScanSeedRepository thirdPartyToolMigrationAutoScanSeedRepository,
             UnityCliLoopServerApplicationService serverApplicationService,
             CliSetupApplicationService cliSetupApplicationService,
             ToolSettingsUseCase toolSettingsUseCase,
@@ -125,6 +129,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             DomainReloadDetectionService = domainReloadDetectionService;
             EditorSettingsPort = editorSettingsPort;
             SessionFlagsRepository = sessionFlagsRepository;
+            ThirdPartyToolMigrationAutoScanSeedRepository = thirdPartyToolMigrationAutoScanSeedRepository;
             ServerApplicationService = serverApplicationService;
             CliSetupApplicationService = cliSetupApplicationService;
             ToolSettingsUseCase = toolSettingsUseCase;
@@ -135,6 +140,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
         internal IDomainReloadDetectionService DomainReloadDetectionService { get; }
         internal IUnityCliLoopEditorSettingsPort EditorSettingsPort { get; }
         internal ISessionFlagsRepository SessionFlagsRepository { get; }
+        internal IThirdPartyToolMigrationAutoScanSeedRepository ThirdPartyToolMigrationAutoScanSeedRepository { get; }
         internal UnityCliLoopServerApplicationService ServerApplicationService { get; }
         internal CliSetupApplicationService CliSetupApplicationService { get; }
         internal ToolSettingsUseCase ToolSettingsUseCase { get; }

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopEditorBootstrapper.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopEditorBootstrapper.cs
@@ -32,6 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             PresentationEditorStartup.Initialize(
                 applicationServices.EditorSettingsPort,
                 applicationServices.SessionFlagsRepository,
+                applicationServices.ThirdPartyToolMigrationAutoScanSeedRepository,
                 applicationServices.ServerApplicationService,
                 applicationServices.CliSetupApplicationService,
                 applicationServices.ToolSettingsUseCase,

--- a/Packages/src/Editor/Domain/ISessionFlagsRepository.cs
+++ b/Packages/src/Editor/Domain/ISessionFlagsRepository.cs
@@ -16,7 +16,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         void SetShowReconnectingUI(bool showReconnectingUI);
         void SetShowPostCompileReconnectingUI(bool showPostCompileReconnectingUI);
         void SetShouldAutoScanThirdPartyToolMigration(bool shouldAutoScanThirdPartyToolMigration);
-        bool GetShouldAutoScanThirdPartyToolMigration();
         bool ConsumeShouldAutoScanThirdPartyToolMigration();
         void MarkServerStarted();
         void MarkServerManuallyStopped();

--- a/Packages/src/Editor/Domain/ISessionFlagsRepository.cs
+++ b/Packages/src/Editor/Domain/ISessionFlagsRepository.cs
@@ -16,6 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         void SetShowReconnectingUI(bool showReconnectingUI);
         void SetShowPostCompileReconnectingUI(bool showPostCompileReconnectingUI);
         void SetShouldAutoScanThirdPartyToolMigration(bool shouldAutoScanThirdPartyToolMigration);
+        bool GetShouldAutoScanThirdPartyToolMigration();
         bool ConsumeShouldAutoScanThirdPartyToolMigration();
         void MarkServerStarted();
         void MarkServerManuallyStopped();

--- a/Packages/src/Editor/Domain/IThirdPartyToolMigrationAutoScanSeedRepository.cs
+++ b/Packages/src/Editor/Domain/IThirdPartyToolMigrationAutoScanSeedRepository.cs
@@ -1,0 +1,13 @@
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Stores the seed file paths for a pending migration auto-scan (the compile-error-matched files
+    /// that triggered it) for the current Unity Editor session.
+    /// </summary>
+    public interface IThirdPartyToolMigrationAutoScanSeedRepository
+    {
+        void StoreSeedFilePaths(string[] filePaths);
+        string[] GetSeedFilePaths();
+        void ClearSeedFilePaths();
+    }
+}

--- a/Packages/src/Editor/Domain/IThirdPartyToolMigrationAutoScanSeedRepository.cs.meta
+++ b/Packages/src/Editor/Domain/IThirdPartyToolMigrationAutoScanSeedRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aebc6b69fed314a2590defdc4d36f6d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
@@ -98,7 +98,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         /// Checks whether the most recent compile failure was caused by V2 legacy custom-tool APIs, by
         /// matching Unity Console error text against known legacy tokens (mirrors Unity's own API
         /// Updater, which performs the same kind of compile-error-driven detection). Returns
-        /// Found == false without inspecting the console when no compile failure is in effect.
+        /// Found == false with an empty TargetFilePaths (never null) without inspecting the console
+        /// when no compile failure is in effect.
         /// </summary>
         (bool Found, List<string> TargetFilePaths) TryDetectAutoScanTargetsFromCompileErrors(string projectRoot);
 

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -81,6 +82,26 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             string projectRoot,
             IProgress<ThirdPartyToolMigrationProgress> progress,
             CancellationToken ct);
+
+        /// <summary>
+        /// Builds a preview scoped to the assemblies containing the given seed files (e.g. compile-
+        /// error-matched migration targets), falling back to a full-project scan when the seeds do not
+        /// resolve to a safe, complete scope (see ThirdPartyToolMigrationScanScopeResolver).
+        /// </summary>
+        Task<ThirdPartyToolMigrationPreview> PreviewMigrationForSeedFilesAsync(
+            string projectRoot,
+            List<string> seedFilePaths,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct);
+
+        /// <summary>
+        /// Checks whether the most recent compile failure was caused by V2 legacy custom-tool APIs, by
+        /// matching Unity Console error text against known legacy tokens (mirrors Unity's own API
+        /// Updater, which performs the same kind of compile-error-driven detection). Returns
+        /// Found == false without inspecting the console when no compile failure is in effect.
+        /// </summary>
+        (bool Found, List<string> TargetFilePaths) TryDetectAutoScanTargetsFromCompileErrors(string projectRoot);
+
         Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct);
         ThirdPartyToolMigrationResult ApplyMigration(string projectRoot);
         Task<ThirdPartyToolMigrationResult> ApplyMigrationAsync(

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopThirdPartyToolMigrationAutoScanSeedRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopThirdPartyToolMigrationAutoScanSeedRepository.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Stores the migration auto-scan seed file paths in Unity SessionState.
+    /// </summary>
+    public sealed class UnityCliLoopThirdPartyToolMigrationAutoScanSeedRepository
+        : IThirdPartyToolMigrationAutoScanSeedRepository
+    {
+        private const string SeedFilePathsKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "thirdPartyToolMigrationAutoScanSeedFilePaths";
+        private const char SeedFilePathSeparator = '\n';
+
+        public void StoreSeedFilePaths(string[] filePaths)
+        {
+            if (filePaths == null)
+            {
+                throw new ArgumentNullException(nameof(filePaths));
+            }
+
+            UnityCliLoopEditorSessionStateStorage.SetString(
+                SeedFilePathsKey,
+                string.Join(SeedFilePathSeparator, filePaths));
+        }
+
+        public string[] GetSeedFilePaths()
+        {
+            string stored = UnityCliLoopEditorSessionStateStorage.GetString(SeedFilePathsKey);
+            if (string.IsNullOrEmpty(stored))
+            {
+                return Array.Empty<string>();
+            }
+
+            return stored
+                .Split(SeedFilePathSeparator)
+                .Where(filePath => filePath.Length > 0)
+                .ToArray();
+        }
+
+        public void ClearSeedFilePaths()
+        {
+            UnityCliLoopEditorSessionStateStorage.SetString(SeedFilePathsKey, string.Empty);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopThirdPartyToolMigrationAutoScanSeedRepository.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopThirdPartyToolMigrationAutoScanSeedRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4afb99e6626884b3d98110c6afb65760
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationConsoleErrorParser.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationConsoleErrorParser.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Parses raw Unity Console error text back into structured CompileErrorLogEntry values (file path
+    /// + line number) so ThirdPartyToolMigrationCompileErrorLogMatcher can match them. Uses the same
+    /// standard csc/Roslyn diagnostic format ("path(line,col): error CSxxxx: message") as
+    /// ExternalCompilerMessageParser; deliberately not shared with that class, which is scoped to a
+    /// different module (external compiler process output) and parsing the same universal diagnostic
+    /// format twice is simpler than coupling two unrelated call sites.
+    /// </summary>
+    internal static class ThirdPartyToolMigrationConsoleErrorParser
+    {
+        private static readonly Regex DiagnosticRegex = new Regex(
+            @"^(?<file>.+)\((?<line>\d+),(?<column>\d+)\): (?<severity>error|warning) (?<code>[A-Za-z]+\d+): (?<message>.+)$",
+            RegexOptions.Compiled);
+
+        internal static List<CompileErrorLogEntry> Parse(
+            IReadOnlyList<string> rawMessages,
+            string projectRoot)
+        {
+            Debug.Assert(rawMessages != null, "rawMessages must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            List<CompileErrorLogEntry> entries = new List<CompileErrorLogEntry>();
+            foreach (string rawMessage in rawMessages)
+            {
+                if (TryParseErrorLine(rawMessage, projectRoot, out CompileErrorLogEntry entry))
+                {
+                    entries.Add(entry);
+                }
+            }
+
+            return entries;
+        }
+
+        private static bool TryParseErrorLine(string rawMessage, string projectRoot, out CompileErrorLogEntry entry)
+        {
+            entry = default;
+            if (string.IsNullOrEmpty(rawMessage))
+            {
+                return false;
+            }
+
+            // A console entry's message can span multiple physical lines; only the first line carries
+            // the diagnostic-format file/line prefix.
+            string firstLine = SplitFirstLine(rawMessage).Trim();
+            Match match = DiagnosticRegex.Match(firstLine);
+            if (!match.Success || match.Groups["severity"].Value != "error")
+            {
+                return false;
+            }
+
+            string filePath = NormalizeFilePath(match.Groups["file"].Value.Trim(), projectRoot);
+            int lineNumber = int.Parse(match.Groups["line"].Value);
+            string message = $"{match.Groups["code"].Value}: {match.Groups["message"].Value}";
+
+            entry = new CompileErrorLogEntry(message, filePath, lineNumber);
+            return true;
+        }
+
+        private static string SplitFirstLine(string text)
+        {
+            int newlineIndex = text.IndexOfAny(new[] { '\r', '\n' });
+            return newlineIndex < 0 ? text : text.Substring(0, newlineIndex);
+        }
+
+        /// <summary>
+        /// Normalizes a compiler-reported path into an absolute, forward-slash path, without relying on
+        /// Path.IsPathRooted/Path.Combine: those resolve rootedness and separators against the host OS
+        /// running the test, not the OS that produced the raw message, so a Windows-style path (backslash
+        /// separators, drive-letter root) must parse correctly even when this code runs on macOS/Linux.
+        /// </summary>
+        private static string NormalizeFilePath(string rawFilePath, string projectRoot)
+        {
+            string slashNormalized = rawFilePath.Replace('\\', '/');
+            if (IsRootedPath(slashNormalized))
+            {
+                return slashNormalized;
+            }
+
+            string normalizedProjectRoot = projectRoot.Replace('\\', '/').TrimEnd('/');
+            return $"{normalizedProjectRoot}/{slashNormalized}";
+        }
+
+        private static bool IsRootedPath(string path)
+        {
+            if (path.Length == 0)
+            {
+                return false;
+            }
+
+            if (path[0] == '/')
+            {
+                return true;
+            }
+
+            // Windows drive-letter absolute path, e.g. "C:/Users/...".
+            return path.Length >= 2 && char.IsLetter(path[0]) && path[1] == ':';
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationConsoleErrorParser.cs.meta
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationConsoleErrorParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c375ef7f2219f4e409f3b70d05b9158b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -7,7 +7,10 @@ using System.Threading.Tasks;
 
 using Newtonsoft.Json.Linq;
 
+using UnityEditor;
+
 using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
@@ -16,6 +19,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public sealed class ThirdPartyToolMigrationFileService : IThirdPartyToolMigrationPort
     {
+        private static readonly ConsoleLogRetriever LogRetriever = new();
+
         private readonly object _migrationCacheLock = new();
         private bool _hasCachedPreview;
         private string _cachedPreviewProjectRoot = string.Empty;
@@ -100,6 +105,75 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 plan.ChangedFilePaths.Count,
                 plan.ReplacementCount,
                 plan.ChangedFilePaths.ToArray());
+        }
+
+        /// <summary>
+        /// Resolves seed files (e.g. compile-error-matched migration targets) to the assembly
+        /// directories that contain them via a lightweight .asmdef/.asmref-only walk, then scans only
+        /// those directories. Falls back to a full-project scan when the seeds don't resolve to a
+        /// complete, safe scope (HasImplicitAssemblySeeds; see ThirdPartyToolMigrationScanScopeResolver)
+        /// or when no seed files were supplied at all.
+        /// </summary>
+        public async Task<ThirdPartyToolMigrationPreview> PreviewMigrationForSeedFilesAsync(
+            string projectRoot,
+            List<string> seedFilePaths,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(seedFilePaths != null, "seedFilePaths must not be null");
+            Debug.Assert(progress != null, "progress must not be null");
+
+            string normalizedProjectRoot = NormalizeProjectRoot(projectRoot);
+            if (seedFilePaths.Count == 0)
+            {
+                return await PreviewMigrationAsync(normalizedProjectRoot, progress, ct);
+            }
+
+            (List<string> asmdefDirectories, List<AssemblyReferenceDirectory> assemblyReferenceDirectories) =
+                ThirdPartyToolMigrationLightweightAssemblyWalker.DiscoverAssemblyStructure(normalizedProjectRoot);
+            (List<string> scopeDirectories, bool hasImplicitAssemblySeeds) =
+                ThirdPartyToolMigrationScanScopeResolver.ResolveScopeAssemblyDirectories(
+                    seedFilePaths,
+                    asmdefDirectories,
+                    assemblyReferenceDirectories,
+                    normalizedProjectRoot);
+
+            if (hasImplicitAssemblySeeds)
+            {
+                return await PreviewMigrationAsync(normalizedProjectRoot, progress, ct);
+            }
+
+            return await PreviewMigrationInScopeAsync(normalizedProjectRoot, scopeDirectories, progress, ct);
+        }
+
+        public (bool Found, List<string> TargetFilePaths) TryDetectAutoScanTargetsFromCompileErrors(
+            string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            if (!EditorUtility.scriptCompilationFailed)
+            {
+                return (false, null);
+            }
+
+            string normalizedProjectRoot = NormalizeProjectRoot(projectRoot);
+            List<string> rawMessages = new List<string>();
+            foreach (LogEntryDto logEntry in LogRetriever.GetLogsByType(UnityEngine.LogType.Error))
+            {
+                rawMessages.Add(logEntry.Message);
+            }
+
+            List<CompileErrorLogEntry> entries =
+                ThirdPartyToolMigrationConsoleErrorParser.Parse(rawMessages, normalizedProjectRoot);
+            ThirdPartyToolMigrationCompileErrorLogMatchResult matchResult =
+                ThirdPartyToolMigrationCompileErrorLogMatcher.Match(entries);
+            if (matchResult.TargetFilePaths.Count == 0)
+            {
+                return (false, null);
+            }
+
+            return (true, matchResult.TargetFilePaths);
         }
 
         public async Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -154,7 +154,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             if (!EditorUtility.scriptCompilationFailed)
             {
-                return (false, null);
+                return (false, new List<string>());
             }
 
             string normalizedProjectRoot = NormalizeProjectRoot(projectRoot);
@@ -170,7 +170,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 ThirdPartyToolMigrationCompileErrorLogMatcher.Match(entries);
             if (matchResult.TargetFilePaths.Count == 0)
             {
-                return (false, null);
+                return (false, new List<string>());
             }
 
             return (true, matchResult.TargetFilePaths);

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationLightweightAssemblyWalker.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationLightweightAssemblyWalker.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Discovers .asmdef/.asmref directory structure only (no C# source files), so the compile-error-
+    /// driven auto-scan can resolve seed files to assembly directories without the full project file
+    /// walk that ThirdPartyToolMigrationProjectFileInventory performs.
+    /// </summary>
+    internal static class ThirdPartyToolMigrationLightweightAssemblyWalker
+    {
+        private const string AssetsDirectoryName = "Assets";
+        private const string AsmdefSearchPattern = "*.asmdef";
+        private const string AsmrefSearchPattern = "*.asmref";
+
+        internal static (List<string> AsmdefDirectories, List<AssemblyReferenceDirectory> AssemblyReferenceDirectories)
+            DiscoverAssemblyStructure(string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            string assetsDirectory = Path.Combine(projectRoot, AssetsDirectoryName);
+            if (!Directory.Exists(assetsDirectory))
+            {
+                return (new List<string>(), new List<AssemblyReferenceDirectory>());
+            }
+
+            List<string> asmdefFilePaths = Directory
+                .GetFiles(assetsDirectory, AsmdefSearchPattern, SearchOption.AllDirectories)
+                .ToList();
+            List<string> asmrefFilePaths = Directory
+                .GetFiles(assetsDirectory, AsmrefSearchPattern, SearchOption.AllDirectories)
+                .ToList();
+
+            List<string> asmdefDirectories = asmdefFilePaths
+                .Select(filePath => Path.GetDirectoryName(filePath) ?? string.Empty)
+                .Where(directory => directory.Length > 0)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories =
+                ThirdPartyToolMigrationAssemblyReferenceResolver.CreateAssemblyReferenceDirectories(
+                    asmdefFilePaths,
+                    asmrefFilePaths);
+
+            return (asmdefDirectories, assemblyReferenceDirectories);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationLightweightAssemblyWalker.cs.meta
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationLightweightAssemblyWalker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3b9580ecf28841f3be7b1c3d53fd37d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/UnityCLILoop.Infrastructure.asmdef
+++ b/Packages/src/Editor/Infrastructure/UnityCLILoop.Infrastructure.asmdef
@@ -6,7 +6,8 @@
         "GUID:5c4588558a3624eacbce0f50007cf1eb",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:5079a8d3a72924a81aa1cbc25f65ed1b",
-        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d",
+        "GUID:e5952ef560e1641f68b2687e6045bf5b"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/Presentation/PresentationEditorStartup.cs
+++ b/Packages/src/Editor/Presentation/PresentationEditorStartup.cs
@@ -11,6 +11,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static void Initialize(
             IUnityCliLoopEditorSettingsPort editorSettingsPort,
             ISessionFlagsRepository sessionFlagsRepository,
+            IThirdPartyToolMigrationAutoScanSeedRepository thirdPartyToolMigrationAutoScanSeedRepository,
             UnityCliLoopServerApplicationService serverApplicationService,
             CliSetupApplicationService cliSetupApplicationService,
             ToolSettingsUseCase toolSettingsUseCase,
@@ -27,13 +28,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ServerEditorWindow.InitializeEditorServices(serverApplicationService);
             ThirdPartyToolMigrationWizardWindow.InitializeEditorServices(
                 sessionFlagsRepository,
+                thirdPartyToolMigrationAutoScanSeedRepository,
                 skillSetupUseCase,
                 thirdPartyToolMigrationUseCase);
             SetupWizardWindow.InitializeForEditorStartup(
                 editorSettingsPort,
                 sessionFlagsRepository,
+                thirdPartyToolMigrationAutoScanSeedRepository,
                 cliSetupApplicationService,
-                skillSetupUseCase);
+                skillSetupUseCase,
+                thirdPartyToolMigrationUseCase);
         }
     }
 }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs
@@ -21,23 +21,31 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private readonly IUnityCliLoopEditorSettingsPort _editorSettingsPort;
         private readonly ISessionFlagsRepository _sessionFlagsRepository;
+        private readonly IThirdPartyToolMigrationAutoScanSeedRepository _autoScanSeedRepository;
         private readonly CliSetupApplicationService _cliSetupApplicationService;
         private readonly SkillSetupUseCase _skillSetupUseCase;
+        private readonly ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
         private readonly System.Action _showWindowOnVersionChange;
         private readonly System.Action _showThirdPartyMigrationAutoScan;
 
         internal SetupWizardStartupFlow(
             IUnityCliLoopEditorSettingsPort editorSettingsPort,
             ISessionFlagsRepository sessionFlagsRepository,
+            IThirdPartyToolMigrationAutoScanSeedRepository autoScanSeedRepository,
             CliSetupApplicationService cliSetupApplicationService,
             SkillSetupUseCase skillSetupUseCase,
+            ThirdPartyToolMigrationUseCase thirdPartyToolMigrationUseCase,
             System.Action showWindowOnVersionChange,
             System.Action showThirdPartyMigrationAutoScan)
         {
             Debug.Assert(editorSettingsPort != null, "editorSettingsPort must not be null");
             Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
+            Debug.Assert(autoScanSeedRepository != null, "autoScanSeedRepository must not be null");
             Debug.Assert(cliSetupApplicationService != null, "cliSetupApplicationService must not be null");
             Debug.Assert(skillSetupUseCase != null, "skillSetupUseCase must not be null");
+            Debug.Assert(
+                thirdPartyToolMigrationUseCase != null,
+                "thirdPartyToolMigrationUseCase must not be null");
             Debug.Assert(showWindowOnVersionChange != null, "showWindowOnVersionChange must not be null");
             Debug.Assert(showThirdPartyMigrationAutoScan != null, "showThirdPartyMigrationAutoScan must not be null");
 
@@ -45,9 +53,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 ?? throw new System.ArgumentNullException(nameof(editorSettingsPort));
             _sessionFlagsRepository = sessionFlagsRepository
                 ?? throw new System.ArgumentNullException(nameof(sessionFlagsRepository));
+            _autoScanSeedRepository = autoScanSeedRepository
+                ?? throw new System.ArgumentNullException(nameof(autoScanSeedRepository));
             _cliSetupApplicationService = cliSetupApplicationService
                 ?? throw new System.ArgumentNullException(nameof(cliSetupApplicationService));
             _skillSetupUseCase = skillSetupUseCase ?? throw new System.ArgumentNullException(nameof(skillSetupUseCase));
+            _thirdPartyToolMigrationUseCase = thirdPartyToolMigrationUseCase
+                ?? throw new System.ArgumentNullException(nameof(thirdPartyToolMigrationUseCase));
             _showWindowOnVersionChange = showWindowOnVersionChange
                 ?? throw new System.ArgumentNullException(nameof(showWindowOnVersionChange));
             _showThirdPartyMigrationAutoScan = showThirdPartyMigrationAutoScan
@@ -94,20 +106,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
 
             return lastSeenMajorVersion < 3 && currentMajorVersion == 3;
-        }
-
-        internal static void MaybeMarkThirdPartyToolMigrationAutoScan(
-            ISessionFlagsRepository sessionFlagsRepository,
-            bool shouldAutoScan)
-        {
-            Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
-
-            if (!shouldAutoScan)
-            {
-                return;
-            }
-
-            sessionFlagsRepository.SetShouldAutoScanThirdPartyToolMigration(true);
         }
 
         internal static void MaybeRecordLastSeenSetupWizardState(
@@ -188,6 +186,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 currentVersion,
                 lastSeenVersion);
             MaybeScheduleThirdPartyToolMigrationAutoScan(shouldAutoScanThirdPartyToolMigration);
+
 
             bool versionChanged = !string.Equals(
                 currentVersion,
@@ -297,14 +296,29 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return HasSkillUpdateForSetupWizard(targets);
         }
 
-        private void MaybeScheduleThirdPartyToolMigrationAutoScan(bool shouldAutoScan)
+        /// <summary>
+        /// The version-gate check alone can no longer trigger the auto-scan window: it must also be
+        /// confirmed against an actual compile-error hit for V2 legacy API tokens (mirroring Unity's own
+        /// API Updater), so a V2-to-V3 upgrade with no legacy custom-tool code present never shows an
+        /// unnecessary window.
+        /// </summary>
+        private void MaybeScheduleThirdPartyToolMigrationAutoScan(bool shouldAutoScanVersionGate)
         {
-            MaybeMarkThirdPartyToolMigrationAutoScan(_sessionFlagsRepository, shouldAutoScan);
-            if (!shouldAutoScan)
+            if (!shouldAutoScanVersionGate)
             {
                 return;
             }
 
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            (bool found, List<string> targetFilePaths) =
+                _thirdPartyToolMigrationUseCase.TryDetectAutoScanTargetsFromCompileErrors(projectRoot);
+            if (!found)
+            {
+                return;
+            }
+
+            _autoScanSeedRepository.StoreSeedFilePaths(targetFilePaths.ToArray());
+            _sessionFlagsRepository.SetShouldAutoScanThirdPartyToolMigration(true);
             EditorApplication.delayCall += () => _showThirdPartyMigrationAutoScan();
         }
     }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs
@@ -187,7 +187,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 lastSeenVersion);
             MaybeScheduleThirdPartyToolMigrationAutoScan(shouldAutoScanThirdPartyToolMigration);
 
-
             bool versionChanged = !string.Equals(
                 currentVersion,
                 lastSeenVersion,

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -29,8 +29,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static void InitializeForEditorStartup(
             IUnityCliLoopEditorSettingsPort editorSettingsPort,
             ISessionFlagsRepository sessionFlagsRepository,
+            IThirdPartyToolMigrationAutoScanSeedRepository autoScanSeedRepository,
             CliSetupApplicationService cliSetupApplicationService,
-            SkillSetupUseCase skillSetupUseCase)
+            SkillSetupUseCase skillSetupUseCase,
+            ThirdPartyToolMigrationUseCase thirdPartyToolMigrationUseCase)
         {
             InitializeEditorServices(
                 editorSettingsPort,
@@ -43,8 +45,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             SetupWizardStartupFlow startupFlow = new(
                 editorSettingsPort,
                 sessionFlagsRepository,
+                autoScanSeedRepository,
                 cliSetupApplicationService,
                 skillSetupUseCase,
+                thirdPartyToolMigrationUseCase,
                 ShowWindowOnVersionChange,
                 ThirdPartyToolMigrationWizardWindow.ShowWindowForAutoScan);
             EditorApplication.delayCall += startupFlow.TryShowOnVersionChange;

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using UnityEditor;
 using UnityEngine;
@@ -20,12 +21,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private static readonly Vector2 MinimumWindowSize =
             ThirdPartyToolMigrationWizardWindowResizer.MinimumWindowSize;
         private static ISessionFlagsRepository RegisteredSessionFlagsRepository;
+        private static IThirdPartyToolMigrationAutoScanSeedRepository RegisteredAutoScanSeedRepository;
         private static SkillSetupUseCase RegisteredSkillSetupUseCase;
         private static ThirdPartyToolMigrationUseCase RegisteredThirdPartyToolMigrationUseCase;
 
         [SerializeField]
         private bool _shouldRefreshAfterCreateGui;
 
+        private List<string> _autoScanSeedFilePaths = new List<string>();
         private SkillSetupUseCase _skillSetupUseCase;
         private ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
         private ThirdPartyToolMigrationWizardView _view;
@@ -34,10 +37,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal static void InitializeEditorServices(
             ISessionFlagsRepository sessionFlagsRepository,
+            IThirdPartyToolMigrationAutoScanSeedRepository autoScanSeedRepository,
             SkillSetupUseCase skillSetupUseCase,
             ThirdPartyToolMigrationUseCase thirdPartyToolMigrationUseCase)
         {
             Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
+            Debug.Assert(autoScanSeedRepository != null, "autoScanSeedRepository must not be null");
             Debug.Assert(skillSetupUseCase != null, "skillSetupUseCase must not be null");
             Debug.Assert(
                 thirdPartyToolMigrationUseCase != null,
@@ -45,6 +50,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             RegisteredSessionFlagsRepository = sessionFlagsRepository
                 ?? throw new ArgumentNullException(nameof(sessionFlagsRepository));
+            RegisteredAutoScanSeedRepository = autoScanSeedRepository
+                ?? throw new ArgumentNullException(nameof(autoScanSeedRepository));
             RegisteredSkillSetupUseCase = skillSetupUseCase
                 ?? throw new ArgumentNullException(nameof(skillSetupUseCase));
             RegisteredThirdPartyToolMigrationUseCase = thirdPartyToolMigrationUseCase
@@ -54,12 +61,21 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         [MenuItem("Window/Unity CLI Loop/Custom Tool Migration", priority = 4)]
         public static void ShowWindow()
         {
-            ShowWindowInternal(false);
+            ShowWindowInternal(false, new List<string>());
         }
 
         internal static void ShowWindowForAutoScan()
         {
-            ShowWindowInternal(true);
+            List<string> seedFilePaths = ConsumeAutoScanSessionState();
+            ShowWindowInternal(true, seedFilePaths);
+        }
+
+        private static List<string> ConsumeAutoScanSessionState()
+        {
+            GetSessionFlagsRepository().ConsumeShouldAutoScanThirdPartyToolMigration();
+            string[] seedFilePaths = GetAutoScanSeedRepository().GetSeedFilePaths();
+            GetAutoScanSeedRepository().ClearSeedFilePaths();
+            return new List<string>(seedFilePaths);
         }
 
         internal static void PrepareForOpen(
@@ -212,7 +228,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 isCancellationRequested);
         }
 
-        private static void ShowWindowInternal(bool shouldRefreshAfterCreateGui)
+        private static void ShowWindowInternal(bool shouldRefreshAfterCreateGui, List<string> seedFilePaths)
         {
             if (HasOpenInstances<ThirdPartyToolMigrationWizardWindow>())
             {
@@ -225,6 +241,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 InitialWindowSize);
             ThirdPartyToolMigrationWizardWindow window =
                 CreateInstance<ThirdPartyToolMigrationWizardWindow>();
+            window._autoScanSeedFilePaths = seedFilePaths;
             PrepareForOpen(window, WindowTitle, windowPosition, shouldRefreshAfterCreateGui);
             window.ShowUtility();
         }
@@ -238,6 +255,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
 
             return RegisteredSessionFlagsRepository;
+        }
+
+        private static IThirdPartyToolMigrationAutoScanSeedRepository GetAutoScanSeedRepository()
+        {
+            if (RegisteredAutoScanSeedRepository == null)
+            {
+                throw new InvalidOperationException(
+                    "Migration Wizard auto-scan seed repository is not initialized.");
+            }
+
+            return RegisteredAutoScanSeedRepository;
         }
 
         private static SkillSetupUseCase GetSkillSetupUseCase()
@@ -297,28 +325,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _view,
                 _skillSetupUseCase,
                 _thirdPartyToolMigrationUseCase,
-                GetSessionFlagsRepository(),
+                _autoScanSeedFilePaths,
                 ScheduleResizeToContent);
 
-            // The serialized flag alone misses a scan interrupted by a domain reload: it is
-            // consumed on the first CreateGUI, so a reload-triggered second CreateGUI would see it
-            // as false even though the scan never reached a result state. The SessionState flag is
-            // only consumed once a result is actually shown (or the window is truly closed, see
-            // OnDestroy), so checking it here as well restarts an interrupted scan.
-            bool shouldStartInitialRefresh = ConsumeShouldStartInitialRefresh() ||
-                GetSessionFlagsRepository().GetShouldAutoScanThirdPartyToolMigration();
+            bool shouldStartInitialRefresh = ConsumeShouldStartInitialRefresh();
             _controller.ShowInitialState(shouldStartInitialRefresh);
             _controller.RefreshMigrationSkillState();
             _controller.ScheduleInitialRefresh(shouldStartInitialRefresh);
-        }
-
-        private void OnDestroy()
-        {
-            // why: OnDisable fires on a domain reload too (the window is serialized and survives),
-            // but OnDestroy only fires when the window is actually closed (custom Close button or
-            // the native title bar close). That makes it the only safe place to treat "closed" as
-            // user intent to dismiss the auto-scan without losing track of an interrupted scan.
-            GetSessionFlagsRepository().ConsumeShouldAutoScanThirdPartyToolMigration();
         }
 
         private void InitializeApplicationServices()

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -59,13 +59,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal static void ShowWindowForAutoScan()
         {
-            ConsumeAutoScanSessionState();
             ShowWindowInternal(true);
-        }
-
-        private static void ConsumeAutoScanSessionState()
-        {
-            GetSessionFlagsRepository().ConsumeShouldAutoScanThirdPartyToolMigration();
         }
 
         internal static void PrepareForOpen(
@@ -303,12 +297,28 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _view,
                 _skillSetupUseCase,
                 _thirdPartyToolMigrationUseCase,
+                GetSessionFlagsRepository(),
                 ScheduleResizeToContent);
 
-            bool shouldStartInitialRefresh = ConsumeShouldStartInitialRefresh();
+            // The serialized flag alone misses a scan interrupted by a domain reload: it is
+            // consumed on the first CreateGUI, so a reload-triggered second CreateGUI would see it
+            // as false even though the scan never reached a result state. The SessionState flag is
+            // only consumed once a result is actually shown (or the window is truly closed, see
+            // OnDestroy), so checking it here as well restarts an interrupted scan.
+            bool shouldStartInitialRefresh = ConsumeShouldStartInitialRefresh() ||
+                GetSessionFlagsRepository().GetShouldAutoScanThirdPartyToolMigration();
             _controller.ShowInitialState(shouldStartInitialRefresh);
             _controller.RefreshMigrationSkillState();
             _controller.ScheduleInitialRefresh(shouldStartInitialRefresh);
+        }
+
+        private void OnDestroy()
+        {
+            // why: OnDisable fires on a domain reload too (the window is serialized and survives),
+            // but OnDestroy only fires when the window is actually closed (custom Close button or
+            // the native title bar close). That makes it the only safe place to treat "closed" as
+            // user intent to dismiss the auto-scan without losing track of an interrupted scan.
+            GetSessionFlagsRepository().ConsumeShouldAutoScanThirdPartyToolMigration();
         }
 
         private void InitializeApplicationServices()

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs
@@ -22,8 +22,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private readonly ThirdPartyToolMigrationWizardView _view;
         private readonly SkillSetupUseCase _skillSetupUseCase;
         private readonly ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
-        private readonly ISessionFlagsRepository _sessionFlagsRepository;
         private readonly Action _scheduleResize;
+
+        // Only the first scan after an auto-scan open is scoped to the compile-error-matched seed
+        // files; any later manual re-check (button click) must scan the whole project, since the
+        // seeds may no longer reflect what's actually broken, so this is cleared after first use.
+        private List<string> _autoScanSeedFilePaths;
 
         private bool _isMigrating;
         private bool _isUpdatingMigrationSkill;
@@ -37,7 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ThirdPartyToolMigrationWizardView view,
             SkillSetupUseCase skillSetupUseCase,
             ThirdPartyToolMigrationUseCase thirdPartyToolMigrationUseCase,
-            ISessionFlagsRepository sessionFlagsRepository,
+            List<string> autoScanSeedFilePaths,
             Action scheduleResize)
         {
             Debug.Assert(view != null, "view must not be null");
@@ -45,7 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             Debug.Assert(
                 thirdPartyToolMigrationUseCase != null,
                 "thirdPartyToolMigrationUseCase must not be null");
-            Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
+            Debug.Assert(autoScanSeedFilePaths != null, "autoScanSeedFilePaths must not be null");
             Debug.Assert(scheduleResize != null, "scheduleResize must not be null");
 
             _view = view ?? throw new ArgumentNullException(nameof(view));
@@ -53,8 +57,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 ?? throw new ArgumentNullException(nameof(skillSetupUseCase));
             _thirdPartyToolMigrationUseCase = thirdPartyToolMigrationUseCase
                 ?? throw new ArgumentNullException(nameof(thirdPartyToolMigrationUseCase));
-            _sessionFlagsRepository = sessionFlagsRepository
-                ?? throw new ArgumentNullException(nameof(sessionFlagsRepository));
+            _autoScanSeedFilePaths = autoScanSeedFilePaths
+                ?? throw new ArgumentNullException(nameof(autoScanSeedFilePaths));
             _scheduleResize = scheduleResize
                 ?? throw new ArgumentNullException(nameof(scheduleResize));
         }
@@ -99,11 +103,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             IProgress<ThirdPartyToolMigrationProgress> progress = CreateProgressReporter(ct);
+            List<string> seedFilePaths = _autoScanSeedFilePaths;
+            _autoScanSeedFilePaths = new List<string>();
             ThirdPartyToolMigrationPreview preview;
             try
             {
                 preview = await Task.Run(async () =>
-                    await _thirdPartyToolMigrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct));
+                    await _thirdPartyToolMigrationUseCase.PreviewMigrationForSeedFilesAsync(
+                        projectRoot, seedFilePaths, progress, ct));
                 await MainThreadSwitcher.SwitchToMainThread();
             }
             catch (OperationCanceledException)
@@ -250,11 +257,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             Debug.Assert(filePaths != null, "filePaths must not be null");
 
-            // why: reaching a result state is the "scan completed" signal the auto-scan flag
-            // lifecycle waits for (see ThirdPartyToolMigrationWizardWindow.CreateGUI/OnDestroy) —
-            // consuming it here, not at window-open time, lets an interrupted scan resume instead
-            // of silently losing the auto-scan intent.
-            _sessionFlagsRepository.ConsumeShouldAutoScanThirdPartyToolMigration();
             _pendingMigrationFilePaths = filePaths;
             _view.ShowMigrationTargetsState(filePaths, _isMigrating);
             _scheduleResize();
@@ -262,7 +264,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal void ShowNoMigrationTargetsState()
         {
-            _sessionFlagsRepository.ConsumeShouldAutoScanThirdPartyToolMigration();
             _view.ShowNoMigrationTargetsState(_isMigrating);
             _scheduleResize();
         }

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs
@@ -22,6 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private readonly ThirdPartyToolMigrationWizardView _view;
         private readonly SkillSetupUseCase _skillSetupUseCase;
         private readonly ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
+        private readonly ISessionFlagsRepository _sessionFlagsRepository;
         private readonly Action _scheduleResize;
 
         private bool _isMigrating;
@@ -36,6 +37,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ThirdPartyToolMigrationWizardView view,
             SkillSetupUseCase skillSetupUseCase,
             ThirdPartyToolMigrationUseCase thirdPartyToolMigrationUseCase,
+            ISessionFlagsRepository sessionFlagsRepository,
             Action scheduleResize)
         {
             Debug.Assert(view != null, "view must not be null");
@@ -43,6 +45,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             Debug.Assert(
                 thirdPartyToolMigrationUseCase != null,
                 "thirdPartyToolMigrationUseCase must not be null");
+            Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
             Debug.Assert(scheduleResize != null, "scheduleResize must not be null");
 
             _view = view ?? throw new ArgumentNullException(nameof(view));
@@ -50,6 +53,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 ?? throw new ArgumentNullException(nameof(skillSetupUseCase));
             _thirdPartyToolMigrationUseCase = thirdPartyToolMigrationUseCase
                 ?? throw new ArgumentNullException(nameof(thirdPartyToolMigrationUseCase));
+            _sessionFlagsRepository = sessionFlagsRepository
+                ?? throw new ArgumentNullException(nameof(sessionFlagsRepository));
             _scheduleResize = scheduleResize
                 ?? throw new ArgumentNullException(nameof(scheduleResize));
         }
@@ -245,6 +250,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             Debug.Assert(filePaths != null, "filePaths must not be null");
 
+            // why: reaching a result state is the "scan completed" signal the auto-scan flag
+            // lifecycle waits for (see ThirdPartyToolMigrationWizardWindow.CreateGUI/OnDestroy) —
+            // consuming it here, not at window-open time, lets an interrupted scan resume instead
+            // of silently losing the auto-scan intent.
+            _sessionFlagsRepository.ConsumeShouldAutoScanThirdPartyToolMigration();
             _pendingMigrationFilePaths = filePaths;
             _view.ShowMigrationTargetsState(filePaths, _isMigrating);
             _scheduleResize();
@@ -252,6 +262,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal void ShowNoMigrationTargetsState()
         {
+            _sessionFlagsRepository.ConsumeShouldAutoScanThirdPartyToolMigration();
             _view.ShowNoMigrationTargetsState(_isMigrating);
             _scheduleResize();
         }


### PR DESCRIPTION
## Summary
- The custom-tool migration wizard now opens only when a compile error actually indicates leftover V2 legacy API usage, instead of always opening and scanning the whole project after a V2→V3 upgrade.
- When it does open via auto-detection, the migration scan is scoped to the assemblies affected by the matched compile errors instead of scanning all of `Assets/`.

## User Impact
- Before: after upgrading to V3, the migration wizard always popped up and ran a full-project scan, even when the project had no legacy custom-tool code, and the scan could take a while to start.
- After: the wizard only appears when Unity's own compiler has already flagged legacy V2 API usage, mirroring how Unity's built-in API Updater detects upgrade-affected code. When it appears, the initial scan only looks at the affected assemblies, so it starts and finishes faster.

## Changes
- Added console-error-to-legacy-API matching (`ThirdPartyToolMigrationConsoleErrorParser`) and a lightweight assembly walker to scope the migration scan to only the assemblies touched by matched errors.
- `SetupWizardStartupFlow` now gates the auto-scan window on `EditorUtility.scriptCompilationFailed` plus a compile-error-log match, instead of unconditionally opening on a version-gate check alone.
- The manual `Window/Unity CLI Loop/Custom Tool Migration` entry point is unchanged and still performs a full-project scan.
- Reverted an in-flight flag-lifecycle change (deferring auto-scan flag consumption until scan completion, to survive a domain reload interrupting an in-progress scan). With detection now instant and the scan scope-limited, the odds of an in-progress scan being interrupted are low enough that this extra machinery is no longer worth the complexity; the flag is consumed at window-open time as before, and a manual re-check via the existing button is a sufficient fallback if a scan is interrupted.

## Verification
- `uloop compile`: 0 errors, 0 warnings.
- `uloop run-tests` (regex filter covering `ThirdPartyToolMigration|SetupWizardWindow|DomainReloadRecoveryUseCase|UnityCliLoopEditorSessionStateRepository`): 597 tests, 593 passed, 0 failed, 4 skipped.
- Manual verification (opening the wizard after inducing a real V2-API compile error and a domain reload) has not yet been performed in this PR and is tracked as an outstanding follow-up before the final integration-branch PR merges.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

