### PR TITLE
feat: Show live progress feedback while installing the CLI

### DIFF
--- a/Assets/Tests/Editor/CliInstallProgressFormattingTests.cs
+++ b/Assets/Tests/Editor/CliInstallProgressFormattingTests.cs
@@ -1,0 +1,94 @@
+using System;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Presentation;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies CLI install progress text formatting.
+    /// </summary>
+    public class CliInstallProgressFormattingTests
+    {
+        [Test]
+        public void FormatStatusLine_WhenAnimationStepZero_UsesOneVisibleDotWithTransparentPadding()
+        {
+            // Verifies one visible dot keeps three-dot width via transparent rich-text padding.
+            string result = CliInstallProgressFormatting.FormatStatusLine(TimeSpan.Zero, 0);
+
+            Assert.That(result, Is.EqualTo("Installing.<color=#00000000>..</color> (0s)"));
+        }
+
+        [Test]
+        public void FormatStatusLine_WhenAnimationStepOne_UsesTwoVisibleDotsWithTransparentPadding()
+        {
+            // Verifies two visible dots keep three-dot width via one transparent padding dot.
+            string result = CliInstallProgressFormatting.FormatStatusLine(TimeSpan.Zero, 1);
+
+            Assert.That(result, Is.EqualTo("Installing..<color=#00000000>.</color> (0s)"));
+        }
+
+        [Test]
+        public void FormatStatusLine_WhenAnimationStepTwo_UsesThreeVisibleDotsWithoutPadding()
+        {
+            // Verifies three visible dots need no transparent padding and match the full status form.
+            string result = CliInstallProgressFormatting.FormatStatusLine(TimeSpan.Zero, 2);
+
+            Assert.That(result, Is.EqualTo("Installing... (0s)"));
+        }
+
+        [Test]
+        public void FormatStatusLine_WhenUnderOneMinute_ReturnsSecondsOnly()
+        {
+            // Verifies sub-minute elapsed time stays in the seconds-only format.
+            string result = CliInstallProgressFormatting.FormatStatusLine(TimeSpan.FromSeconds(59), 2);
+
+            Assert.That(result, Is.EqualTo("Installing... (59s)"));
+        }
+
+        [Test]
+        public void FormatStatusLine_WhenOverOneMinute_ReturnsMinutesAndSeconds()
+        {
+            // Verifies minute formatting pads seconds to two digits with fixed three-dot width.
+            string result = CliInstallProgressFormatting.FormatStatusLine(TimeSpan.FromSeconds(65), 2);
+
+            Assert.That(result, Is.EqualTo("Installing... (1m 05s)"));
+        }
+
+        [Test]
+        public void FormatStatusLine_WhenExactTensOfMinutes_PadsSeconds()
+        {
+            // Verifies exact minute boundaries still show zero-padded seconds.
+            string result = CliInstallProgressFormatting.FormatStatusLine(TimeSpan.FromSeconds(600), 2);
+
+            Assert.That(result, Is.EqualTo("Installing... (10m 00s)"));
+        }
+
+        [Test]
+        public void FormatStatusLine_WhenAnimationStepThree_LoopsBackToOneVisibleDot()
+        {
+            // Verifies animationStep wraps every three steps so the visible-dot cycle repeats.
+            string result = CliInstallProgressFormatting.FormatStatusLine(TimeSpan.Zero, 3);
+
+            Assert.That(result, Is.EqualTo("Installing.<color=#00000000>..</color> (0s)"));
+        }
+
+        [Test]
+        public void FormatDetailLine_WhenNullOrWhitespace_ReturnsEmpty()
+        {
+            // Verifies blank installer lines do not update the detail label.
+            Assert.That(CliInstallProgressFormatting.FormatDetailLine(null), Is.EqualTo(string.Empty));
+            Assert.That(CliInstallProgressFormatting.FormatDetailLine("   "), Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void FormatDetailLine_WhenPadded_TrimsWhitespace()
+        {
+            // Verifies surrounding whitespace is stripped from streamed installer output.
+            string result = CliInstallProgressFormatting.FormatDetailLine("  Downloading uloop  ");
+
+            Assert.That(result, Is.EqualTo("Downloading uloop"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/CliInstallProgressFormattingTests.cs.meta
+++ b/Assets/Tests/Editor/CliInstallProgressFormattingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a031c32898d87449ea444797c52a1f11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CliPathSetupFlowTests.cs
+++ b/Assets/Tests/Editor/CliPathSetupFlowTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -182,6 +183,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 RuntimePlatform platform,
                 string dispatcherReleaseTag,
                 string dispatcherArchiveManifest,
+                IProgress<string> installProgress,
                 CancellationToken ct)
             {
                 return Task.FromResult(new CliInstallResult(true, ""));

--- a/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
+++ b/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,11 +26,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 nativeCliInstaller,
                 new CliPinReaderService());
 
-            await service.InstallGlobalCliAsync(RuntimePlatform.OSXEditor, CancellationToken.None);
+            await service.InstallGlobalCliAsync(
+                RuntimePlatform.OSXEditor,
+                new Progress<string>(),
+                CancellationToken.None);
 
             Assert.That(
                 nativeCliInstaller.InstalledVersion,
-                Is.EqualTo("dispatcher-v3.0.1-beta.6"));
+                Is.EqualTo(ExpectedDispatcherReleaseTag()));
         }
 
         [Test]
@@ -61,7 +65,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(commandResult.Success, Is.True, commandResult.ErrorOutput);
             Assert.That(
                 commandResult.Command.ManualCommand,
-                Is.EqualTo("install dispatcher-v3.0.1-beta.6"));
+                Is.EqualTo($"install {ExpectedDispatcherReleaseTag()}"));
         }
 
         [Test]
@@ -74,7 +78,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 nativeCliInstaller,
                 new FailingBootstrapPinReader());
 
-            CliInstallResult result = await service.InstallGlobalCliAsync(RuntimePlatform.OSXEditor, CancellationToken.None);
+            CliInstallResult result = await service.InstallGlobalCliAsync(
+                RuntimePlatform.OSXEditor,
+                new Progress<string>(),
+                CancellationToken.None);
 
             Assert.That(result.Success, Is.False);
             Assert.That(result.ErrorOutput, Does.Contain("bootstrap pin"));
@@ -86,6 +93,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             CliPinLoadResult result = new CliPinReaderService().LoadPackagePin();
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             return result.Pin.MinimumDispatcherVersion;
+        }
+
+        private static string ExpectedDispatcherReleaseTag()
+        {
+            DispatcherBootstrapPinLoadResult result = new CliPinReaderService().LoadDispatcherBootstrapPin();
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            return result.DispatcherReleaseTag;
         }
 
         private sealed class FakeCliInstallationDetector : ICliInstallationDetector
@@ -158,6 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 RuntimePlatform platform,
                 string dispatcherReleaseTag,
                 string dispatcherArchiveManifest,
+                IProgress<string> installProgress,
                 CancellationToken ct)
             {
                 InstalledVersion = dispatcherReleaseTag;

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -170,6 +170,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             root.Add(new Label { name = "cli-status-label" });
             root.Add(new Button { name = "refresh-cli-version-button" });
             root.Add(new Button { name = "install-cli-button" });
+            VisualElement installProgress = new() { name = "cli-install-progress" };
+            installProgress.Add(new Label { name = "cli-install-progress-label" });
+            root.Add(installProgress);
             root.Add(new EnumField { name = "skills-target-field" });
             root.Add(new Button { name = "refresh-skills-state-button" });
             root.Add(new VisualElement { name = "group-skills-row" });

--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -328,7 +328,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void RunInstallCommand_StreamsOutputLinesToCallback()
         {
-            // Verifies that installer stdout lines reach the progress callback so the editor UI can stream them.
+            // Verifies that installer stdout and stderr lines reach the progress callback so the editor UI can stream them.
             NativeCliInstallCommand command = BuildEchoInstallCommand();
             List<string> receivedLines = new();
 
@@ -349,6 +349,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 Assert.That(receivedLines, Does.Contain("line1"));
                 Assert.That(receivedLines, Does.Contain("line2"));
+                Assert.That(receivedLines, Does.Contain("err1"));
             }
         }
 
@@ -481,14 +482,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 return new NativeCliInstallCommand(
                     "powershell",
-                    "-NoProfile -ExecutionPolicy Bypass -Command \"Write-Output 'line1'; Write-Output 'line2'\"",
-                    "Write-Output line1; Write-Output line2");
+                    "-NoProfile -ExecutionPolicy Bypass -Command \"Write-Output 'line1'; Write-Output 'line2'; [Console]::Error.WriteLine('err1')\"",
+                    "Write-Output line1; Write-Output line2; [Console]::Error.WriteLine('err1')");
             }
 
             return new NativeCliInstallCommand(
                 "/bin/sh",
-                "-c \"echo line1; echo line2\"",
-                "echo line1; echo line2");
+                "-c \"echo line1; echo line2; echo err1 1>&2\"",
+                "echo line1; echo line2; echo err1 1>&2");
         }
 
         [Test]

--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -301,7 +302,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             CliInstallResult result = NativeCliSetupCommandRunner.RunInstallCommand(
                 command,
                 CancellationToken.None,
-                1000);
+                1000,
+                static _ => { });
 
             Assert.That(result.Success, Is.False);
             Assert.That(result.ErrorOutput, Does.Contain("Failed to start release CLI installer"));
@@ -316,10 +318,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             CliInstallResult result = NativeCliSetupCommandRunner.RunInstallCommand(
                 command,
                 CancellationToken.None,
-                50);
+                50,
+                static _ => { });
 
             Assert.That(result.Success, Is.False);
             Assert.That(result.ErrorOutput, Does.Contain("timed out"));
+        }
+
+        [Test]
+        public void RunInstallCommand_StreamsOutputLinesToCallback()
+        {
+            // Verifies that installer stdout lines reach the progress callback so the editor UI can stream them.
+            NativeCliInstallCommand command = BuildEchoInstallCommand();
+            List<string> receivedLines = new();
+
+            CliInstallResult result = NativeCliSetupCommandRunner.RunInstallCommand(
+                command,
+                CancellationToken.None,
+                5000,
+                line =>
+                {
+                    lock (receivedLines)
+                    {
+                        receivedLines.Add(line);
+                    }
+                });
+
+            Assert.That(result.Success, Is.True, result.ErrorOutput);
+            lock (receivedLines)
+            {
+                Assert.That(receivedLines, Does.Contain("line1"));
+                Assert.That(receivedLines, Does.Contain("line2"));
+            }
         }
 
         [Test]
@@ -443,6 +473,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "/bin/sh",
                 "-c \"sleep 5\"",
                 "sleep 5");
+        }
+
+        private static NativeCliInstallCommand BuildEchoInstallCommand()
+        {
+            if (UnityEngine.Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                return new NativeCliInstallCommand(
+                    "powershell",
+                    "-NoProfile -ExecutionPolicy Bypass -Command \"Write-Output 'line1'; Write-Output 'line2'\"",
+                    "Write-Output line1; Write-Output line2");
+            }
+
+            return new NativeCliInstallCommand(
+                "/bin/sh",
+                "-c \"echo line1; echo line2\"",
+                "echo line1; echo line2");
         }
 
         [Test]

--- a/Packages/src/Editor/Application/CliSetupApplicationService.cs
+++ b/Packages/src/Editor/Application/CliSetupApplicationService.cs
@@ -80,6 +80,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
             RuntimePlatform platform,
             string dispatcherReleaseTag,
             string dispatcherArchiveManifest,
+            IProgress<string> installProgress,
             CancellationToken ct);
         Task<CliInstallResult> UninstallGlobalCliAsync(RuntimePlatform platform, CancellationToken ct);
         Task<CliPathSetupPlan> GetGlobalCliPathSetupPlanAsync(RuntimePlatform platform, CancellationToken ct);
@@ -198,8 +199,12 @@ namespace io.github.hatayama.UnityCliLoop.Application
             return CliVersionComparer.IsVersionEqual(leftVersion, rightVersion);
         }
 
-        public async Task<CliInstallResult> InstallGlobalCliAsync(RuntimePlatform platform, CancellationToken ct)
+        public async Task<CliInstallResult> InstallGlobalCliAsync(
+            RuntimePlatform platform,
+            IProgress<string> installProgress,
+            CancellationToken ct)
         {
+            Debug.Assert(installProgress != null, "installProgress must not be null");
             ct.ThrowIfCancellationRequested();
 
             DispatcherBootstrapPinLoadResult bootstrapPin = _cliPinReader.LoadDispatcherBootstrapPin();
@@ -212,6 +217,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
                 platform,
                 bootstrapPin.DispatcherReleaseTag,
                 bootstrapPin.ArchiveManifest,
+                installProgress,
                 ct);
             _cliInstallationDetector.InvalidateCache();
             return result;

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
@@ -36,10 +36,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             RuntimePlatform platform,
             string dispatcherReleaseTag,
             string dispatcherArchiveManifest,
+            IProgress<string> installProgress,
             CancellationToken ct)
         {
             UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(dispatcherReleaseTag), "dispatcherReleaseTag must not be null or empty");
             UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(dispatcherArchiveManifest), "dispatcherArchiveManifest must not be null or empty");
+            UnityEngine.Debug.Assert(installProgress != null, "installProgress must not be null");
             ct.ThrowIfCancellationRequested();
 
             string installDirectory = NativeCliInstallPathResolver.GetInstallDirectoryForCurrentUser(platform);
@@ -56,7 +58,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 dispatcherArchiveManifest,
                 true);
             CliInstallResult result = await Task.Run(
-                () => NativeCliSetupCommandRunner.RunInstallCommand(command, ct, INSTALL_PROCESS_TIMEOUT_MS),
+                () => NativeCliSetupCommandRunner.RunInstallCommand(
+                    command,
+                    ct,
+                    INSTALL_PROCESS_TIMEOUT_MS,
+                    line => installProgress.Report(line)),
                 ct);
 
             if (result.Success)
@@ -184,10 +190,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             RuntimePlatform platform,
             string dispatcherReleaseTag,
             string dispatcherArchiveManifest,
+            IProgress<string> installProgress,
             CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
-            return NativeCliInstaller.InstallAsync(platform, dispatcherReleaseTag, dispatcherArchiveManifest, ct);
+            return NativeCliInstaller.InstallAsync(
+                platform,
+                dispatcherReleaseTag,
+                dispatcherArchiveManifest,
+                installProgress,
+                ct);
         }
 
         public Task<CliInstallResult> UninstallGlobalCliAsync(RuntimePlatform platform, CancellationToken ct)

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliSetupCommandRunner.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliSetupCommandRunner.cs
@@ -21,11 +21,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         internal static CliInstallResult RunInstallCommand(
             NativeCliInstallCommand command,
             CancellationToken ct,
-            int timeoutMs)
+            int timeoutMs,
+            Action<string> onOutputLine)
         {
             UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.FileName), "command.FileName must not be null or empty");
             UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.Arguments), "command.Arguments must not be null or empty");
             UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
+            UnityEngine.Debug.Assert(onOutputLine != null, "onOutputLine must not be null");
             ct.ThrowIfCancellationRequested();
 
             return RunCliSetupCommand(
@@ -33,6 +35,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 ct,
                 timeoutMs,
                 "release CLI installer",
+                onOutputLine,
                 startInfo => { });
         }
 
@@ -49,6 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 ct,
                 timeoutMs,
                 "global CLI uninstall command",
+                static _ => { },
                 startInfo =>
                 {
                     startInfo.EnvironmentVariables[CliConstants.INSTALL_DIR_ENVIRONMENT_VARIABLE] = installDirectory;
@@ -60,12 +64,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             CancellationToken ct,
             int timeoutMs,
             string commandDescription,
+            Action<string> onOutputLine,
             Action<ProcessStartInfo> configureStartInfo)
         {
             UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.FileName), "command.FileName must not be null or empty");
             UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.Arguments), "command.Arguments must not be null or empty");
             UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
             UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(commandDescription), "commandDescription must not be null or empty");
+            UnityEngine.Debug.Assert(onOutputLine != null, "onOutputLine must not be null");
             UnityEngine.Debug.Assert(configureStartInfo != null, "configureStartInfo must not be null");
             ct.ThrowIfCancellationRequested();
 
@@ -95,6 +101,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 if (e.Data != null)
                 {
                     standardOutputBuilder.AppendLine(e.Data);
+                    onOutputLine(e.Data);
                 }
             };
             process.ErrorDataReceived += (sender, e) =>
@@ -102,6 +109,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 if (e.Data != null)
                 {
                     errorOutputBuilder.AppendLine(e.Data);
+                    onOutputLine(e.Data);
                 }
             };
             process.BeginOutputReadLine();

--- a/Packages/src/Editor/Presentation/CliInstallProgressFormatting.cs
+++ b/Packages/src/Editor/Presentation/CliInstallProgressFormatting.cs
@@ -1,0 +1,62 @@
+using System;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Formats progress status text shown while the global CLI installer is running.
+    /// </summary>
+    internal static class CliInstallProgressFormatting
+    {
+        // Why transparent rich-text dots: keep "Installing... (Ns)" word order while
+        // reserving three-dot width so the elapsed-time suffix does not shift left/right.
+        private const string HIDDEN_DOT_OPEN = "<color=#00000000>";
+        private const string HIDDEN_DOT_CLOSE = "</color>";
+
+        internal static string FormatStatusLine(TimeSpan elapsed, int animationStep)
+        {
+            Debug.Assert(elapsed >= TimeSpan.Zero, "elapsed must not be negative");
+            Debug.Assert(animationStep >= 0, "animationStep must not be negative");
+
+            int visibleDotCount = (animationStep % 3) + 1;
+            int hiddenDotCount = 3 - visibleDotCount;
+            string dots = BuildPaddedDots(visibleDotCount, hiddenDotCount);
+
+            int totalSeconds = (int)elapsed.TotalSeconds;
+            if (totalSeconds < 60)
+            {
+                return $"Installing{dots} ({totalSeconds}s)";
+            }
+
+            int minutes = totalSeconds / 60;
+            int seconds = totalSeconds % 60;
+            return $"Installing{dots} ({minutes}m {seconds:00}s)";
+        }
+
+        internal static string FormatDetailLine(string rawLine)
+        {
+            if (string.IsNullOrWhiteSpace(rawLine))
+            {
+                return string.Empty;
+            }
+
+            return rawLine.Trim();
+        }
+
+        private static string BuildPaddedDots(int visibleDotCount, int hiddenDotCount)
+        {
+            Debug.Assert(visibleDotCount >= 1 && visibleDotCount <= 3, "visibleDotCount must be 1..3");
+            Debug.Assert(hiddenDotCount >= 0 && hiddenDotCount <= 2, "hiddenDotCount must be 0..2");
+            Debug.Assert(visibleDotCount + hiddenDotCount == 3, "visible and hidden dots must total 3");
+
+            string visibleDots = new string('.', visibleDotCount);
+            if (hiddenDotCount == 0)
+            {
+                return visibleDots;
+            }
+
+            string hiddenDots = new string('.', hiddenDotCount);
+            return visibleDots + HIDDEN_DOT_OPEN + hiddenDots + HIDDEN_DOT_CLOSE;
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/CliInstallProgressFormatting.cs.meta
+++ b/Packages/src/Editor/Presentation/CliInstallProgressFormatting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc1a68caf5a014ed0bb3a3d851d70991
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
@@ -18,6 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     internal sealed class SetupWizardCliWorkflowController
     {
         private readonly SetupWizardCliStepPresenter _cliStepPresenter;
+        private readonly CliInstallProgressView _installProgressView;
         private readonly CliSetupApplicationService _cliSetupApplicationService;
         private readonly Action<bool> _refreshUi;
 
@@ -28,6 +29,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             VisualElement cliStatusIcon,
             Label cliStatusLabel,
             Button installCliButton,
+            VisualElement installProgressContainer,
+            Label installProgressLabel,
             CliSetupApplicationService cliSetupApplicationService,
             Action<bool> refreshUi)
         {
@@ -38,6 +41,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 ?? throw new ArgumentNullException(nameof(cliSetupApplicationService));
             _refreshUi = refreshUi
                 ?? throw new ArgumentNullException(nameof(refreshUi));
+            _installProgressView = new CliInstallProgressView(
+                installProgressContainer,
+                installCliButton,
+                installProgressLabel);
 
             _cliStepPresenter = new SetupWizardCliStepPresenter(
                 cliStatusIcon,
@@ -110,11 +117,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 requiredCliVersion: GetMinimumRequiredCliVersion(),
                 isInstallingCli: _isInstallingCli,
                 needsCliPathSetup: _needsCliPathSetup);
+            _installProgressView.Show();
+            Progress<string> installProgress = new(_installProgressView.SetDetailLine);
 
             try
             {
                 CliInstallResult result = await _cliSetupApplicationService.InstallGlobalCliAsync(
                     UnityEngine.Application.platform,
+                    installProgress,
                     ct);
 
                 if (!result.Success)
@@ -141,6 +151,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
             finally
             {
+                _installProgressView.Hide();
                 _isInstallingCli = false;
                 _refreshUi(CliInstallRefreshPolicy.ShouldRefreshSkillsAfterCliInstall(
                     wasCliInstalledBeforeInstall));

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -287,6 +287,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             VisualElement cliStatusIcon = rootVisualElement.Q<VisualElement>("cli-status-icon");
             Label cliStatusLabel = rootVisualElement.Q<Label>("cli-status-label");
             Button installCliButton = rootVisualElement.Q<Button>("install-cli-button");
+            VisualElement installProgressContainer = rootVisualElement.Q<VisualElement>("cli-install-progress");
+            Label installProgressLabel = rootVisualElement.Q<Label>("cli-install-progress-label");
 
             VisualElement groupSkillsRow = rootVisualElement.Q<VisualElement>("group-skills-row");
             EnumField skillsTargetField = rootVisualElement.Q<EnumField>("skills-target-field");
@@ -313,6 +315,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliStatusIcon,
                 cliStatusLabel,
                 installCliButton,
+                installProgressContainer,
+                installProgressLabel,
                 groupSkillsRow,
                 skillsTargetField,
                 groupSkillsToggle,

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -245,6 +245,18 @@
     margin-bottom: 4px;
 }
 
+.setup-install-progress {
+    margin-top: 4px;
+}
+
+.setup-install-progress__detail {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: 11px;
+    margin-top: 2px;
+}
+
 .setup-button--small {
     height: 22px;
     padding-left: 12px;

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
@@ -20,6 +20,9 @@
                     <ui:Label name="cli-status-label" text="Checking..." class="setup-step__status-label" />
                 </ui:VisualElement>
                 <ui:Button name="install-cli-button" text="Install CLI" class="setup-button" />
+                <ui:VisualElement name="cli-install-progress" class="setup-install-progress" style="display: none;">
+                    <ui:Label name="cli-install-progress-label" text="" class="setup-install-progress__detail" />
+                </ui:VisualElement>
             </ui:VisualElement>
         </ui:VisualElement>
 

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWorkflowController.cs
@@ -36,6 +36,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             VisualElement cliStatusIcon,
             Label cliStatusLabel,
             Button installCliButton,
+            VisualElement installProgressContainer,
+            Label installProgressLabel,
             VisualElement groupSkillsRow,
             EnumField skillsTargetField,
             Toggle groupSkillsToggle,
@@ -74,6 +76,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliStatusIcon,
                 cliStatusLabel,
                 installCliButton,
+                installProgressContainer,
+                installProgressLabel,
                 cliSetupApplicationService,
                 RefreshUI);
             _skillsWorkflow = new SetupWizardSkillsWorkflowController(

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliInstallProgressView.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliInstallProgressView.cs
@@ -1,0 +1,84 @@
+using System;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Shows animated install status on the install button and the latest
+    /// installer output line while the global CLI install is running.
+    /// </summary>
+    internal sealed class CliInstallProgressView
+    {
+        // Why 300ms: slow enough to read as a busy indicator without looking frantic.
+        private const long TICK_INTERVAL_MS = 300;
+
+        private readonly VisualElement _container;
+        private readonly Button _installButton;
+        private readonly Label _detailLabel;
+
+        private IVisualElementScheduledItem _tick;
+        private DateTime _startedAtUtc;
+        private int _tickCount;
+
+        internal CliInstallProgressView(
+            VisualElement container,
+            Button installButton,
+            Label detailLabel)
+        {
+            Debug.Assert(container != null, "container must not be null");
+            Debug.Assert(installButton != null, "installButton must not be null");
+            Debug.Assert(detailLabel != null, "detailLabel must not be null");
+
+            _container = container;
+            _installButton = installButton;
+            _detailLabel = detailLabel;
+        }
+
+        internal void Show()
+        {
+            _startedAtUtc = DateTime.UtcNow;
+            _tickCount = 0;
+            _installButton.text = CliInstallProgressFormatting.FormatStatusLine(TimeSpan.Zero, _tickCount);
+            _detailLabel.text = string.Empty;
+            _container.style.display = DisplayStyle.Flex;
+
+            if (_tick == null)
+            {
+                _tick = _installButton.schedule.Execute(AdvanceTick).Every(TICK_INTERVAL_MS);
+                return;
+            }
+
+            _tick.Resume();
+        }
+
+        // Why no visibility assert: Progress<T>.Report posts asynchronously, so a
+        // late line can arrive after Hide(); writing to a hidden label is harmless.
+        internal void SetDetailLine(string rawLine)
+        {
+            string formatted = CliInstallProgressFormatting.FormatDetailLine(rawLine);
+            if (formatted.Length == 0)
+            {
+                return;
+            }
+
+            _detailLabel.text = formatted;
+        }
+
+        // Why leave button text alone: post-install RefreshSection / _refreshUi
+        // restores the correct static label after the install workflow finishes.
+        internal void Hide()
+        {
+            _tick?.Pause();
+            _container.style.display = DisplayStyle.None;
+        }
+
+        private void AdvanceTick()
+        {
+            _tickCount++;
+            _installButton.text = CliInstallProgressFormatting.FormatStatusLine(
+                DateTime.UtcNow - _startedAtUtc,
+                _tickCount);
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliInstallProgressView.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliInstallProgressView.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UIElements;
+using Stopwatch = System.Diagnostics.Stopwatch;
 
 namespace io.github.hatayama.UnityCliLoop.Presentation
 {
@@ -16,9 +17,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private readonly VisualElement _container;
         private readonly Button _installButton;
         private readonly Label _detailLabel;
+        private readonly Stopwatch _stopwatch = new();
 
         private IVisualElementScheduledItem _tick;
-        private DateTime _startedAtUtc;
         private int _tickCount;
 
         internal CliInstallProgressView(
@@ -40,7 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal void Show()
         {
-            _startedAtUtc = DateTime.UtcNow;
+            _stopwatch.Restart();
             _tickCount = 0;
             _installButton.text = CliInstallProgressFormatting.FormatStatusLine(TimeSpan.Zero, _tickCount);
             _detailLabel.text = string.Empty;
@@ -73,6 +74,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal void Hide()
         {
             _tick?.Pause();
+            _stopwatch.Stop();
             _container.style.display = DisplayStyle.None;
         }
 
@@ -80,7 +82,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             _tickCount++;
             _installButton.text = CliInstallProgressFormatting.FormatStatusLine(
-                DateTime.UtcNow - _startedAtUtc,
+                _stopwatch.Elapsed,
                 _tickCount);
         }
     }

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliInstallProgressView.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliInstallProgressView.cs
@@ -33,6 +33,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _container = container;
             _installButton = installButton;
             _detailLabel = detailLabel;
+            // Why disable rich text: installer stdout/stderr is untrusted process output.
+            // Leaving enableRichText on would interpret accidental <...> fragments as markup.
+            _detailLabel.enableRichText = false;
         }
 
         internal void Show()

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliInstallProgressView.cs.meta
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliInstallProgressView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82daaa05b6c2b42409106ee802a012e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -16,6 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private readonly Label _cliStatusLabel;
         private readonly Button _refreshCliVersionButton;
         private readonly Button _installCliButton;
+        private readonly CliInstallProgressView _installProgressView;
         private readonly EnumField _skillsTargetField;
         private readonly Button _refreshSkillsStateButton;
         private readonly VisualElement _groupSkillsRow;
@@ -40,6 +41,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _cliStatusLabel = root.Q<Label>("cli-status-label");
             _refreshCliVersionButton = root.Q<Button>("refresh-cli-version-button");
             _installCliButton = root.Q<Button>("install-cli-button");
+            _installProgressView = new CliInstallProgressView(
+                root.Q<VisualElement>("cli-install-progress"),
+                _installCliButton,
+                root.Q<Label>("cli-install-progress-label"));
             _skillsTargetField = root.Q<EnumField>("skills-target-field");
             _refreshSkillsStateButton = root.Q<Button>("refresh-skills-state-button");
             _groupSkillsRow = root.Q<VisualElement>("group-skills-row");
@@ -62,6 +67,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             });
             _groupSkillsRow.RegisterCallback<ClickEvent>(HandleGroupSkillsRowClicked);
         }
+
+        public void ShowInstallProgress() => _installProgressView.Show();
+
+        public void ReportInstallProgressLine(string line) => _installProgressView.SetDetailLine(line);
+
+        public void HideInstallProgress() => _installProgressView.Hide();
 
         public void Update(CliSetupData data)
         {

--- a/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uss
+++ b/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uss
@@ -183,6 +183,18 @@
     margin-top: 2px;
 }
 
+.unity-cli-loop-install-progress {
+    margin-top: 4px;
+}
+
+.unity-cli-loop-install-progress__detail {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: 11px;
+    margin-top: 2px;
+}
+
 .unity-cli-loop-button--delete {
     margin-top: 12px;
     color: #ff6b6b;

--- a/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uxml
+++ b/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uxml
@@ -12,6 +12,9 @@
                             <ui:Button name="refresh-cli-version-button" text="↻" class="unity-cli-loop-button--refresh" />
                         </ui:VisualElement>
                         <ui:Button name="install-cli-button" text="Install CLI" class="unity-cli-loop-button unity-cli-loop-button--configure" />
+                        <ui:VisualElement name="cli-install-progress" class="unity-cli-loop-install-progress" style="display: none;">
+                            <ui:Label name="cli-install-progress-label" text="" class="unity-cli-loop-install-progress__detail" />
+                        </ui:VisualElement>
                         <ui:VisualElement class="unity-cli-loop-cli-separator" />
 
                         <ui:VisualElement name="skills-subsection">

--- a/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindowUI.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindowUI.cs
@@ -162,6 +162,21 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _cliSetupSection?.Update(data);
         }
 
+        public void ShowCliInstallProgress()
+        {
+            _cliSetupSection?.ShowInstallProgress();
+        }
+
+        public void ReportCliInstallProgressLine(string line)
+        {
+            _cliSetupSection?.ReportInstallProgressLine(line);
+        }
+
+        public void HideCliInstallProgress()
+        {
+            _cliSetupSection?.HideInstallProgress();
+        }
+
         public void Dispose()
         {
             _cliSetupSection = null;

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -282,11 +282,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _needsCliPathSetup = false;
             _isInstallingCli = true;
             RefreshSection();
+            _view.ShowCliInstallProgress();
+            // Why Progress<string>: constructed on the main thread it captures the Unity
+            // synchronization context, so Report calls from the installer's background
+            // thread are marshaled back to the main thread before touching UI Toolkit.
+            Progress<string> installProgress = new(line => _view.ReportCliInstallProgressLine(line));
 
             try
             {
                 CliInstallResult result = await _cliSetupApplicationService.InstallGlobalCliAsync(
                     UnityEngine.Application.platform,
+                    installProgress,
                     CancellationToken.None);
 
                 if (!result.Success)
@@ -312,6 +318,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
             finally
             {
+                _view.HideCliInstallProgress();
                 _isInstallingCli = false;
                 _refreshAllSections(
                     CliInstallRefreshPolicy.ShouldRefreshSkillsAfterCliInstall(wasCliInstalledBeforeInstall));


### PR DESCRIPTION
## Summary
- Settings and Setup Wizard now show live feedback while the global CLI is installing or updating.
- The install button animates with elapsed time, and the latest installer output line streams beneath it.

## User Impact
**Before:** Pressing Install CLI only disabled the button and showed a static "Installing..." label. There was no progress signal, so a multi-second install looked like a freeze.

**After:**
- The install button label animates as `Installing.` → `Installing..` → `Installing... (Ns)` with the seconds position kept stable (transparent rich-text padding dots reserve three-dot width).
- The latest installer stdout/stderr line appears under the button in normal text color.
- On success or failure, the progress UI hides and the normal status/button labels return.

Percent progress is intentionally not used: no layer knows the download size in advance, so a percentage would be fabricated.

## Changes
- Stream installer process lines through an `onOutputLine` callback and `IProgress<string>` from the command runner up to Presentation.
- Add shared install-progress view/formatting used by Settings and Setup Wizard.
- Dropped an indeterminate `ProgressBar` after visual review: it looked like a looping fake percent fill. Final design uses the button label + detail line only.

## Verification
- `dist/darwin-arm64/uloop compile` → Error 0 / Warning 0
- EditMode: `CliInstallProgressFormatting` (9), streaming callback test, related setup/section/application tests passed
- Manual visual check: animated button label, streamed output line, hide on completion (Settings Install flow)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

