### PR TITLE
fix: Restore green EditMode suite for schema and startup-hook guards

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
@@ -11,6 +11,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             DomainReloadDisableScopeRecovery.RestoreForEditorStartup();
             ExternalSceneChangeTracker.Initialize();
             ControlPlayModeEditorStartup.Initialize();
+            PausePointEditorStartup.Initialize();
             ExecuteDynamicCodeEditorStartup.Initialize();
             GetLogsEditorStartup.Initialize();
             ScreenshotEditorStartup.Initialize();

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointResolver")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointCapture")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointPatcher")]

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointDomainReloadTracker.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointDomainReloadTracker.cs
@@ -1,21 +1,30 @@
 using System;
 
-using UnityEditor;
+using UnityEngine;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
-    // [InitializeOnLoad] runs this type's static field initializers once per AppDomain load, so
-    // LoadedAtUtc marks this domain's birth. Used by physics-callback dispatch diagnostics to
-    // report how long the current domain has been alive without a reload -- a suspected factor in
-    // the existing-instance physics-dispatch miss (see docs/regression-harness.md).
-    [InitializeOnLoad]
+    // MarkDomainLoaded is invoked once per AppDomain load by the composition-root bootstrap
+    // (through FirstPartyToolsEditorStartup), so the recorded timestamp marks this domain's
+    // birth. Used by physics-callback dispatch diagnostics to report how long the current
+    // domain has been alive without a reload -- a suspected factor in the existing-instance
+    // physics-dispatch miss (see docs/regression-harness.md).
     internal static class PausePointDomainReloadTracker
     {
-        public static readonly DateTime LoadedAtUtc = DateTime.UtcNow;
+        private static DateTime? _loadedAtUtc;
+
+        public static void MarkDomainLoaded()
+        {
+            Debug.Assert(!_loadedAtUtc.HasValue, "MarkDomainLoaded must run once per domain load");
+
+            _loadedAtUtc = DateTime.UtcNow;
+        }
 
         public static double SecondsSinceLoad()
         {
-            return (DateTime.UtcNow - LoadedAtUtc).TotalSeconds;
+            Debug.Assert(_loadedAtUtc.HasValue, "MarkDomainLoaded must run before SecondsSinceLoad");
+
+            return (DateTime.UtcNow - _loadedAtUtc.Value).TotalSeconds;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEditorStartup.cs
@@ -1,0 +1,12 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    // Keeps pause-point startup wiring inside the pause-point assembly so the composition
+    // root only depends on the bundled-tool facade.
+    internal static class PausePointEditorStartup
+    {
+        public static void Initialize()
+        {
+            PausePointDomainReloadTracker.MarkDomainLoaded();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEditorStartup.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEditorStartup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1caf71ad9cb024a0d8ff2a5d31e82d1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeSchema.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -9,10 +7,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public sealed class SetGameViewSizeSchema : UnityCliLoopToolSchema
     {
-        [Description("Target Game View rendering width in pixels. Provide with Height to change the resolution.")]
         public int? Width { get; set; }
 
-        [Description("Target Game View rendering height in pixels. Provide with Width to change the resolution.")]
         public int? Height { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- EditMode guard failures around first-party schema metadata and editor startup ownership are fixed, so the full EditMode suite returns `FailedCount: 0` again.

## User Impact
- Before: the EditMode suite failed on schema DescriptionAttribute checks and on forbidden `[InitializeOnLoad]` ownership outside the composition-root bootstrap.
- After: those guard rules pass again. Domain-load age diagnostics for pause-point still record domain birth (not first access).

## Changes
- Remove forbidden `DescriptionAttribute` usage from `SetGameViewSizeSchema` (descriptions already live in the skill file and CLI tool JSON).
- Move pause-point domain-load timestamp recording into the composition-root startup chain via `PausePointEditorStartup.MarkDomainLoaded`.
- Group A (`CliSetupApplicationServiceTests` pinned dispatcher tag expectations) was already fixed upstream by #1959 (pin-derived expected values), so it is intentionally out of this PR.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` → `Success: true`, errors 0, warnings 0
- Filtered runs (serial):
  - `CliSetupApplicationServiceTests` → `FailedCount: 0` (4/4)
  - `FirstPartyToolSchemaMetadataTests` → `FailedCount: 0` (2/2)
  - `OnionAssemblyDependencyTests` → `FailedCount: 0` (83/83)
- Full EditMode run → `TestCount: 2356`, `PassedCount: 2349`, `FailedCount: 0`, `SkippedCount: 7`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

