### PR TITLE
fix: Windows CLI install robustness and uninstall message wording

### DIFF
--- a/Assets/Tests/Editor/CliInstallProgressFormattingTests.cs
+++ b/Assets/Tests/Editor/CliInstallProgressFormattingTests.cs
@@ -90,5 +90,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(result, Is.EqualTo("Downloading uloop"));
         }
+
+        [Test]
+        public void InitialDetailLine_IsNonBlankAndSurvivesDetailFormatting()
+        {
+            // Verifies the Show() placeholder is visible immediately and would not be filtered out as a blank detail line.
+            Assert.That(CliInstallProgressFormatting.INITIAL_DETAIL_LINE, Is.EqualTo("Preparing installer..."));
+            Assert.That(
+                CliInstallProgressFormatting.FormatDetailLine(CliInstallProgressFormatting.INITIAL_DETAIL_LINE),
+                Is.EqualTo(CliInstallProgressFormatting.INITIAL_DETAIL_LINE));
+        }
     }
 }

--- a/Assets/Tests/Editor/CliUninstallPromptTests.cs
+++ b/Assets/Tests/Editor/CliUninstallPromptTests.cs
@@ -20,7 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 {
                     showedDialog = true;
                     Assert.That(title, Does.Contain("Uninstall"));
-                    Assert.That(message, Does.Contain("native uLoop CLI command"));
+                    Assert.That(message, Does.Contain("native uloop CLI command"));
                     Assert.That(message, Does.Contain("package-owned PATH entries"));
                     Assert.That(ok, Is.EqualTo("OK"));
                     Assert.That(cancel, Is.EqualTo("Cancel"));

--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -90,7 +90,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void GetInstallCommand_OnWindowsKeepsDispatcherPowerShellInstallerAvailable()
         {
-            // Verifies that editor installs download the dispatcher PowerShell installer script and its checksum from the release, verify SHA-256, and run via -File, not `irm | iex`.
+            // Verifies that editor installs download the dispatcher PowerShell installer script from the release, verify its SHA-256 via module-free .NET APIs (not Get-FileHash, which is a PS 5.1 script function needing module autoloading), emit UTF-8 output, and run via -File, not `irm | iex`.
             NativeCliInstallCommand command = NativeCliCommandBuilder.BuildRemoteInstallCommand(
                 RuntimePlatform.WindowsEditor,
                 TestBetaReleaseTag,
@@ -106,14 +106,52 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(command.Arguments, Does.Contain("[char]10"));
             Assert.That(command.Arguments, Does.Not.Contain("install.sh\n"));
             Assert.That(command.Arguments, Does.Not.Contain("ULOOP_REMOVE_LEGACY"));
+            Assert.That(command.ManualCommand, Does.StartWith("[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "));
             Assert.That(command.ManualCommand, Does.Contain("$ErrorActionPreference = 'Stop'"));
             Assert.That(command.ManualCommand, Does.Contain("Invoke-WebRequest"));
-            Assert.That(command.ManualCommand, Does.Contain("Get-FileHash"));
+            Assert.That(command.ManualCommand, Does.Contain("[System.Security.Cryptography.SHA256]::Create().ComputeHash([System.IO.File]::ReadAllBytes($script_path))"));
+            Assert.That(command.ManualCommand, Does.Not.Contain("Get-FileHash"));
+            Assert.That(command.ManualCommand, Does.Contain("installer-env PSVersion="));
+            Assert.That(command.ManualCommand, Does.Contain("Write-Output 'Downloading installer script...'"));
+            Assert.That(command.ManualCommand, Does.Contain("Write-Output 'Verifying installer script digest...'"));
+            Assert.That(command.ManualCommand, Does.Contain("Write-Output 'Starting install script...'"));
             Assert.That(command.ManualCommand, Does.Contain("-File $script_path"));
             Assert.That(command.ManualCommand, Does.Not.Contain("irm"));
             Assert.That(command.ManualCommand, Does.Not.Contain("| iex"));
             Assert.That(command.ManualCommand, Does.Not.Contain("raw.githubusercontent.com"));
             Assert.That(command.ManualCommand, Does.Not.Contain("npm"));
+        }
+
+        [Test]
+        public void GetInstallCommand_RemoteBootstrapsEmitProgressLinesInStageOrder()
+        {
+            // Verifies both remote bootstraps print download, verify, and start progress lines in stage order so the install progress label never stays blank until the installer script speaks.
+            NativeCliInstallCommand posixCommand = NativeCliCommandBuilder.BuildRemoteInstallCommand(
+                RuntimePlatform.OSXEditor,
+                TestBetaReleaseTag,
+                TestArchiveManifest,
+                false,
+                "/bin/zsh");
+            NativeCliInstallCommand windowsCommand = NativeCliCommandBuilder.BuildRemoteInstallCommand(
+                RuntimePlatform.WindowsEditor,
+                TestBetaReleaseTag,
+                TestArchiveManifest,
+                false,
+                "/bin/zsh");
+
+            AssertProgressLinesInStageOrder(posixCommand.ManualCommand, "echo");
+            AssertProgressLinesInStageOrder(windowsCommand.ManualCommand, "Write-Output");
+        }
+
+        private static void AssertProgressLinesInStageOrder(string manualCommand, string printCommand)
+        {
+            int downloadIndex = manualCommand.IndexOf($"{printCommand} 'Downloading installer script...'", System.StringComparison.Ordinal);
+            int verifyIndex = manualCommand.IndexOf($"{printCommand} 'Verifying installer script digest...'", System.StringComparison.Ordinal);
+            int startIndex = manualCommand.IndexOf($"{printCommand} 'Starting install script...'", System.StringComparison.Ordinal);
+
+            Assert.That(downloadIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(verifyIndex, Is.GreaterThan(downloadIndex));
+            Assert.That(startIndex, Is.GreaterThan(verifyIndex));
         }
 
         [Test]
@@ -241,6 +279,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     packageResolvedPath);
 
                 Assert.That(command.FileName, Is.EqualTo("powershell"));
+                Assert.That(command.ManualCommand, Does.StartWith("[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "));
                 Assert.That(command.ManualCommand, Does.Contain($"& '{scriptPath}'"));
                 Assert.That(command.ManualCommand, Does.Contain($"$env:ULOOP_VERSION='{TestBetaReleaseTag}'"));
                 Assert.That(command.ManualCommand, Does.Contain("$env:ULOOP_ARCHIVE_MANIFEST"));
@@ -350,6 +389,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Assert.That(receivedLines, Does.Contain("line1"));
                 Assert.That(receivedLines, Does.Contain("line2"));
                 Assert.That(receivedLines, Does.Contain("err1"));
+            }
+        }
+
+        [Test]
+        public void RunInstallCommand_ReportsSyntheticStartingLineBeforeProcessOutput()
+        {
+            // Verifies the install path reports a synthetic first progress line before process spawn so the UI shows activity even while the shell is still starting.
+            NativeCliInstallCommand command = BuildEchoInstallCommand();
+            List<string> receivedLines = new();
+
+            CliInstallResult result = NativeCliSetupCommandRunner.RunInstallCommand(
+                command,
+                CancellationToken.None,
+                5000,
+                line =>
+                {
+                    lock (receivedLines)
+                    {
+                        receivedLines.Add(line);
+                    }
+                });
+
+            Assert.That(result.Success, Is.True, result.ErrorOutput);
+            lock (receivedLines)
+            {
+                Assert.That(receivedLines[0], Is.EqualTo("Launching installer process..."));
             }
         }
 

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliCommandBuilder.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliCommandBuilder.cs
@@ -102,14 +102,19 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             // Why: The whole command runs as a single /bin/sh -c string where `set -e` is not applied
             // for us, so every step is && chained to fail fast when curl, checksum verification, or
             // execution fails. `trap ... EXIT` ensures the temp directory is removed even on failure.
+            // The echo progress lines feed the Unity progress label during the otherwise silent
+            // download/verify phase before the installer script produces its own output.
             string scriptName = CliConstants.POSIX_INSTALL_SCRIPT_NAME;
             return "tmp_dir=$(mktemp -d) && "
                 + "trap 'rm -rf \"$tmp_dir\"' EXIT && "
+                + "echo 'Downloading installer script...' && "
                 + $"curl -fsSL {QuotePosixShellValue(scriptUrl)} -o \"$tmp_dir/{scriptName}\" && "
+                + "echo 'Verifying installer script digest...' && "
                 + "( if command -v sha256sum >/dev/null 2>&1; then actual_digest=$(sha256sum \"$tmp_dir/" + scriptName + "\" | awk '{print $1}'); "
                 + "elif command -v shasum >/dev/null 2>&1; then actual_digest=$(shasum -a 256 \"$tmp_dir/" + scriptName + "\" | awk '{print $1}'); "
                 + $"else echo 'sha256sum or shasum is required to verify {scriptName}' >&2; exit 1; fi && "
                 + $"[ \"$actual_digest\" = {QuotePosixShellValue(expectedDigest)} ] ) && "
+                + "echo 'Starting install script...' && "
                 + $"{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE}={QuotePosixShellValue(releaseTag)} "
                 + $"{CliConstants.ARCHIVE_MANIFEST_ENVIRONMENT_VARIABLE}={QuotePosixShellValue(archiveManifest)} sh \"$tmp_dir/{scriptName}\"";
         }
@@ -137,20 +142,34 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             // Why: Downloading to a file and running it with -File avoids the previous streaming
             // execution path. The trusted package pin supplies the expected digest, so the downloaded
-            // script is never executed until the locally calculated SHA-256 matches that pin.
+            // script is never executed until the locally calculated SHA-256 matches that pin. The
+            // digest is computed via .NET SHA-256 APIs instead of Get-FileHash because in Windows
+            // PowerShell 5.1 Get-FileHash is a script function that needs PSModulePath-based module
+            // autoloading, which can be broken in Unity-spawned processes. [Console]::OutputEncoding
+            // is forced to UTF-8 first so captured output is not written in the OEM codepage, and the
+            // catch block writes PSVersion/PSModulePath context to stderr to ease future diagnosis.
+            // The Write-Output progress lines feed the Unity progress label during the otherwise
+            // silent download/verify phase before the installer script produces its own output.
             string scriptName = CliConstants.WINDOWS_INSTALL_SCRIPT_NAME;
-            return "$tmp_dir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP ([System.Guid]::NewGuid().ToString())) -Force; "
+            return "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "
+                + "$tmp_dir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP ([System.Guid]::NewGuid().ToString())) -Force; "
                 + $"$script_path = Join-Path $tmp_dir.FullName {QuotePowerShellSingleQuotedValue(scriptName)}; "
                 + "try { "
                 + "$ErrorActionPreference = 'Stop'; "
                 + "$ProgressPreference = 'SilentlyContinue'; "
+                + "Write-Output 'Downloading installer script...'; "
                 + $"Invoke-WebRequest -UseBasicParsing -Uri {QuotePowerShellSingleQuotedValue(scriptUrl)} -OutFile $script_path; "
-                + "$actual_hash = (Get-FileHash -Algorithm SHA256 -Path $script_path).Hash.ToLowerInvariant(); "
+                + "Write-Output 'Verifying installer script digest...'; "
+                + "$actual_hash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.IO.File]::ReadAllBytes($script_path))).Replace('-','').ToLowerInvariant(); "
                 + $"if ($actual_hash -ne {QuotePowerShellSingleQuotedValue(expectedDigest)}) {{ throw ('Pinned digest mismatch for {scriptName}: actual=' + $actual_hash) }}; "
                 + $"$env:{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE} = {QuotePowerShellSingleQuotedValue(releaseTag)}; "
                 + $"$env:{CliConstants.ARCHIVE_MANIFEST_ENVIRONMENT_VARIABLE} = {BuildPowerShellManifestExpression(archiveManifest)}; "
+                + "Write-Output 'Starting install script...'; "
                 + "& powershell -NoProfile -ExecutionPolicy Bypass -File $script_path; "
                 + $"if ($LASTEXITCODE -ne 0) {{ throw ('{scriptName} exited with code ' + $LASTEXITCODE) }} "
+                + "} catch { "
+                + "[Console]::Error.WriteLine('installer-env PSVersion=' + $PSVersionTable.PSVersion + ' PSModulePath=' + $env:PSModulePath); "
+                + "throw "
                 + "} finally { "
                 + "Remove-Item -Recurse -Force -LiteralPath $tmp_dir.FullName -ErrorAction SilentlyContinue "
                 + "}";
@@ -161,7 +180,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(scriptPath), "scriptPath must not be null or empty");
             UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(releaseTag), "releaseTag must not be null or empty");
 
-            return $"$env:{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE}={QuotePowerShellSingleQuotedValue(releaseTag)}; "
+            // Why: [Console]::OutputEncoding is forced to UTF-8 so captured installer output is not
+            // written in the OEM codepage (mojibake when the Unity-side reader decodes it as UTF-8).
+            return "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "
+                + $"$env:{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE}={QuotePowerShellSingleQuotedValue(releaseTag)}; "
                 + $"$env:{CliConstants.ARCHIVE_MANIFEST_ENVIRONMENT_VARIABLE}={BuildPowerShellManifestExpression(archiveManifest)}; "
                 + $"& {QuotePowerShellSingleQuotedValue(scriptPath)}";
         }

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliSetupCommandRunner.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliSetupCommandRunner.cs
@@ -18,6 +18,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     {
         internal const int INSTALL_PROCESS_WAIT_SLICE_MS = 250;
 
+        // Why a synthetic first line: the installer shell (powershell.exe in particular) can be
+        // slow to start, so a line reported before process spawn guarantees the progress label
+        // shows activity even before the bootstrap emits its first stdout line.
+        internal const string INSTALL_STARTING_LINE = "Launching installer process...";
+
         internal static CliInstallResult RunInstallCommand(
             NativeCliInstallCommand command,
             CancellationToken ct,
@@ -29,6 +34,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
             UnityEngine.Debug.Assert(onOutputLine != null, "onOutputLine must not be null");
             ct.ThrowIfCancellationRequested();
+
+            // Why only here and not in RunCliSetupCommand: the shared runner also serves
+            // uninstall, which streams no progress; the synthetic line is install-only.
+            onOutputLine(INSTALL_STARTING_LINE);
 
             return RunCliSetupCommand(
                 command,
@@ -75,6 +84,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             UnityEngine.Debug.Assert(configureStartInfo != null, "configureStartInfo must not be null");
             ct.ThrowIfCancellationRequested();
 
+            // Why: Setup command output is UTF-8 (the Windows bootstrap forces
+            // [Console]::OutputEncoding to UTF-8 and POSIX shells emit UTF-8), so both streams are
+            // decoded as UTF-8 instead of the platform default, which mojibakes non-ASCII output.
             ProcessStartInfo startInfo = new()
             {
                 FileName = command.FileName,
@@ -82,6 +94,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
                 CreateNoWindow = true
             };
             configureStartInfo(startInfo);

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliUninstallCompletionWaiter.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliUninstallCompletionWaiter.cs
@@ -43,7 +43,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 {
                     return new CliInstallResult(
                         false,
-                        $"Timed out waiting for uLoop CLI uninstall to remove {targetPath}.");
+                        $"Timed out waiting for uloop CLI uninstall to remove {targetPath}.");
                 }
 
                 int delayMs = Math.Min(pollMs, timeoutMs - elapsedMs);

--- a/Packages/src/Editor/Presentation/CliInstallProgressFormatting.cs
+++ b/Packages/src/Editor/Presentation/CliInstallProgressFormatting.cs
@@ -8,6 +8,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     /// </summary>
     internal static class CliInstallProgressFormatting
     {
+        // Why a non-empty placeholder: the installer bootstrap stays silent for seconds
+        // (process start, script download) before its first stdout line arrives, and an
+        // empty detail label during that window reads as a hang.
+        internal const string INITIAL_DETAIL_LINE = "Preparing installer...";
+
         // Why transparent rich-text dots: keep "Installing... (Ns)" word order while
         // reserving three-dot width so the elapsed-time suffix does not shift left/right.
         private const string HIDDEN_DOT_OPEN = "<color=#00000000>";

--- a/Packages/src/Editor/Presentation/CliUninstallPrompt.cs
+++ b/Packages/src/Editor/Presentation/CliUninstallPrompt.cs
@@ -9,9 +9,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     /// </summary>
     internal static class CliUninstallPrompt
     {
-        private const string DialogTitle = "Uninstall uLoop CLI?";
+        private const string DialogTitle = "Uninstall uloop CLI?";
         private const string DialogMessage =
-            "This removes the native uLoop CLI command from this user account and removes package-owned PATH entries when applicable.";
+            "This removes the native uloop CLI command from this user account and removes package-owned PATH entries when applicable.";
         private const string ConfirmButtonText = "OK";
         private const string CancelButtonText = "Cancel";
 

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliInstallProgressView.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliInstallProgressView.cs
@@ -44,7 +44,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _stopwatch.Restart();
             _tickCount = 0;
             _installButton.text = CliInstallProgressFormatting.FormatStatusLine(TimeSpan.Zero, _tickCount);
-            _detailLabel.text = string.Empty;
+            // Why a placeholder instead of clearing: Show() is install-only, and the first
+            // installer stdout line can take seconds; seeding the label gives immediate feedback.
+            _detailLabel.text = CliInstallProgressFormatting.INITIAL_DETAIL_LINE;
             _container.style.display = DisplayStyle.Flex;
 
             if (_tick == null)

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -395,7 +395,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 {
                     EditorUtility.DisplayDialog(
                         "Uninstallation Failed",
-                        $"Failed to uninstall uLoop CLI.\n\n{result.ErrorOutput}",
+                        $"Failed to uninstall uloop CLI.\n\n{result.ErrorOutput}",
                         "OK");
                     return;
                 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "bc86212bf2f189b735e14300a5580cacec379e65"
+  "sharedInputsHash": "4a146ae2b32c8ea65ce2c81cfb254c825ef856b7"
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -501,8 +501,10 @@ New-Item -ItemType Directory -Path $TempDir | Out-Null
 try {
     $ArchivePath = Join-Path $TempDir $AssetName
     $ChecksumPath = Join-Path $TempDir "$AssetName.sha256"
+    Write-Host "Downloading uloop dispatcher archive..."
     Invoke-WebRequest -Uri $DownloadUrl -OutFile $ArchivePath
     Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumPath
+    Write-Host "Verifying uloop dispatcher archive..."
     $ExpectedHash = ((Get-Content -Path $ChecksumPath -Raw) -split "\s+")[0].ToLowerInvariant()
     $ActualHash = Get-UloopSha256Hash -Path $ArchivePath
     if ($ExpectedHash -ne $ActualHash) {
@@ -534,6 +536,7 @@ try {
         throw "Attestation manifest hash mismatch for $AssetName"
     }
 
+    Write-Host "Extracting uloop dispatcher archive..."
     Expand-UloopArchive -ArchivePath $ArchivePath -DestinationPath $TempDir
 
     New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -515,10 +515,13 @@ verify_archive_attestation_manifest() {
 }
 
 mkdir -p "$INSTALL_DIR"
+echo "Downloading uloop dispatcher archive..."
 curl -fsSL "$download_url" -o "$tmp_dir/$asset_name"
 curl -fsSL "$checksum_url" -o "$tmp_dir/$asset_name.sha256"
+echo "Verifying uloop dispatcher archive..."
 verify_checksum
 verify_archive_attestation_manifest
+echo "Extracting uloop dispatcher archive..."
 extract_asset
 staged_uloop_path="$INSTALL_DIR/.uloop-install-$$"
 if [ "$installed_command_name" = "uloop.exe" ]; then


### PR DESCRIPTION
## Summary
- The Windows install bootstrap failed with "Get-FileHash is not recognized" on machines where PSModulePath is broken in Unity-spawned processes (Get-FileHash is a module script function in Windows PowerShell 5.1, unlike the built-in Invoke-WebRequest cmdlet). The digest is now computed via .NET SHA-256 APIs instead, both PowerShell output and the Process stream readers are forced to UTF-8 so localized errors no longer show as mojibake, and PSVersion/PSModulePath are written to stderr on failure to aid future diagnosis.
- Removed the ~15s silent gap after pressing Install: the progress label now shows "Preparing installer..." immediately on click, a synthetic line is reported right before the process spawns, and download/verify/start progress lines are emitted from the remote bootstraps and the standalone install scripts (the install.sh/install.ps1 lines only reach users once the next dispatcher release repins them).
- Fixed "uLoop" -> "uloop" in the uninstall confirmation dialog, failure message, and timeout message to match the CLI's actual command name.

## Test plan
- [x] `bash scripts/test-install-release-filter.sh` — pass
- [x] `bash scripts/test-install-archive-manifest.sh` — pass
- [x] `bash scripts/test-install-version-format.sh` — pass
- [x] `scripts/test-check-release-installer.ps1` — pass
- [x] Reproduced the generated Windows/POSIX bootstrap one-liners byte-for-byte against a `file:///` fake installer: progress lines arrive in order, and the digest-mismatch failure path still stops before running the script
- [ ] Unity EditMode tests (`NativeCliInstallerTests`, `CliInstallProgressFormattingTests`, `CliUninstallPromptTests`) — not run in this environment (uloop bridge not installed in this checkout); please run in Editor before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

