### PR TITLE
fix: Document that --force-recompile is rarely needed in compile skill

### DIFF
--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -17,8 +17,26 @@ uloop compile [--force-recompile <true|false>] [--wait-for-domain-reload <true|f
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--force-recompile` | boolean value | `false` | Force full recompilation (triggers Domain Reload). Pass `true` or `false`; bare flags are not accepted. |
+| `--force-recompile` | boolean value | `false` | Force full recompilation (triggers Domain Reload). Rarely needed — see "When to use --force-recompile" below. Pass `true` or `false`; bare flags are not accepted. |
 | `--wait-for-domain-reload` | boolean value | `false` | Wait until Domain Reload completes before returning. Pass `true` or `false`; bare flags are not accepted. |
+
+## When to use --force-recompile
+
+`--force-recompile true` is almost never needed. Detecting changed files is Unity's job: even when
+files were edited outside the Editor, a plain `uloop compile` refreshes assets and runs every
+recompilation the changes require. "The files were changed externally, so recompile everything
+just in case" is not a valid reason.
+
+Why to avoid it:
+
+- On large projects a full recompile plus Domain Reload can freeze Unity for a long time.
+- With `--wait-for-domain-reload true`, the response crosses a Domain Reload and Unity cannot
+  summarize compiler messages until after reload, so `Success` comes back as `null` and it does
+  not work as a verification step.
+- It puts the Editor into the unstable just-after-reload state for no benefit.
+
+The one legitimate use case: you need warnings hidden by other asmdefs surfaced by a full
+build. Otherwise always run plain `uloop compile`.
 
 ## Global Options
 

--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -22,21 +22,12 @@ uloop compile [--force-recompile <true|false>] [--wait-for-domain-reload <true|f
 
 ## When to use --force-recompile
 
-`--force-recompile true` is almost never needed. Detecting changed files is Unity's job: even when
-files were edited outside the Editor, a plain `uloop compile` refreshes assets and runs every
-recompilation the changes require. "The files were changed externally, so recompile everything
-just in case" is not a valid reason.
-
-Why to avoid it:
-
-- On large projects a full recompile plus Domain Reload can freeze Unity for a long time.
-- With `--wait-for-domain-reload true`, the response crosses a Domain Reload and Unity cannot
-  summarize compiler messages until after reload, so `Success` comes back as `null` and it does
-  not work as a verification step.
-- It puts the Editor into the unstable just-after-reload state for no benefit.
-
-The one legitimate use case: you need warnings hidden by other asmdefs surfaced by a full
-build. Otherwise always run plain `uloop compile`.
+Almost never. Unity itself detects changed files — even when they were edited outside the
+Editor, a plain `uloop compile` runs every recompilation the changes require. A forced full
+recompile can freeze the Editor for a long time on large projects, and with
+`--wait-for-domain-reload true` the response crosses a Domain Reload so `Success` comes back
+as `null`, making it useless as a verification step. The only legitimate use: surfacing
+warnings hidden by other asmdefs with a full build.
 
 ## Global Options
 

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -17,8 +17,26 @@ uloop compile [--force-recompile <true|false>] [--wait-for-domain-reload <true|f
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--force-recompile` | boolean value | `false` | Force full recompilation (triggers Domain Reload). Pass `true` or `false`; bare flags are not accepted. |
+| `--force-recompile` | boolean value | `false` | Force full recompilation (triggers Domain Reload). Rarely needed — see "When to use --force-recompile" below. Pass `true` or `false`; bare flags are not accepted. |
 | `--wait-for-domain-reload` | boolean value | `false` | Wait until Domain Reload completes before returning. Pass `true` or `false`; bare flags are not accepted. |
+
+## When to use --force-recompile
+
+`--force-recompile true` is almost never needed. Detecting changed files is Unity's job: even when
+files were edited outside the Editor, a plain `uloop compile` refreshes assets and runs every
+recompilation the changes require. "The files were changed externally, so recompile everything
+just in case" is not a valid reason.
+
+Why to avoid it:
+
+- On large projects a full recompile plus Domain Reload can freeze Unity for a long time.
+- With `--wait-for-domain-reload true`, the response crosses a Domain Reload and Unity cannot
+  summarize compiler messages until after reload, so `Success` comes back as `null` and it does
+  not work as a verification step.
+- It puts the Editor into the unstable just-after-reload state for no benefit.
+
+The one legitimate use case: you need warnings hidden by other asmdefs surfaced by a full
+build. Otherwise always run plain `uloop compile`.
 
 ## Global Options
 

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -22,21 +22,12 @@ uloop compile [--force-recompile <true|false>] [--wait-for-domain-reload <true|f
 
 ## When to use --force-recompile
 
-`--force-recompile true` is almost never needed. Detecting changed files is Unity's job: even when
-files were edited outside the Editor, a plain `uloop compile` refreshes assets and runs every
-recompilation the changes require. "The files were changed externally, so recompile everything
-just in case" is not a valid reason.
-
-Why to avoid it:
-
-- On large projects a full recompile plus Domain Reload can freeze Unity for a long time.
-- With `--wait-for-domain-reload true`, the response crosses a Domain Reload and Unity cannot
-  summarize compiler messages until after reload, so `Success` comes back as `null` and it does
-  not work as a verification step.
-- It puts the Editor into the unstable just-after-reload state for no benefit.
-
-The one legitimate use case: you need warnings hidden by other asmdefs surfaced by a full
-build. Otherwise always run plain `uloop compile`.
+Almost never. Unity itself detects changed files — even when they were edited outside the
+Editor, a plain `uloop compile` runs every recompilation the changes require. A forced full
+recompile can freeze the Editor for a long time on large projects, and with
+`--wait-for-domain-reload true` the response crosses a Domain Reload so `Success` comes back
+as `null`, making it useless as a verification step. The only legitimate use: surfacing
+warnings hidden by other asmdefs with a full build.
 
 ## Global Options
 

--- a/Packages/src/Editor/Api/McpTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/Compile/Skill/SKILL.md
@@ -17,8 +17,26 @@ uloop compile [--force-recompile <true|false>] [--wait-for-domain-reload <true|f
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--force-recompile` | boolean value | `false` | Force full recompilation (triggers Domain Reload). Pass `true` or `false`; bare flags are not accepted. |
+| `--force-recompile` | boolean value | `false` | Force full recompilation (triggers Domain Reload). Rarely needed — see "When to use --force-recompile" below. Pass `true` or `false`; bare flags are not accepted. |
 | `--wait-for-domain-reload` | boolean value | `false` | Wait until Domain Reload completes before returning. Pass `true` or `false`; bare flags are not accepted. |
+
+## When to use --force-recompile
+
+`--force-recompile true` is almost never needed. Detecting changed files is Unity's job: even when
+files were edited outside the Editor, a plain `uloop compile` refreshes assets and runs every
+recompilation the changes require. "The files were changed externally, so recompile everything
+just in case" is not a valid reason.
+
+Why to avoid it:
+
+- On large projects a full recompile plus Domain Reload can freeze Unity for a long time.
+- With `--wait-for-domain-reload true`, the response crosses a Domain Reload and Unity cannot
+  summarize compiler messages until after reload, so `Success` comes back as `null` and it does
+  not work as a verification step.
+- It puts the Editor into the unstable just-after-reload state for no benefit.
+
+The one legitimate use case: you need warnings hidden by other asmdefs surfaced by a full
+build. Otherwise always run plain `uloop compile`.
 
 ## Global Options
 

--- a/Packages/src/Editor/Api/McpTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/Compile/Skill/SKILL.md
@@ -22,21 +22,12 @@ uloop compile [--force-recompile <true|false>] [--wait-for-domain-reload <true|f
 
 ## When to use --force-recompile
 
-`--force-recompile true` is almost never needed. Detecting changed files is Unity's job: even when
-files were edited outside the Editor, a plain `uloop compile` refreshes assets and runs every
-recompilation the changes require. "The files were changed externally, so recompile everything
-just in case" is not a valid reason.
-
-Why to avoid it:
-
-- On large projects a full recompile plus Domain Reload can freeze Unity for a long time.
-- With `--wait-for-domain-reload true`, the response crosses a Domain Reload and Unity cannot
-  summarize compiler messages until after reload, so `Success` comes back as `null` and it does
-  not work as a verification step.
-- It puts the Editor into the unstable just-after-reload state for no benefit.
-
-The one legitimate use case: you need warnings hidden by other asmdefs surfaced by a full
-build. Otherwise always run plain `uloop compile`.
+Almost never. Unity itself detects changed files — even when they were edited outside the
+Editor, a plain `uloop compile` runs every recompilation the changes require. A forced full
+recompile can freeze the Editor for a long time on large projects, and with
+`--wait-for-domain-reload true` the response crosses a Domain Reload so `Success` comes back
+as `null`, making it useless as a verification step. The only legitimate use: surfacing
+warnings hidden by other asmdefs with a full build.
 
 ## Global Options
 


### PR DESCRIPTION
## Summary
- Add a "When to use --force-recompile" section to the `uloop-compile` skill, explaining that the flag is almost never needed since Unity already detects and recompiles changed files on a plain `uloop compile`
- Document why it should be avoided: it can freeze large projects, crosses a Domain Reload so `Success` comes back as `null` (unusable for verification), and leaves the Editor in an unstable post-reload state
- Mirrors the guidance already present in the `v3-beta` branch's compile skill

## Test plan
- [x] Verified the source SKILL.md and its two generated copies (`.claude/skills`, `.agents/skills`) are byte-identical

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Documented when `uloop-compile --force-recompile true` should and should not be used, emphasizing it’s rarely needed because Unity auto-detects changes (including externally edited files) during a standard `uloop compile`.
- Clarified that `--force-recompile` and `--wait-for-domain-reload` require explicit `true`/`false` values and do not accept bare flags.
- Added cautions that forced recompilation can freeze large Unity projects, and that combining `--wait-for-domain-reload true` can cause the skill to return `Success: null`, making the result unusable for verification.
- Documented the only legitimate use case: surfacing warnings hidden by other assembly definitions.
- Synchronized the guidance across all copies of the skill documentation (including the `v3-beta`-mirrored content), verified as byte-identical between source and generated skill docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->