### PR TITLE
fix: Tighten v3 migration skill guidance and align wizard prompt

### DIFF
--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
@@ -10,6 +10,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     internal static class SkillTargetInstaller
     {
+        // Cleanup names for previously installed skill directories. Keep them here
+        // and in the dispatcher's deprecatedSkillNames (cli/dispatcher/internal/
+        // dispatcher/skills.go); agent-facing V2-to-V3 CLI migration guidance lives
+        // in Packages/src/TemporarySkills~/v3-cli-invocation-migration.
         private static readonly string[] DeprecatedSkillNames =
         {
             "uloop-wait-for-pause-point",

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardText.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardText.cs
@@ -26,7 +26,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             "for V3.\n\n" +
             "Scope:\n" +
             "- Check SKILL.md, Markdown, POSIX shell scripts, and PowerShell scripts.\n" +
-            "- Migrate V2 boolean arguments, renamed first-party options, and removed commands.\n" +
+            "- Migrate V2 boolean arguments and renamed first-party options.\n" +
+            "- Report removed commands as migration candidates. Do not rewrite or delete them.\n" +
             "- Read nearby context before editing. Do not change C# snippets, enum/member references, regex match properties, DTO properties, or non-uloop JSON.\n" +
             "- After editing, summarize changed files, remaining candidates, and any commands I should verify manually.";
         internal const string MigrationNotCheckedText = "C# source migration status has not been checked.";

--- a/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/SKILL.md
+++ b/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/SKILL.md
@@ -5,8 +5,6 @@ description: Migrate only uloop V2 CLI option syntax in agent skills, Markdown, 
 
 # V3 CLI Invocation Migration
 
-Agent-facing CLI migration candidates live in this skill. Installed-skill cleanup names stay in `SkillTargetInstaller` / `skills.go` `deprecatedSkillNames`.
-
 Use this skill to update V2-era `uloop` CLI option syntax to V3
 syntax in agent-facing docs and automation.
 
@@ -46,6 +44,13 @@ Prefer `rg` for searches when available. If `rg` is unavailable, use the best av
 - For first-party tools, use the reference table. `compile`, `run-tests`,
   `get-hierarchy`, `record-input`, and `replay-input` have special renamed
   negative flags.
+- For first-party boolean options that are not in the reference tables, run
+  `uloop <command> --help` and apply the boolean rules to the printed
+  default: `default: enabled` means the V3 default is true, and
+  `default: disabled` means it is false.
+- Some option names are valid V3 syntax on one command and V2 leftovers on
+  another. Match every hit to its `uloop` command before editing; the
+  reference lists the known same-name collisions.
 - A valid edit is limited to replacing, adding, or removing a `uloop` option
   token and the boolean value attached to that option in the same invocation.
 - Preserve surrounding Markdown, shell, and PowerShell formatting. Do not

--- a/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md
+++ b/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md
@@ -76,9 +76,12 @@ For third-party tools, inspect the current tool schema or docs before choosing t
 ## Same-Name Options on Other Commands
 
 These option names appear in the table above for one command but are valid
-V3 syntax on another command. Never migrate them by token match alone.
+V3 syntax on another command. Never migrate them by token match alone. On the
+other command, only the already-bare flag is exempt: value-bearing forms such
+as `--flag true` or `--flag=false` still follow the Boolean Argument Rules
+against that command's default.
 
-| Option | Migrate on | Leave unchanged on |
+| Option | Migrate on | Also valid V3 on |
 | --- | --- | --- |
 | `wait-for-domain-reload` | `uloop compile` (see Special First-Party Options) | `uloop execute-dynamic-code`, where bare `--wait-for-domain-reload` is a valid V3 default-false flag |
 | `include-inactive` | `uloop get-hierarchy` (see Special First-Party Options) | `uloop find-game-objects`, where bare `--include-inactive` is a valid V3 default-false flag |

--- a/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md
+++ b/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md
@@ -1,7 +1,5 @@
 # First-Party V2 to V3 CLI Migration
 
-Agent-facing CLI migration candidates live here. Installed-skill cleanup names stay in `SkillTargetInstaller` / `skills.go` `deprecatedSkillNames`.
-
 Use this reference as the canonical option migration map. Search results are
 only candidates. Edit a match only after the surrounding context proves it is
 a V2 `uloop` invocation.
@@ -23,6 +21,9 @@ Prefer `rg` when available, but any repository search tool is acceptable.
 - Search `uloop` first and inspect command examples, shell scripts, PowerShell scripts, and agent skills.
 - Search boolean-looking CLI syntax: `--` plus nearby `true` or `false`, including `--flag true`, `--flag=false`, and inline Markdown command examples.
 - Search renamed first-party option names: `wait-for-domain-reload`, `reload-external-scene-changes`, `force-recompile`, `save-before-run`, `show-overlay`, `include-components`, `include-inactive`, and `compile-only`.
+- Treat renamed-option hits as command-scoped. `wait-for-domain-reload` and
+  `include-inactive` also exist as valid V3 positive flags on other
+  commands; check Same-Name Options on Other Commands before editing them.
 - Search removed or renamed first-party commands only to report them as
   out-of-scope command migration candidates: `get-project-info`, `get-version`,
   `unity-search`, `execute-menu-item`, `get-menu-items`,
@@ -41,6 +42,11 @@ Prefer `rg` when available, but any repository search tool is acceptable.
 | `--flag=true` | remove the option when the V3 default is already true |
 | `--flag false` | use the V3 negative option when the V3 default is true |
 | `--flag=false` | use the V3 negative option when the V3 default is true |
+
+For first-party boolean options that are not listed in Special First-Party
+Options, run `uloop <command> --help`. Every V3 flag is printed with its
+default: `default: enabled` means the V3 default is true, and
+`default: disabled` means it is false.
 
 For third-party tools, inspect the current tool schema or docs before choosing the replacement. Do not infer third-party negative flags from first-party conventions.
 
@@ -66,6 +72,19 @@ For third-party tools, inspect the current tool schema or docs before choosing t
 | `uloop get-hierarchy` | `--include-inactive false` | `--no-include-inactive` |
 | `uloop execute-dynamic-code` | `--compile-only true` | `--compile-only` |
 | `uloop execute-dynamic-code` | `--compile-only false` | remove |
+
+## Same-Name Options on Other Commands
+
+These option names appear in the table above for one command but are valid
+V3 syntax on another command. Never migrate them by token match alone.
+
+| Option | Migrate on | Leave unchanged on |
+| --- | --- | --- |
+| `wait-for-domain-reload` | `uloop compile` (see Special First-Party Options) | `uloop execute-dynamic-code`, where bare `--wait-for-domain-reload` is a valid V3 default-false flag |
+| `include-inactive` | `uloop get-hierarchy` (see Special First-Party Options) | `uloop find-game-objects`, where bare `--include-inactive` is a valid V3 default-false flag |
+
+Bare `--force-recompile` on `uloop compile` and bare `--compile-only` on
+`uloop execute-dynamic-code` are already valid V3 syntax and need no edit.
 
 ## Removed First-Party Commands
 

--- a/cli/dispatcher/internal/dispatcher/skills.go
+++ b/cli/dispatcher/internal/dispatcher/skills.go
@@ -65,6 +65,10 @@ func buildDefaultSkillTargetIDs() []string {
 	return ids
 }
 
+// deprecatedSkillNames lists previously installed skill directory names that
+// skills install/uninstall runs clean up. Keep cleanup names here and in the
+// Unity-side SkillTargetInstaller; agent-facing V2-to-V3 CLI migration
+// guidance lives in Packages/src/TemporarySkills~/v3-cli-invocation-migration.
 var deprecatedSkillNames = []string{
 	"uloop-wait-for-pause-point",
 	"uloop-capture-window",


### PR DESCRIPTION
## Summary

The `v3-cli-invocation-migration` skill (installed into third-party projects via the migration wizard's "Install Migration Skill" button) predates several V3 changes. This PR fixes four accuracy problems found by re-auditing the skill against the current tool schemas and CLI flag-naming logic:

1. **Same-name option collisions**: `--wait-for-domain-reload` and `--include-inactive` are listed as V2 migration targets, but they are now valid V3 positive flags on `uloop execute-dynamic-code` and `uloop find-game-objects` respectively. Added a "Same-Name Options on Other Commands" reference section and a command-scoping rule so agents do not remove or negate valid V3 usage by token match alone.
2. **No way to resolve unlisted first-party defaults**: for first-party boolean options outside the special table, the skill never said how to find the V3 default. Added guidance to run `uloop <command> --help` and read the printed `default: enabled` / `default: disabled`.
3. **Repo-internal maintainer note leaked into the installed skill**: the note referencing `SkillTargetInstaller` / `skills.go` `deprecatedSkillNames` is meaningless in third-party projects. Removed it from the skill and restated it as code comments above the two cleanup lists.
4. **Wizard prompt contradiction**: the copyable AI prompt said "Migrate ... removed commands" while the skill treats removed commands as report-only. Reworded the prompt to match.

The special-options table itself was verified against `cli/common/tools/default-tools.json` and `cli/common/tooldocs/tool_options.go` and needed no changes.

## Verification

- `scripts/check-go-cli.sh`: format / vet / lint (0 issues) / tests all pass
- `dist/darwin-arm64/uloop compile`: 0 errors, 0 warnings
- `rg "Installed-skill cleanup names" Packages/src/TemporarySkills~` and `rg "and removed commands" Packages/src/Editor` both return no hits

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

