### PR TITLE
fix: Improve skills setup panel empty state and refresh scoping

### DIFF
--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -222,7 +222,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 installableSkillTargets: new List<SkillSetupTargetInfo>
                 {
                     CreateSkillTarget("Claude", ".claude", SkillInstallState.Checking),
-                    CreateSkillTarget("Cursor", ".cursor", SkillInstallState.Missing)
+                    CreateSkillTarget("Common", ".agents", SkillInstallState.Missing)
                 }));
 
             Assert.That(foldout.value, Is.False);
@@ -386,8 +386,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isSkillStateChecking: isSkillStateChecking ?? isChecking,
                 isClaudeSkillsInstalled: false,
                 isAgentsSkillsInstalled: false,
-                isCursorSkillsInstalled: false,
-                isGeminiSkillsInstalled: false,
                 isCodexSkillsInstalled: false,
                 isAntigravitySkillsInstalled: false,
                 selectedTargetInstallState,

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -181,14 +181,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             CliSetupSection section = new(root);
             List<SkillSetupTargetInfo> targets = new()
             {
-                new(
-                    "Claude",
-                    ".claude",
-                    "--claude",
-                    hasSkillsDirectory: true,
-                    hasExistingSkills: false,
-                    hasDifferentLayoutSkills: false,
-                    SkillInstallState.Missing)
+                CreateSkillTarget("Claude", ".claude", SkillInstallState.Missing)
             };
             CliSetupData data = CreateData(
                 isCliInstalled: true,
@@ -202,6 +195,142 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Label noTargetsMessage = root.Q<Label>("skills-no-targets-message");
             Assert.That(installAllSkillsButton.style.display.value, Is.EqualTo(DisplayStyle.Flex));
             Assert.That(noTargetsMessage.style.display.value, Is.EqualTo(DisplayStyle.None));
+        }
+
+        [Test]
+        public void Update_WhenCheckingTargetsArrive_DoesNotChangeSpecificTargetFoldout()
+        {
+            // Verifies Checking updates leave the foldout value untouched until a resolved state arrives.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            Foldout foldout = root.Q<Foldout>("install-specific-target-foldout");
+            section.Update(CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Missing,
+                installableSkillTargets: new List<SkillSetupTargetInfo>
+                {
+                    CreateSkillTarget("Claude", ".claude", SkillInstallState.Missing)
+                }));
+            Assert.That(foldout.value, Is.True);
+            foldout.SetValueWithoutNotify(false);
+
+            section.Update(CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Checking,
+                installableSkillTargets: new List<SkillSetupTargetInfo>
+                {
+                    CreateSkillTarget("Claude", ".claude", SkillInstallState.Checking),
+                    CreateSkillTarget("Cursor", ".cursor", SkillInstallState.Missing)
+                }));
+
+            Assert.That(foldout.value, Is.False);
+        }
+
+        [Test]
+        public void Update_WhenMissingTargetsBecomeInstalled_ClosesSpecificTargetFoldout()
+        {
+            // Verifies the foldout closes when reload resolves missing targets to installed.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            Foldout foldout = root.Q<Foldout>("install-specific-target-foldout");
+            section.Update(CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Missing,
+                installableSkillTargets: new List<SkillSetupTargetInfo>
+                {
+                    CreateSkillTarget("Claude", ".claude", SkillInstallState.Missing)
+                }));
+            Assert.That(foldout.value, Is.True);
+
+            section.Update(CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                installableSkillTargets: new List<SkillSetupTargetInfo>
+                {
+                    CreateSkillTarget("Claude", ".claude", SkillInstallState.Installed)
+                }));
+
+            Assert.That(foldout.value, Is.False);
+        }
+
+        [Test]
+        public void Update_WhenInstalledDefaultUnchanged_PreservesUserOpenedFoldout()
+        {
+            // Verifies a user-opened foldout stays open across later installed-only updates.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            Foldout foldout = root.Q<Foldout>("install-specific-target-foldout");
+            List<SkillSetupTargetInfo> installedTargets = new()
+            {
+                CreateSkillTarget("Claude", ".claude", SkillInstallState.Installed)
+            };
+            section.Update(CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                installableSkillTargets: installedTargets));
+            Assert.That(foldout.value, Is.False);
+            foldout.SetValueWithoutNotify(true);
+
+            section.Update(CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                installableSkillTargets: new List<SkillSetupTargetInfo>
+                {
+                    CreateSkillTarget("Claude", ".claude", SkillInstallState.Installed)
+                }));
+
+            Assert.That(foldout.value, Is.True);
+        }
+
+        [Test]
+        public void Update_WhenMissingDefaultUnchanged_PreservesUserClosedFoldout()
+        {
+            // Verifies a user-closed foldout is not forced open while targets remain missing.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            Foldout foldout = root.Q<Foldout>("install-specific-target-foldout");
+            section.Update(CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Missing,
+                installableSkillTargets: new List<SkillSetupTargetInfo>
+                {
+                    CreateSkillTarget("Claude", ".claude", SkillInstallState.Missing)
+                }));
+            Assert.That(foldout.value, Is.True);
+            foldout.SetValueWithoutNotify(false);
+
+            section.Update(CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Missing,
+                installableSkillTargets: new List<SkillSetupTargetInfo>
+                {
+                    CreateSkillTarget("Claude", ".claude", SkillInstallState.Missing)
+                }));
+
+            Assert.That(foldout.value, Is.False);
+        }
+
+        private static SkillSetupTargetInfo CreateSkillTarget(
+            string displayName,
+            string dirName,
+            SkillInstallState installState)
+        {
+            return new(
+                displayName,
+                dirName,
+                "--flag",
+                hasSkillsDirectory: true,
+                hasExistingSkills: true,
+                hasDifferentLayoutSkills: false,
+                installState);
         }
 
         private static VisualElement CreateRootElement()

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -130,6 +130,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(skillsTargetField.enabledSelf, Is.False);
         }
 
+        [Test]
+        public void Update_WhenNoInstallableTargets_HidesBulkInstallAndShowsGuidance()
+        {
+            // Verifies empty detection hides the bulk Install Skills button and shows guidance instead.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Missing,
+                installableSkillTargets: new List<SkillSetupTargetInfo>());
+
+            section.Update(data);
+
+            Button installAllSkillsButton = root.Q<Button>("install-all-skills-button");
+            Label noTargetsMessage = root.Q<Label>("skills-no-targets-message");
+            Assert.That(installAllSkillsButton.style.display.value, Is.EqualTo(DisplayStyle.None));
+            Assert.That(noTargetsMessage.style.display.value, Is.EqualTo(DisplayStyle.Flex));
+        }
+
+        [Test]
+        public void Update_WhenInstallableTargetsExist_ShowsBulkInstallAndHidesGuidance()
+        {
+            // Verifies detected targets keep the bulk Install Skills button and hide empty-state guidance.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                new(
+                    "Claude",
+                    ".claude",
+                    "--claude",
+                    hasSkillsDirectory: true,
+                    hasExistingSkills: false,
+                    hasDifferentLayoutSkills: false,
+                    SkillInstallState.Missing)
+            };
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Missing,
+                installableSkillTargets: targets);
+
+            section.Update(data);
+
+            Button installAllSkillsButton = root.Q<Button>("install-all-skills-button");
+            Label noTargetsMessage = root.Q<Label>("skills-no-targets-message");
+            Assert.That(installAllSkillsButton.style.display.value, Is.EqualTo(DisplayStyle.Flex));
+            Assert.That(noTargetsMessage.style.display.value, Is.EqualTo(DisplayStyle.None));
+        }
+
         private static VisualElement CreateRootElement()
         {
             VisualElement root = new();
@@ -146,6 +197,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             skillsSetupPanel.Add(new VisualElement { name = "skill-target-status-list" });
             skillsSetupPanel.Add(new VisualElement { name = "skill-target-status-divider" });
             skillsSetupPanel.Add(new Label { name = "skill-target-status-summary" });
+            skillsSetupPanel.Add(new Label { name = "skills-no-targets-message" });
             skillsSetupPanel.Add(new Button { name = "install-all-skills-button" });
             Foldout specificTargetFoldout = new() { name = "install-specific-target-foldout" };
             VisualElement groupSkillsRow = new() { name = "group-skills-row" };
@@ -166,7 +218,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private static CliSetupData CreateData(
             bool isCliInstalled,
             bool isChecking,
-            SkillInstallState selectedTargetInstallState)
+            SkillInstallState selectedTargetInstallState,
+            IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets = null)
         {
             return new CliSetupData(
                 isCliInstalled,
@@ -187,7 +240,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 SkillsTarget.Claude,
                 groupSkillsUnderUnityCliLoop: false,
                 isInstallingSkills: false,
-                installableSkillTargets: new List<SkillSetupTargetInfo>());
+                installableSkillTargets: installableSkillTargets ?? new List<SkillSetupTargetInfo>());
         }
     }
 }

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -85,14 +85,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void Update_WhenCliRefreshIsChecking_ShowsSkillsCheckingState()
+        public void Update_WhenSkillStateIsChecking_ShowsSkillsCheckingState()
         {
-            // Verifies that IsChecking routes the shared skills panel into ShowChecking.
+            // Verifies that IsSkillStateChecking routes the shared skills panel into ShowChecking.
             VisualElement root = CreateRootElement();
             CliSetupSection section = new(root);
             CliSetupData data = CreateData(
                 isCliInstalled: true,
-                isChecking: true,
+                isChecking: false,
+                isSkillStateChecking: true,
                 selectedTargetInstallState: SkillInstallState.Missing);
 
             section.Update(data);
@@ -111,6 +112,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(installSelectedSkillsButton.text, Is.EqualTo("Checking..."));
             Assert.That(skillsTargetField.enabledSelf, Is.False);
             Assert.That(groupSkillsToggle.enabledSelf, Is.False);
+        }
+
+        [Test]
+        public void Update_WhenOnlyCliIsChecking_DoesNotShowSkillsCheckingState()
+        {
+            // Verifies CLI refresh checking does not force the skills panel into Checking... state.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: true,
+                isSkillStateChecking: false,
+                selectedTargetInstallState: SkillInstallState.Missing);
+
+            section.Update(data);
+
+            Button installAllSkillsButton = root.Q<Button>("install-all-skills-button");
+            EnumField skillsTargetField = root.Q<EnumField>("skills-target-field");
+            Button refreshCliVersionButton = root.Q<Button>("refresh-cli-version-button");
+            Assert.That(installAllSkillsButton.text, Is.Not.EqualTo("Checking..."));
+            Assert.That(skillsTargetField.enabledSelf, Is.True);
+            Assert.That(refreshCliVersionButton.enabledSelf, Is.False);
         }
 
         [Test]
@@ -219,7 +242,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool isCliInstalled,
             bool isChecking,
             SkillInstallState selectedTargetInstallState,
-            IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets = null)
+            IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets = null,
+            bool? isSkillStateChecking = null)
         {
             return new CliSetupData(
                 isCliInstalled,
@@ -230,6 +254,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 needsCliPathSetup: false,
                 isInstallingCli: false,
                 isChecking,
+                isSkillStateChecking: isSkillStateChecking ?? isChecking,
                 isClaudeSkillsInstalled: false,
                 isAgentsSkillsInstalled: false,
                 isCursorSkillsInstalled: false,

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -192,6 +192,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             installProgress.Add(new Label { name = "cli-install-progress-label" });
             root.Add(installProgress);
 
+            root.Add(new Button { name = "refresh-skills-state-button" });
             VisualElement skillsSubsection = new() { name = "skills-subsection" };
             VisualElement skillsSetupPanel = new() { name = "skills-setup-panel" };
             skillsSetupPanel.Add(new VisualElement { name = "skill-target-status-list" });
@@ -206,7 +207,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             specificTargetFoldout.Add(groupSkillsRow);
             VisualElement skillsTargetRow = new() { name = "skills-target-row" };
             skillsTargetRow.Add(new EnumField { name = "skills-target-field" });
-            skillsTargetRow.Add(new Button { name = "refresh-skills-state-button" });
             specificTargetFoldout.Add(skillsTargetRow);
             specificTargetFoldout.Add(new Button { name = "install-selected-skills-button" });
             skillsSetupPanel.Add(specificTargetFoldout);

--- a/Assets/Tests/Editor/SkillsSetupPanelViewTests.cs
+++ b/Assets/Tests/Editor/SkillsSetupPanelViewTests.cs
@@ -292,21 +292,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void ShouldExpandSpecificTargetFoldout_WhenAnyChecking_ReturnsFalse()
-        {
-            // Verifies the foldout does not expand while any target install state is still Checking.
-            List<SkillSetupTargetInfo> targets = new()
-            {
-                CreateTarget("Claude", ".claude", SkillInstallState.Checking),
-                CreateTarget("Cursor", ".cursor", SkillInstallState.Missing)
-            };
-
-            bool shouldExpand = SkillsSetupPanelView.ShouldExpandSpecificTargetFoldout(targets);
-
-            Assert.That(shouldExpand, Is.False);
-        }
-
-        [Test]
         public void ShouldExpandSpecificTargetFoldout_WhenOnlyOutdated_ReturnsFalse()
         {
             // Verifies outdated targets count as installed for foldout expansion and stay collapsed.

--- a/Assets/Tests/Editor/SkillsSetupPanelViewTests.cs
+++ b/Assets/Tests/Editor/SkillsSetupPanelViewTests.cs
@@ -48,7 +48,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(SkillsTarget.Cursor, "Cursor", ".cursor", "--cursor")]
         [TestCase(SkillsTarget.Gemini, "Gemini CLI", ".gemini", "--gemini")]
         [TestCase(SkillsTarget.Codex, "Codex CLI", ".codex", "--codex")]
-        [TestCase(SkillsTarget.Agents, "Other (.agents)", ".agents", "--agents")]
+        [TestCase(SkillsTarget.Agents, "Other", ".agents", "--agents")]
         public void CreateFirstInstallSkillTarget_ReturnsMappedTarget(
             SkillsTarget targetType,
             string expectedDisplayName,

--- a/Assets/Tests/Editor/SkillsSetupPanelViewTests.cs
+++ b/Assets/Tests/Editor/SkillsSetupPanelViewTests.cs
@@ -48,7 +48,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(SkillsTarget.Cursor, "Cursor", ".cursor", "--cursor")]
         [TestCase(SkillsTarget.Gemini, "Gemini CLI", ".gemini", "--gemini")]
         [TestCase(SkillsTarget.Codex, "Codex CLI", ".codex", "--codex")]
-        [TestCase(SkillsTarget.Agents, "Other", ".agents", "--agents")]
+        [TestCase(SkillsTarget.Agents, "Common", ".agents", "--agents")]
         public void CreateFirstInstallSkillTarget_ReturnsMappedTarget(
             SkillsTarget targetType,
             string expectedDisplayName,

--- a/Assets/Tests/Editor/SkillsSetupPanelViewTests.cs
+++ b/Assets/Tests/Editor/SkillsSetupPanelViewTests.cs
@@ -250,18 +250,90 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(summary, Is.EqualTo("Installed for 2 targets"));
         }
 
-        [TestCase(0, true)]
-        [TestCase(1, false)]
-        [TestCase(3, false)]
-        public void ShouldExpandSpecificTargetFoldout_ReturnsExpectedValue(
-            int installableTargetCount,
-            bool expected)
+        [Test]
+        public void ShouldExpandSpecificTargetFoldout_WhenNoTargets_ReturnsTrue()
         {
-            // Verifies the specific-target foldout auto-expands only when no installable targets exist.
-            bool shouldExpand = SkillsSetupPanelView.ShouldExpandSpecificTargetFoldout(
-                installableTargetCount);
+            // Verifies the foldout expands when no installable skill targets were detected.
+            List<SkillSetupTargetInfo> targets = new();
 
-            Assert.That(shouldExpand, Is.EqualTo(expected));
+            bool shouldExpand = SkillsSetupPanelView.ShouldExpandSpecificTargetFoldout(targets);
+
+            Assert.That(shouldExpand, Is.True);
+        }
+
+        [Test]
+        public void ShouldExpandSpecificTargetFoldout_WhenAllInstalled_ReturnsFalse()
+        {
+            // Verifies the foldout stays collapsed when every detected target is already installed.
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                CreateTarget("Claude", ".claude", SkillInstallState.Installed),
+                CreateTarget("Agents", ".agents", SkillInstallState.Installed)
+            };
+
+            bool shouldExpand = SkillsSetupPanelView.ShouldExpandSpecificTargetFoldout(targets);
+
+            Assert.That(shouldExpand, Is.False);
+        }
+
+        [Test]
+        public void ShouldExpandSpecificTargetFoldout_WhenAnyMissing_ReturnsTrue()
+        {
+            // Verifies the foldout expands when at least one detected target still needs install.
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                CreateTarget("Claude", ".claude", SkillInstallState.Installed),
+                CreateTarget("Cursor", ".cursor", SkillInstallState.Missing)
+            };
+
+            bool shouldExpand = SkillsSetupPanelView.ShouldExpandSpecificTargetFoldout(targets);
+
+            Assert.That(shouldExpand, Is.True);
+        }
+
+        [Test]
+        public void ShouldExpandSpecificTargetFoldout_WhenAnyChecking_ReturnsFalse()
+        {
+            // Verifies the foldout does not expand while any target install state is still Checking.
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                CreateTarget("Claude", ".claude", SkillInstallState.Checking),
+                CreateTarget("Cursor", ".cursor", SkillInstallState.Missing)
+            };
+
+            bool shouldExpand = SkillsSetupPanelView.ShouldExpandSpecificTargetFoldout(targets);
+
+            Assert.That(shouldExpand, Is.False);
+        }
+
+        [Test]
+        public void ShouldExpandSpecificTargetFoldout_WhenOnlyOutdated_ReturnsFalse()
+        {
+            // Verifies outdated targets count as installed for foldout expansion and stay collapsed.
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                CreateTarget("Claude", ".claude", SkillInstallState.Outdated),
+                CreateTarget("Agents", ".agents", SkillInstallState.Outdated)
+            };
+
+            bool shouldExpand = SkillsSetupPanelView.ShouldExpandSpecificTargetFoldout(targets);
+
+            Assert.That(shouldExpand, Is.False);
+        }
+
+        private static SkillSetupTargetInfo CreateTarget(
+            string displayName,
+            string dirName,
+            SkillInstallState installState)
+        {
+            return new(
+                displayName,
+                dirName,
+                "--flag",
+                hasSkillsDirectory: true,
+                hasExistingSkills: true,
+                hasDifferentLayoutSkills: false,
+                installState);
         }
     }
 }

--- a/Assets/Tests/Editor/SkillsSetupPanelViewTests.cs
+++ b/Assets/Tests/Editor/SkillsSetupPanelViewTests.cs
@@ -19,7 +19,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             List<SkillSetupTargetInfo> targets = new()
             {
                 new("Claude Code", ".claude", "--claude", true, true),
-                new("Cursor", ".cursor", "--cursor", false, false),
+                new("Common", ".agents", "--agents", false, false),
                 new("Codex CLI", ".codex", "--codex", true, false, hasDifferentLayoutSkills: true)
             };
 
@@ -45,8 +45,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(target.HasExistingSkills, Is.False);
         }
 
-        [TestCase(SkillsTarget.Cursor, "Cursor", ".cursor", "--cursor")]
-        [TestCase(SkillsTarget.Gemini, "Gemini CLI", ".gemini", "--gemini")]
         [TestCase(SkillsTarget.Codex, "Codex CLI", ".codex", "--codex")]
         [TestCase(SkillsTarget.Agents, "Common", ".agents", "--agents")]
         public void CreateFirstInstallSkillTarget_ReturnsMappedTarget(
@@ -283,7 +281,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             List<SkillSetupTargetInfo> targets = new()
             {
                 CreateTarget("Claude", ".claude", SkillInstallState.Installed),
-                CreateTarget("Cursor", ".cursor", SkillInstallState.Missing)
+                CreateTarget("Common", ".agents", SkillInstallState.Missing)
             };
 
             bool shouldExpand = SkillsSetupPanelView.ShouldExpandSpecificTargetFoldout(targets);

--- a/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
+++ b/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
@@ -13,8 +13,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     public class SkillsTargetSelectionResolverTests
     {
         [TestCase(SkillsTarget.Claude, true, "Claude Code", ".claude", "skills install --claude")]
-        [TestCase(SkillsTarget.Cursor, true, "Cursor", ".cursor", "skills install --cursor")]
-        [TestCase(SkillsTarget.Gemini, true, "Gemini CLI", ".gemini", "skills install --gemini")]
         [TestCase(SkillsTarget.Codex, true, "Codex CLI", ".codex", "skills install --codex")]
         [TestCase(SkillsTarget.Agents, true, "Common", ".agents", "skills install --agents")]
         [TestCase(SkillsTarget.Claude, false, "Claude Code", ".claude", "skills install --claude --flat")]
@@ -50,8 +48,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [TestCase(SkillsTarget.Claude, true)]
-        [TestCase(SkillsTarget.Cursor, false)]
-        [TestCase(SkillsTarget.Gemini, true)]
         [TestCase(SkillsTarget.Codex, false)]
         [TestCase(SkillsTarget.Agents, true)]
         public void IsInstalled_ReturnsExpectedStateForTarget(
@@ -70,8 +66,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isSkillStateChecking: false,
                 isClaudeSkillsInstalled: true,
                 isAgentsSkillsInstalled: true,
-                isCursorSkillsInstalled: false,
-                isGeminiSkillsInstalled: true,
                 isCodexSkillsInstalled: false,
                 isAntigravitySkillsInstalled: false,
                 selectedTargetInstallState: SkillInstallState.Installed,

--- a/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
+++ b/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
@@ -16,7 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(SkillsTarget.Cursor, true, "Cursor", ".cursor", "skills install --cursor")]
         [TestCase(SkillsTarget.Gemini, true, "Gemini CLI", ".gemini", "skills install --gemini")]
         [TestCase(SkillsTarget.Codex, true, "Codex CLI", ".codex", "skills install --codex")]
-        [TestCase(SkillsTarget.Agents, true, "Other (.agents)", ".agents", "skills install --agents")]
+        [TestCase(SkillsTarget.Agents, true, "Other", ".agents", "skills install --agents")]
         [TestCase(SkillsTarget.Claude, false, "Claude Code", ".claude", "skills install --claude --flat")]
         public void Resolve_ReturnsMappedSelection(
             SkillsTarget target,
@@ -32,6 +32,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(selection.DisplayName, Is.EqualTo(expectedDisplayName));
             Assert.That(selection.DirectoryName, Is.EqualTo(expectedDirectoryName));
             Assert.That(selection.InstallArguments, Is.EqualTo(expectedInstallArguments));
+        }
+
+        [Test]
+        public void Resolve_DisplayNameDoesNotContainDirectoryName_ForAllTargets()
+        {
+            // Verifies list labels can append ({DirectoryName}/) without duplicating the directory name.
+            foreach (SkillsTarget target in Enum.GetValues(typeof(SkillsTarget)))
+            {
+                SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(target, true);
+
+                Assert.That(
+                    selection.DisplayName,
+                    Does.Not.Contain(selection.DirectoryName),
+                    $"DisplayName '{selection.DisplayName}' must not include DirectoryName '{selection.DirectoryName}' for {target}");
+            }
         }
 
         [TestCase(SkillsTarget.Claude, true)]

--- a/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
+++ b/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
@@ -16,7 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(SkillsTarget.Cursor, true, "Cursor", ".cursor", "skills install --cursor")]
         [TestCase(SkillsTarget.Gemini, true, "Gemini CLI", ".gemini", "skills install --gemini")]
         [TestCase(SkillsTarget.Codex, true, "Codex CLI", ".codex", "skills install --codex")]
-        [TestCase(SkillsTarget.Agents, true, "Other", ".agents", "skills install --agents")]
+        [TestCase(SkillsTarget.Agents, true, "Common", ".agents", "skills install --agents")]
         [TestCase(SkillsTarget.Claude, false, "Claude Code", ".claude", "skills install --claude --flat")]
         public void Resolve_ReturnsMappedSelection(
             SkillsTarget target,

--- a/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
+++ b/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
@@ -52,6 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 needsCliPathSetup: false,
                 isInstallingCli: false,
                 isChecking: false,
+                isSkillStateChecking: false,
                 isClaudeSkillsInstalled: true,
                 isAgentsSkillsInstalled: true,
                 isCursorSkillsInstalled: false,

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowRefreshPolicyTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowRefreshPolicyTests.cs
@@ -217,6 +217,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(delaySeconds, Is.EqualTo(expectedDelaySeconds).Within(0.0001));
         }
 
+        [Test]
+        public void IsSkillStateChecking_WhenCliCheckCompletedButSkillScanPending_ReturnsTrue()
+        {
+            // Verifies pending skill-target scan stays in checking after CLI check completes.
+            bool isSkillStateChecking = UnityCliLoopSettingsWindowRefreshPolicy.IsSkillStateChecking(
+                isCliCheckCompleted: true,
+                includeSkillDirectoryChecks: true,
+                hasSkillTargetScanResult: false);
+
+            Assert.That(isSkillStateChecking, Is.True);
+        }
+
+        [TestCase(false, true, true, true)]
+        [TestCase(true, false, true, true)]
+        [TestCase(true, true, false, true)]
+        [TestCase(true, true, true, false)]
+        public void IsSkillStateChecking_ReturnsExpectedValue(
+            bool isCliCheckCompleted,
+            bool includeSkillDirectoryChecks,
+            bool hasSkillTargetScanResult,
+            bool expected)
+        {
+            // Verifies skill-state checking combines CLI completion, include flag, and scan arrival.
+            bool isSkillStateChecking = UnityCliLoopSettingsWindowRefreshPolicy.IsSkillStateChecking(
+                isCliCheckCompleted,
+                includeSkillDirectoryChecks,
+                hasSkillTargetScanResult);
+
+            Assert.That(isSkillStateChecking, Is.EqualTo(expected));
+        }
+
         private static ToolSettingsSectionData CreateToolSettingsData(
             bool showToolSettings,
             bool isRegistryAvailable)

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
@@ -30,8 +30,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly SkillTargetDefinition[] SkillTargets =
         {
             new(".claude", "--claude", "Claude Code"),
-            new(".cursor", "--cursor", "Cursor"),
-            new(".gemini", "--gemini", "Gemini CLI"),
             new(".codex", "--codex", "Codex CLI"),
             new(".agents", "--agents", "Common"),
             new(".agent", "--antigravity", "Antigravity")

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
@@ -33,7 +33,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             new(".cursor", "--cursor", "Cursor"),
             new(".gemini", "--gemini", "Gemini CLI"),
             new(".codex", "--codex", "Codex CLI"),
-            new(".agents", "--agents", "Other (.agents)"),
+            new(".agents", "--agents", "Other"),
             new(".agent", "--antigravity", "Antigravity")
         };
 

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
@@ -33,7 +33,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             new(".cursor", "--cursor", "Cursor"),
             new(".gemini", "--gemini", "Gemini CLI"),
             new(".codex", "--codex", "Codex CLI"),
-            new(".agents", "--agents", "Other"),
+            new(".agents", "--agents", "Common"),
             new(".agent", "--antigravity", "Antigravity")
         };
 

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -303,7 +303,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             VisualElement skillsSetupPanel = rootVisualElement.Q<VisualElement>("skills-setup-panel");
             Debug.Assert(skillsSetupPanel != null, "skills-setup-panel must not be null");
-            SkillsSetupPanelView skillsSetupPanelView = new(skillsSetupPanel);
+            Button refreshSkillsStateButton = rootVisualElement.Q<Button>("refresh-skills-state-button");
+            Debug.Assert(refreshSkillsStateButton != null, "refresh-skills-state-button must not be null");
+            SkillsSetupPanelView skillsSetupPanelView = new(
+                skillsSetupPanel,
+                refreshSkillsStateButton);
 
             _suppressAutoShowToggle = rootVisualElement.Q<Toggle>("suppress-auto-show-toggle");
             _openSettingsButton = rootVisualElement.Q<Button>("open-settings-button");

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -86,6 +86,11 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    margin-bottom: 10px;
+}
+
+.setup-step__title-row .setup-step__title {
+    margin-bottom: 0;
 }
 
 .setup-step__content {

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -89,6 +89,11 @@
     margin-bottom: 10px;
 }
 
+.setup-step__title-row .skills-setup-panel__refresh-button {
+    /* why: optically center the refresh glyph on the heading text (wizard only) */
+    translate: 0 1px;
+}
+
 .setup-step__title-row .setup-step__title {
     margin-bottom: 0;
 }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -82,6 +82,12 @@
     margin-bottom: 10px;
 }
 
+.setup-step__title-row {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
 .setup-step__content {
     padding-left: 4px;
 }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
@@ -28,7 +28,10 @@
 
         <!-- Step 2: Install Skills -->
         <ui:VisualElement name="step-2" class="setup-step">
-            <ui:Label text="Step 2: Install Skills (Optional)" class="setup-step__title" />
+            <ui:VisualElement class="setup-step__title-row">
+                <ui:Label text="Step 2: Install Skills (Optional)" class="setup-step__title" />
+                <ui:Button name="refresh-skills-state-button" text="↻" class="skills-setup-panel__refresh-button" />
+            </ui:VisualElement>
             <ui:VisualElement class="setup-step__content">
                 <ui:VisualElement name="skills-setup-panel-placeholder" />
                 <ui:Label name="skills-hint-label" text="Install skills later from&#10;Window &gt; Unity CLI Loop &gt; Settings." class="setup-step__hint-label" />

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanel.uss
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanel.uss
@@ -57,6 +57,12 @@
     margin-bottom: 4px;
 }
 
+.skills-no-targets-message {
+    white-space: normal;
+    color: #999999;
+    margin-bottom: 4px;
+}
+
 .skills-setup-panel__install-button {
     margin-top: 4px;
     margin-bottom: 4px;

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanel.uxml
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanel.uxml
@@ -14,7 +14,6 @@
             <ui:VisualElement name="skills-target-row" class="skills-setup-panel__target-row">
                 <ui:Label text="Target:" class="skills-setup-panel__target-label" />
                 <uie:EnumField name="skills-target-field" class="skills-setup-panel__target-field" />
-                <ui:Button name="refresh-skills-state-button" text="↻" class="skills-setup-panel__refresh-button" />
             </ui:VisualElement>
             <ui:Button name="install-selected-skills-button" text="Install Skills" class="skills-setup-panel__install-button" />
         </ui:Foldout>

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanel.uxml
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanel.uxml
@@ -4,6 +4,7 @@
         <ui:VisualElement name="skill-target-status-list" class="skill-target-status-list" />
         <ui:VisualElement name="skill-target-status-divider" class="skill-target-status-divider" />
         <ui:Label name="skill-target-status-summary" text="" class="skill-target-status-summary" />
+        <ui:Label name="skills-no-targets-message" text="No agent skill folders (.claude, .codex, ...) found in this project. Use &quot;Install to specific target&quot; below to install." class="skills-no-targets-message" />
         <ui:Button name="install-all-skills-button" text="Install Skills" class="skills-setup-panel__install-button" />
         <ui:Foldout name="install-specific-target-foldout" text="Install to specific target" class="skills-setup-panel__foldout">
             <ui:VisualElement name="group-skills-row" class="skills-setup-panel__toggle-row">

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
@@ -147,7 +147,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool listVisible = canManageSkills && installableTargets.Count > 0;
             ViewDataBinder.SetVisible(_skillTargetStatusList, listVisible);
 
-            bool shouldExpand = ShouldExpandSpecificTargetFoldout(installableTargets.Count);
+            bool shouldExpand = ShouldExpandSpecificTargetFoldout(installableTargets);
             _installSpecificTargetFoldout.SetValueWithoutNotify(
                 shouldExpand ? true : _installSpecificTargetFoldout.value);
 
@@ -390,10 +390,27 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return $"Installed for {installedTargetCount} targets";
         }
 
-        internal static bool ShouldExpandSpecificTargetFoldout(int installableTargetCount)
+        internal static bool ShouldExpandSpecificTargetFoldout(
+            List<SkillSetupTargetInfo> installableTargets)
         {
-            Debug.Assert(installableTargetCount >= 0, "installableTargetCount must not be negative");
-            return installableTargetCount == 0;
+            Debug.Assert(installableTargets != null, "installableTargets must not be null");
+
+            if (installableTargets.Count == 0)
+            {
+                return true;
+            }
+
+            if (installableTargets.Any(target => target.InstallState == SkillInstallState.Checking))
+            {
+                return false;
+            }
+
+            if (installableTargets.Any(target => target.InstallState == SkillInstallState.Missing))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private void InitializeTargetFieldIfNeeded(SkillsTarget currentTarget)

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
@@ -38,10 +38,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal Label GroupSkillsLabel => _groupSkillsLabel;
         internal VisualElement GroupSkillsRow => _groupSkillsRow;
 
-        internal SkillsSetupPanelView(VisualElement panelRoot)
+        internal SkillsSetupPanelView(VisualElement panelRoot, Button refreshSkillsStateButton)
         {
             Debug.Assert(panelRoot != null, "panelRoot must not be null");
+            Debug.Assert(refreshSkillsStateButton != null, "refreshSkillsStateButton must not be null");
             VisualElement root = panelRoot ?? throw new System.ArgumentNullException(nameof(panelRoot));
+            _refreshSkillsStateButton = refreshSkillsStateButton
+                ?? throw new System.ArgumentNullException(nameof(refreshSkillsStateButton));
 
             _skillTargetStatusList = root.Q<VisualElement>("skill-target-status-list");
             _skillTargetStatusDivider = root.Q<VisualElement>("skill-target-status-divider");
@@ -53,7 +56,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _groupSkillsToggle = root.Q<Toggle>("group-skills-toggle");
             _groupSkillsLabel = root.Q<Label>("group-skills-label");
             _skillsTargetField = root.Q<EnumField>("skills-target-field");
-            _refreshSkillsStateButton = root.Q<Button>("refresh-skills-state-button");
             _installSelectedSkillsButton = root.Q<Button>("install-selected-skills-button");
 
             Debug.Assert(_skillTargetStatusList != null, "skill-target-status-list must not be null");
@@ -66,7 +68,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             Debug.Assert(_groupSkillsToggle != null, "group-skills-toggle must not be null");
             Debug.Assert(_groupSkillsLabel != null, "group-skills-label must not be null");
             Debug.Assert(_skillsTargetField != null, "skills-target-field must not be null");
-            Debug.Assert(_refreshSkillsStateButton != null, "refresh-skills-state-button must not be null");
             Debug.Assert(_installSelectedSkillsButton != null, "install-selected-skills-button must not be null");
 
             _ = _skillTargetStatusList ?? throw new System.ArgumentNullException(nameof(_skillTargetStatusList));
@@ -80,7 +81,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _ = _groupSkillsToggle ?? throw new System.ArgumentNullException(nameof(_groupSkillsToggle));
             _ = _groupSkillsLabel ?? throw new System.ArgumentNullException(nameof(_groupSkillsLabel));
             _ = _skillsTargetField ?? throw new System.ArgumentNullException(nameof(_skillsTargetField));
-            _ = _refreshSkillsStateButton ?? throw new System.ArgumentNullException(nameof(_refreshSkillsStateButton));
             _ = _installSelectedSkillsButton
                 ?? throw new System.ArgumentNullException(nameof(_installSelectedSkillsButton));
 

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
@@ -16,6 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private readonly VisualElement _skillTargetStatusList;
         private readonly VisualElement _skillTargetStatusDivider;
         private readonly Label _skillTargetStatusSummary;
+        private readonly Label _skillsNoTargetsMessage;
         private readonly Button _installAllSkillsButton;
         private readonly Foldout _installSpecificTargetFoldout;
         private readonly VisualElement _groupSkillsRow;
@@ -45,6 +46,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _skillTargetStatusList = root.Q<VisualElement>("skill-target-status-list");
             _skillTargetStatusDivider = root.Q<VisualElement>("skill-target-status-divider");
             _skillTargetStatusSummary = root.Q<Label>("skill-target-status-summary");
+            _skillsNoTargetsMessage = root.Q<Label>("skills-no-targets-message");
             _installAllSkillsButton = root.Q<Button>("install-all-skills-button");
             _installSpecificTargetFoldout = root.Q<Foldout>("install-specific-target-foldout");
             _groupSkillsRow = root.Q<VisualElement>("group-skills-row");
@@ -57,6 +59,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             Debug.Assert(_skillTargetStatusList != null, "skill-target-status-list must not be null");
             Debug.Assert(_skillTargetStatusDivider != null, "skill-target-status-divider must not be null");
             Debug.Assert(_skillTargetStatusSummary != null, "skill-target-status-summary must not be null");
+            Debug.Assert(_skillsNoTargetsMessage != null, "skills-no-targets-message must not be null");
             Debug.Assert(_installAllSkillsButton != null, "install-all-skills-button must not be null");
             Debug.Assert(_installSpecificTargetFoldout != null, "install-specific-target-foldout must not be null");
             Debug.Assert(_groupSkillsRow != null, "group-skills-row must not be null");
@@ -69,6 +72,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _ = _skillTargetStatusList ?? throw new System.ArgumentNullException(nameof(_skillTargetStatusList));
             _ = _skillTargetStatusDivider ?? throw new System.ArgumentNullException(nameof(_skillTargetStatusDivider));
             _ = _skillTargetStatusSummary ?? throw new System.ArgumentNullException(nameof(_skillTargetStatusSummary));
+            _ = _skillsNoTargetsMessage ?? throw new System.ArgumentNullException(nameof(_skillsNoTargetsMessage));
             _ = _installAllSkillsButton ?? throw new System.ArgumentNullException(nameof(_installAllSkillsButton));
             _ = _installSpecificTargetFoldout
                 ?? throw new System.ArgumentNullException(nameof(_installSpecificTargetFoldout));
@@ -82,6 +86,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             _installSpecificTargetFoldout.SetValueWithoutNotify(false);
             ViewDataBinder.SetVisible(_groupSkillsRow, false);
+            ViewDataBinder.SetVisible(_skillsNoTargetsMessage, false);
 
             _installAllSkillsButton.clicked += () => OnInstallAllClicked?.Invoke();
             _installSelectedSkillsButton.clicked += () => OnInstallSelectedClicked?.Invoke();
@@ -98,6 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             _skillTargetStatusList.Clear();
             UpdateSkillsStatusLabel("Checking installed skills...");
+            ViewDataBinder.SetVisible(_skillsNoTargetsMessage, false);
             _installAllSkillsButton.SetEnabled(false);
             _installAllSkillsButton.text = "Checking...";
             _installSelectedSkillsButton.SetEnabled(false);
@@ -147,6 +153,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             bool isCheckingSkills = installableTargets.Any(
                 target => target.InstallState == SkillInstallState.Checking);
+            ViewDataBinder.SetVisible(_installAllSkillsButton, installableTargets.Count > 0);
+            ViewDataBinder.SetVisible(_skillsNoTargetsMessage, !isCheckingSkills && installableTargets.Count == 0);
             if (isCheckingSkills)
             {
                 UpdateSkillsStatusLabel("Checking installed skills...");

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
@@ -27,6 +27,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private readonly Button _installSelectedSkillsButton;
 
         private bool _isTargetFieldInitialized;
+        private bool? _lastAppliedFoldoutDefault;
 
         internal event System.Action OnInstallAllClicked;
         internal event System.Action OnInstallSelectedClicked;
@@ -147,12 +148,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool listVisible = canManageSkills && installableTargets.Count > 0;
             ViewDataBinder.SetVisible(_skillTargetStatusList, listVisible);
 
-            bool shouldExpand = ShouldExpandSpecificTargetFoldout(installableTargets);
-            _installSpecificTargetFoldout.SetValueWithoutNotify(
-                shouldExpand ? true : _installSpecificTargetFoldout.value);
-
             bool isCheckingSkills = installableTargets.Any(
                 target => target.InstallState == SkillInstallState.Checking);
+            if (!isCheckingSkills)
+            {
+                bool foldoutDefault = ShouldExpandSpecificTargetFoldout(installableTargets);
+                if (_lastAppliedFoldoutDefault != foldoutDefault)
+                {
+                    _installSpecificTargetFoldout.SetValueWithoutNotify(foldoutDefault);
+                    _lastAppliedFoldoutDefault = foldoutDefault;
+                }
+            }
+
             ViewDataBinder.SetVisible(_installAllSkillsButton, installableTargets.Count > 0);
             ViewDataBinder.SetVisible(_skillsNoTargetsMessage, !isCheckingSkills && installableTargets.Count == 0);
             if (isCheckingSkills)
@@ -394,23 +401,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             List<SkillSetupTargetInfo> installableTargets)
         {
             Debug.Assert(installableTargets != null, "installableTargets must not be null");
+            Debug.Assert(
+                installableTargets.All(target => target.InstallState != SkillInstallState.Checking),
+                "installableTargets must not include Checking; caller must guard before applying foldout defaults");
 
             if (installableTargets.Count == 0)
             {
                 return true;
             }
 
-            if (installableTargets.Any(target => target.InstallState == SkillInstallState.Checking))
-            {
-                return false;
-            }
-
-            if (installableTargets.Any(target => target.InstallState == SkillInstallState.Missing))
-            {
-                return true;
-            }
-
-            return false;
+            return installableTargets.Any(target => target.InstallState == SkillInstallState.Missing);
         }
 
         private void InitializeTargetFieldIfNeeded(SkillsTarget currentTarget)

--- a/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
+++ b/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
@@ -42,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 SkillsTarget.Cursor => new("Cursor", ".cursor", "--cursor", groupSkillsUnderUnityCliLoop),
                 SkillsTarget.Gemini => new("Gemini CLI", ".gemini", "--gemini", groupSkillsUnderUnityCliLoop),
                 SkillsTarget.Codex => new("Codex CLI", ".codex", "--codex", groupSkillsUnderUnityCliLoop),
-                SkillsTarget.Agents => new("Other", ".agents", "--agents", groupSkillsUnderUnityCliLoop),
+                SkillsTarget.Agents => new("Common", ".agents", "--agents", groupSkillsUnderUnityCliLoop),
                 _ => throw new ArgumentOutOfRangeException(nameof(target), target, null)
             };
         }

--- a/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
+++ b/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
@@ -42,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 SkillsTarget.Cursor => new("Cursor", ".cursor", "--cursor", groupSkillsUnderUnityCliLoop),
                 SkillsTarget.Gemini => new("Gemini CLI", ".gemini", "--gemini", groupSkillsUnderUnityCliLoop),
                 SkillsTarget.Codex => new("Codex CLI", ".codex", "--codex", groupSkillsUnderUnityCliLoop),
-                SkillsTarget.Agents => new("Other (.agents)", ".agents", "--agents", groupSkillsUnderUnityCliLoop),
+                SkillsTarget.Agents => new("Other", ".agents", "--agents", groupSkillsUnderUnityCliLoop),
                 _ => throw new ArgumentOutOfRangeException(nameof(target), target, null)
             };
         }

--- a/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
+++ b/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
@@ -39,8 +39,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return target switch
             {
                 SkillsTarget.Claude => new("Claude Code", ".claude", "--claude", groupSkillsUnderUnityCliLoop),
-                SkillsTarget.Cursor => new("Cursor", ".cursor", "--cursor", groupSkillsUnderUnityCliLoop),
-                SkillsTarget.Gemini => new("Gemini CLI", ".gemini", "--gemini", groupSkillsUnderUnityCliLoop),
                 SkillsTarget.Codex => new("Codex CLI", ".codex", "--codex", groupSkillsUnderUnityCliLoop),
                 SkillsTarget.Agents => new("Common", ".agents", "--agents", groupSkillsUnderUnityCliLoop),
                 _ => throw new ArgumentOutOfRangeException(nameof(target), target, null)
@@ -52,8 +50,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return target switch
             {
                 SkillsTarget.Claude => data.IsClaudeSkillsInstalled,
-                SkillsTarget.Cursor => data.IsCursorSkillsInstalled,
-                SkillsTarget.Gemini => data.IsGeminiSkillsInstalled,
                 SkillsTarget.Codex => data.IsCodexSkillsInstalled,
                 SkillsTarget.Agents => data.IsAgentsSkillsInstalled,
                 _ => false

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -153,7 +153,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 data.GroupSkillsUnderUnityCliLoop,
                 data.IsCliInstalled && !data.IsInstallingSkills);
 
-            if (data.IsChecking)
+            if (data.IsSkillStateChecking)
             {
                 _skillsSetupPanelView.ShowChecking();
                 return;

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -46,8 +46,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             VisualElement skillsSetupPanel = root.Q<VisualElement>("skills-setup-panel");
             Debug.Assert(skillsSetupPanel != null, "skills-setup-panel must not be null");
+            Button refreshSkillsStateButton = root.Q<Button>("refresh-skills-state-button");
+            Debug.Assert(refreshSkillsStateButton != null, "refresh-skills-state-button must not be null");
             _skillsSetupPanelView = new SkillsSetupPanelView(
-                skillsSetupPanel ?? throw new ArgumentNullException(nameof(skillsSetupPanel)));
+                skillsSetupPanel ?? throw new ArgumentNullException(nameof(skillsSetupPanel)),
+                refreshSkillsStateButton ?? throw new ArgumentNullException(nameof(refreshSkillsStateButton)));
         }
 
         public void SetupBindings()

--- a/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uss
+++ b/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uss
@@ -479,6 +479,13 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    margin-top: 6px;
+    margin-bottom: 4px;
+}
+
+.unity-cli-loop-cli-subsection-header-row .unity-cli-loop-cli-subsection-header {
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 .unity-cli-loop-cli-separator {

--- a/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uss
+++ b/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uss
@@ -475,6 +475,12 @@
     margin-bottom: 4px;
 }
 
+.unity-cli-loop-cli-subsection-header-row {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
 .unity-cli-loop-cli-separator {
     height: 1px;
     margin-top: 10px;

--- a/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uxml
+++ b/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uxml
@@ -18,7 +18,10 @@
                         <ui:VisualElement class="unity-cli-loop-cli-separator" />
 
                         <ui:VisualElement name="skills-subsection">
-                            <ui:Label text="Skills" class="unity-cli-loop-cli-subsection-header" />
+                            <ui:VisualElement class="unity-cli-loop-cli-subsection-header-row">
+                                <ui:Label text="Skills" class="unity-cli-loop-cli-subsection-header" />
+                                <ui:Button name="refresh-skills-state-button" text="↻" class="skills-setup-panel__refresh-button" />
+                            </ui:VisualElement>
                             <ui:VisualElement name="skills-setup-panel-placeholder" />
                         </ui:VisualElement>
                     </ui:VisualElement>

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -76,7 +76,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 skills.SelectedTargetInstallState,
                 skills.SkillsTarget,
                 skills.IsInstallingSkills,
-                skills.InstallableSkillTargets);
+                skills.InstallableSkillTargets,
+                skills.HasSkillTargetScanResult);
         }
 
         internal void Update(
@@ -89,7 +90,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             SkillInstallState selectedTargetInstallState,
             SkillsTarget skillsTarget,
             bool isInstallingSkills,
-            System.Collections.Generic.IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets)
+            System.Collections.Generic.IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets,
+            bool hasSkillTargetScanResult)
         {
             CliSetupData cliData = CreateCliSetupData(
                 needsCliPathSetup,
@@ -101,7 +103,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 selectedTargetInstallState,
                 skillsTarget,
                 isInstallingSkills,
-                installableSkillTargets);
+                installableSkillTargets,
+                hasSkillTargetScanResult);
             _view.UpdateCliSetup(cliData);
         }
 
@@ -427,7 +430,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             SkillInstallState selectedTargetInstallState,
             SkillsTarget skillsTarget,
             bool isInstallingSkills,
-            System.Collections.Generic.IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets)
+            System.Collections.Generic.IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets,
+            bool hasSkillTargetScanResult)
         {
             string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
             bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
@@ -441,8 +445,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool isChecking = !_cliSetupApplicationService.IsCliCheckCompleted()
                 || isRefreshingVersion
                 || isRefreshingCliPathSetup;
-            bool isSkillStateChecking = !_cliSetupApplicationService.IsCliCheckCompleted()
-                || !includeSkillDirectoryChecks;
+            bool isSkillStateChecking = UnityCliLoopSettingsWindowRefreshPolicy.IsSkillStateChecking(
+                _cliSetupApplicationService.IsCliCheckCompleted(),
+                includeSkillDirectoryChecks,
+                hasSkillTargetScanResult);
             CliSetupCompatibilityState state = CliSetupCompatibility.Evaluate(
                 cliVersion,
                 cliIsDispatcher,

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -470,8 +470,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 isSkillStateChecking,
                 isClaudeSkillsInstalled: false,
                 isAgentsSkillsInstalled: false,
-                isCursorSkillsInstalled: false,
-                isGeminiSkillsInstalled: false,
                 isCodexSkillsInstalled: false,
                 isAntigravitySkillsInstalled: false,
                 displayedTargetInstallState,

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -440,7 +440,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 UnityEngine.Application.platform);
             bool isChecking = !_cliSetupApplicationService.IsCliCheckCompleted()
                 || isRefreshingVersion
-                || isRefreshingCliPathSetup
+                || isRefreshingCliPathSetup;
+            bool isSkillStateChecking = !_cliSetupApplicationService.IsCliCheckCompleted()
                 || !includeSkillDirectoryChecks;
             CliSetupCompatibilityState state = CliSetupCompatibility.Evaluate(
                 cliVersion,
@@ -460,6 +461,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 needsCliPathSetup,
                 isInstallingCli,
                 isChecking,
+                isSkillStateChecking,
                 isClaudeSkillsInstalled: false,
                 isAgentsSkillsInstalled: false,
                 isCursorSkillsInstalled: false,

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsSkillsPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsSkillsPresenter.cs
@@ -22,13 +22,15 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             SkillInstallState selectedTargetInstallState,
             SkillsTarget skillsTarget,
             bool isInstallingSkills,
-            IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets)
+            IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets,
+            bool hasSkillTargetScanResult)
         {
             InstallSkillsFlat = installSkillsFlat;
             SelectedTargetInstallState = selectedTargetInstallState;
             SkillsTarget = skillsTarget;
             IsInstallingSkills = isInstallingSkills;
             InstallableSkillTargets = installableSkillTargets;
+            HasSkillTargetScanResult = hasSkillTargetScanResult;
         }
 
         internal bool InstallSkillsFlat { get; }
@@ -36,6 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal SkillsTarget SkillsTarget { get; }
         internal bool IsInstallingSkills { get; }
         internal IReadOnlyList<SkillSetupTargetInfo> InstallableSkillTargets { get; }
+        internal bool HasSkillTargetScanResult { get; }
     }
 
     /// <summary>
@@ -57,6 +60,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private bool _isInstallingSkills;
         private SkillInstallState _selectedTargetInstallState = SkillInstallState.Missing;
         private List<SkillSetupTargetInfo> _installableTargets = new();
+        private bool _hasSkillTargetScanResult;
         private CancellationTokenSource _skillInstallStateRefreshCts;
 
         internal UnityCliLoopSettingsSkillsPresenter(
@@ -96,7 +100,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _selectedTargetInstallState,
                 _skillsTarget,
                 _isInstallingSkills,
-                _installableTargets);
+                _installableTargets,
+                _hasSkillTargetScanResult);
         }
 
         internal void MarkSelectedTargetInstallStateChecking()
@@ -149,6 +154,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             {
                 _selectedTargetInstallState = SkillInstallState.Missing;
                 _installableTargets = new List<SkillSetupTargetInfo>();
+                _hasSkillTargetScanResult = true;
                 RefreshCliSetupSection();
                 return;
             }
@@ -159,6 +165,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 ? SkillInstallState.Missing
                 : selectedTargetInfo.InstallState;
             _installableTargets = SkillsSetupPanelView.FilterInstallableSkillTargets(allTargets);
+            _hasSkillTargetScanResult = true;
             RefreshCliSetupSection();
         }
 
@@ -339,6 +346,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 ? SkillInstallState.Missing
                 : selectedTargetInfo.InstallState;
             _installableTargets = SkillsSetupPanelView.FilterInstallableSkillTargets(allTargets);
+            _hasSkillTargetScanResult = true;
             RefreshCliSetupSection();
         }
 

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowEventHandler.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowEventHandler.cs
@@ -172,6 +172,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return isCliInstalled ? currentState : SkillInstallState.Missing;
         }
 
+        public static bool IsSkillStateChecking(
+            bool isCliCheckCompleted,
+            bool includeSkillDirectoryChecks,
+            bool hasSkillTargetScanResult)
+        {
+            // why: an empty installable-target list before the first scan result must not look resolved
+            return !isCliCheckCompleted
+                || !includeSkillDirectoryChecks
+                || !hasSkillTargetScanResult;
+        }
+
         public static bool ShouldKeepToolSettingsCatalogDirty(ToolSettingsSectionData toolSettingsData)
         {
             Debug.Assert(toolSettingsData != null, "toolSettingsData must not be null");

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowState.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowState.cs
@@ -18,7 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         Codex = 4,
         Cursor = 2,
         Gemini = 3,
-        [InspectorName("Other (.agents)")]
+        [InspectorName("Common (.agents)")]
         Agents = 1
     }
 

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowState.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowState.cs
@@ -16,8 +16,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     {
         Claude = 0,
         Codex = 4,
-        Cursor = 2,
-        Gemini = 3,
         [InspectorName("Common (.agents)")]
         Agents = 1
     }

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowViewData.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowViewData.cs
@@ -91,8 +91,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         public readonly bool IsSkillStateChecking;
         public readonly bool IsClaudeSkillsInstalled;
         public readonly bool IsAgentsSkillsInstalled;
-        public readonly bool IsCursorSkillsInstalled;
-        public readonly bool IsGeminiSkillsInstalled;
         public readonly bool IsCodexSkillsInstalled;
         public readonly bool IsAntigravitySkillsInstalled;
         public readonly SkillInstallState SelectedTargetInstallState;
@@ -113,8 +111,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool isSkillStateChecking,
             bool isClaudeSkillsInstalled,
             bool isAgentsSkillsInstalled,
-            bool isCursorSkillsInstalled,
-            bool isGeminiSkillsInstalled,
             bool isCodexSkillsInstalled,
             bool isAntigravitySkillsInstalled,
             SkillInstallState selectedTargetInstallState,
@@ -134,8 +130,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             IsSkillStateChecking = isSkillStateChecking;
             IsClaudeSkillsInstalled = isClaudeSkillsInstalled;
             IsAgentsSkillsInstalled = isAgentsSkillsInstalled;
-            IsCursorSkillsInstalled = isCursorSkillsInstalled;
-            IsGeminiSkillsInstalled = isGeminiSkillsInstalled;
             IsCodexSkillsInstalled = isCodexSkillsInstalled;
             IsAntigravitySkillsInstalled = isAntigravitySkillsInstalled;
             SelectedTargetInstallState = selectedTargetInstallState;

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowViewData.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowViewData.cs
@@ -88,6 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         public readonly bool NeedsCliPathSetup;
         public readonly bool IsInstallingCli;
         public readonly bool IsChecking;
+        public readonly bool IsSkillStateChecking;
         public readonly bool IsClaudeSkillsInstalled;
         public readonly bool IsAgentsSkillsInstalled;
         public readonly bool IsCursorSkillsInstalled;
@@ -109,6 +110,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool needsCliPathSetup,
             bool isInstallingCli,
             bool isChecking,
+            bool isSkillStateChecking,
             bool isClaudeSkillsInstalled,
             bool isAgentsSkillsInstalled,
             bool isCursorSkillsInstalled,
@@ -129,6 +131,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             NeedsCliPathSetup = needsCliPathSetup;
             IsInstallingCli = isInstallingCli;
             IsChecking = isChecking;
+            IsSkillStateChecking = isSkillStateChecking;
             IsClaudeSkillsInstalled = isClaudeSkillsInstalled;
             IsAgentsSkillsInstalled = isAgentsSkillsInstalled;
             IsCursorSkillsInstalled = isCursorSkillsInstalled;

--- a/cli/dispatcher/internal/dispatcher/skills.go
+++ b/cli/dispatcher/internal/dispatcher/skills.go
@@ -30,8 +30,6 @@ const (
 var targetConfigs = map[string]skillTarget{
 	"claude":      {id: "claude", displayName: "Claude Code", projectDir: ".claude"},
 	"codex":       {id: "codex", displayName: "Codex CLI", projectDir: ".codex"},
-	"cursor":      {id: "cursor", displayName: "Cursor", projectDir: ".cursor"},
-	"gemini":      {id: "gemini", displayName: "Gemini CLI", projectDir: ".gemini"},
 	"agents":      {id: "agents", displayName: "Common", projectDir: ".agents"},
 	"windsurf":    {id: "windsurf", displayName: "Windsurf", projectDir: ".agents"},
 	"antigravity": {id: "antigravity", displayName: "Antigravity", projectDir: ".agent"},
@@ -42,7 +40,7 @@ var targetConfigs = map[string]skillTarget{
 // slice is the single source of truth for iteration order and for the set of
 // accepted --<id> flags; help lines and parseSkillsOptions must both derive
 // from it to avoid drift.
-var allSkillTargetIDs = []string{"claude", "codex", "cursor", "gemini", "agents", "windsurf", "antigravity"}
+var allSkillTargetIDs = []string{"claude", "codex", "agents", "windsurf", "antigravity"}
 
 // nonDefaultSkillTargetIDs lists targets that are excluded from the default
 // target set and are only installed when explicitly requested via their

--- a/cli/dispatcher/internal/dispatcher/skills.go
+++ b/cli/dispatcher/internal/dispatcher/skills.go
@@ -32,7 +32,7 @@ var targetConfigs = map[string]skillTarget{
 	"codex":       {id: "codex", displayName: "Codex CLI", projectDir: ".codex"},
 	"cursor":      {id: "cursor", displayName: "Cursor", projectDir: ".cursor"},
 	"gemini":      {id: "gemini", displayName: "Gemini CLI", projectDir: ".gemini"},
-	"agents":      {id: "agents", displayName: "Other (.agents)", projectDir: ".agents"},
+	"agents":      {id: "agents", displayName: "Common", projectDir: ".agents"},
 	"windsurf":    {id: "windsurf", displayName: "Windsurf", projectDir: ".agents"},
 	"antigravity": {id: "antigravity", displayName: "Antigravity", projectDir: ".agent"},
 }

--- a/cli/dispatcher/internal/dispatcher/skills_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_test.go
@@ -840,7 +840,7 @@ func TestAllSkillTargetIDsMatchesTargetConfigs(t *testing.T) {
 // nonDefaultSkillTargetIDs cannot silently change which targets install by
 // default.
 func TestDefaultSkillTargetIDsDerivedFromAllSkillTargetIDs(t *testing.T) {
-	expected := []string{"claude", "codex", "cursor", "gemini", "agents", "antigravity"}
+	expected := []string{"claude", "codex", "agents", "antigravity"}
 
 	if !reflect.DeepEqual(defaultSkillTargetIDs, expected) {
 		t.Fatalf("defaultSkillTargetIDs mismatch: got=%v want=%v", defaultSkillTargetIDs, expected)


### PR DESCRIPTION
## Summary
- Drop Cursor and Gemini skill targets from Settings, detection, and the Go CLI (Gemini CLI ended; Common covers Antigravity's default `.agents` location).
- The Install to specific target foldout follows the resolved skill-state default and reapplies that default when a reload changes it (for example, it opens while targets are missing and closes once they become installed).
- When no agent skill folders are detected, Settings/Setup Wizard hide the bulk Install Skills button and show short muted guidance instead of a permanently disabled control.
- The skills reload control (↻) now sits on the Skills / Step 2 heading row so it is easy to find without opening Install to specific target.
- Refreshing CLI status no longer briefly forces the skills panel into Checking....

## User Impact
- Projects without `.claude` / `.codex` / similar folders no longer look stuck on a disabled Install Skills button.
- Reloading skill detection is visible at the section heading in both Settings and Setup Wizard.
- Pressing the CLI ↻ control only updates CLI status; the skills list stays interactive.

## Changes
- Shared skills panel empty-state label + visibility rules in `SkillsSetupPanelView`.
- Move `refresh-skills-state-button` out of the Target row into each window's heading row; pass the button into `SkillsSetupPanelView`.
- Split `CliSetupData.IsSkillStateChecking` from `IsChecking` so CLI refresh and skill-state refresh drive separate UI paths.

## Verification
- `uloop compile` → ErrorCount 0 / WarningCount 0
- Filtered EditMode tests (`CliSetupSectionTests|SkillsSetupPanelViewTests|SetupWizardWindowTests|StaticFacadeStateGuardTests|SkillsTargetSelectionResolverTests`) → 178 passed
- Manual screenshots (Settings + Setup Wizard):
  - ↻ is on the heading row (right side) and gone from the Target row
  - Heading spacing looks intact
  - Empty-state (0 targets) covered by unit tests in this project (folders present, so not reproduced live)

## Screenshots
Local captures used for visual check (not committed):
- Settings: `/tmp/skills-panel-screenshots/Unity CLI Loop_20260724_223955_947.png`
- Setup Wizard: `/tmp/skills-panel-screenshots/Unity CLI Loop Setup_20260724_224035_989.png`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




