### PR TITLE
docs: add curated V3 release notes

### DIFF
--- a/Packages/src/Documentation~/whats-new-v3.md
+++ b/Packages/src/Documentation~/whats-new-v3.md
@@ -1,0 +1,72 @@
+# What's New in V3
+
+[日本語](whats-new-v3_ja.md)
+
+V3 replaces the npm-distributed CLI with a native Go binary, so Node.js is no longer required to drive Unity from an AI agent. The transport moved from TCP port management to a Unix domain socket on macOS/Linux and a named pipe on Windows, which removes port configuration and port conflicts entirely. The headline new capability is `pause-point`: it stops PlayMode at any `file:line` and reports the locals, parameters, and instance fields at that exact frame, without editing source or recompiling. MCP support and shell completion are gone; the CLI plus Skills is now the only integration path.
+
+## Upgrading
+
+For most users the upgrade is two steps: raise the Unity package version, then open `Window > Unity CLI Loop > Settings` and press **Install CLI** (or **Update CLI**) to replace the old npm CLI with the native dispatcher. The installer attempts to remove the obsolete npm package with `npm uninstall -g uloop-cli` and prints the command to run manually when it cannot.
+
+You only need the migration guide if you wrote your own integrations: C# custom tools built on the V2 extension API, or your own `SKILL.md` files, Markdown docs, shell scripts, or PowerShell scripts that invoke `uloop`. In that case read [Migrating Custom Tools and Skills to V3](migration-v2-to-v3.md) before you start fixing anything by hand.
+
+## Highlights
+
+- **Native Go CLI, no Node.js** — `uloop` ships as a platform binary instead of an npm package. Node.js 22+ is no longer a requirement for running V3 projects.
+- **`pause-point` — breakpoint-style investigation without touching code** — pause PlayMode at any source line and read the variables at that frame. No `Debug.Log` statements, no recompile, and it can be armed in the middle of a PlayMode session.
+- **No more port management** — the CLI reaches Unity over a Unix domain socket (macOS/Linux) or a named pipe (Windows). There is no port to configure, and no port to collide with another Editor instance.
+- **Version compatibility is enforced by protocol version** — the CLI and the Unity package agree on an integer protocol version, so a mismatched pair fails fast with a clear message instead of misbehaving at runtime.
+- **Per-project CLI resolution** — each project pins the runner version it needs in `.uloop/project-runner-pin.json`, so several projects on different versions can coexist on one machine.
+
+## New Tools
+
+### `pause-point` — stop at a line and read the frame
+
+`pause-point` patches an already-compiled method at a source `file:line` and pauses Unity when execution reaches it, so you do not edit source or recompile to investigate a bug. The hit response carries `CapturedVariables` — the method's locals, its parameters, and the `this` instance fields — captured immediately before the target line runs, exactly like an IDE breakpoint. Because the values are point-in-time strings rather than live references, they remain valid evidence after Unity resumes.
+
+Markers come in three capture modes: `single-shot` (the default) disarms after the first hit, `continuous` pauses on every hit and keeps a history of earlier frames, and `trace` records every hit without pausing at all. Watch expressions (`uloop enable-watch` / `uloop get-watch-values`) re-evaluate automatically on each paused Editor Step, which is how you follow a value as it changes frame by frame. The Editor's Code Optimization mode must be Debug; enabling is rejected with instructions when it is set to Release.
+
+```bash
+# Arm a pause point, fire the input, and wait for the hit in one call
+uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seconds 30 \
+  --await --trigger "simulate-keyboard --action Press --key Space"
+
+# Inspect the current marker state, then clear it
+uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"
+uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"
+```
+
+### `raycast` — check what a Game View coordinate hits
+
+`raycast` casts a ray from `Camera.main` through a Game View coordinate and reports what 3D physics hits. It takes the same top-left coordinate system as `simulate-mouse-ui`, so you can feed it a coordinate straight from an annotated screenshot and confirm the target before clicking. The response names the hit GameObject and its path, layer, distance, hit point, and hit normal.
+
+Both hit and no-hit responses report `CameraName` and `CameraPath`, which is the fastest way to diagnose a surprising `No physics hit` result — another camera tagged `MainCamera` can silently win the `Camera.main` resolution, so the ray may not start from the viewpoint you assumed. Note that this uses Unity Physics raycasts, not UI EventSystem raycasts.
+
+```bash
+uloop raycast --x 960 --y 540
+uloop raycast --x 960 --y 540 --layer-mask 1
+```
+
+> `set-game-view-size` also arrives in V3: it reads and sets the Game View custom rendering resolution (`uloop set-game-view-size --width 1920 --height 1080`), which is useful for keeping the coordinate space of `screenshot --capture-mode rendering` stable across runs.
+
+## CLI and Distribution Changes
+
+- **npm package to native binary** — the CLI is distributed as a signed platform binary rather than through npm. The V2 `uloop-cli` npm package is obsolete; remove it with `npm uninstall -g uloop-cli` if the installer could not.
+- **Two-layer architecture** — a single global `uloop` dispatcher lives on your `PATH` and delegates to a per-project `uloop-project-runner`. The runner version comes from `.uloop/project-runner-pin.json` in each project and is downloaded into a per-version user cache automatically, so upgrading one project does not disturb another.
+- **Installer authenticity verification** — release assets carry sigstore attestations. The documented install flow verifies them with `gh attestation verify` against the signing workflow and the release tag's commit before running the installer.
+- **Bounded runtime output** — each subfolder under `.uloop/outputs/` is capped at 20 files, with the oldest removed first, so screenshots, test results, and hierarchy dumps no longer accumulate without limit.
+- **Automatic delegation to V2 projects** — when the V3 dispatcher detects that a project still resolves to the V2 package, it installs the matching V2 `uloop-cli` release into a per-version cache and forwards the command. Keeping the V3 dispatcher installed is the supported way to work across V2 and V3 projects at the same time. Delegation itself still needs Node.js 22+, since it goes through npm.
+
+## Removed in V3
+
+- **MCP connection** — removed. Use the CLI together with the bundled Skills; every capability that was exposed over MCP is reachable through `uloop` commands.
+- **Shell completion** — removed. `uloop completion` remains only as a no-op stub so existing shell profiles do not error out.
+- **`capture-window`** — use `screenshot`, which absorbed its role and adds Game View rendering capture and element annotation.
+- **`unity-search`, `get-unity-search-providers`, `get-provider-details`** — removed. Use `execute-dynamic-code` to call the Unity Search API directly when you need it, or `find-game-objects` for ordinary scene lookups.
+- **`execute-menu-item`, `get-menu-items`** — removed. Use `execute-dynamic-code` with `EditorApplication.ExecuteMenuItem(...)`.
+
+## Breaking Changes
+
+- **Boolean options no longer take a value.** V2 accepted `--flag true` and `--flag=false`; V3 uses valueless flags. Options that default to true gained a negative form instead — for example `uloop compile --wait-for-domain-reload false` becomes `uloop compile --no-wait-for-domain-reload`, while `--wait-for-domain-reload true` is simply dropped. Run `uloop <command> --help` to see each flag's default (`default: enabled` / `default: disabled`).
+- **Removed commands.** The commands listed above are gone; scripts and skills that call them need to be rewritten against their replacements.
+- **The custom tool API moved to a new namespace and type names.** Custom tools now derive from `UnityCliLoopTool<TSchema, TResponse>` under `io.github.hatayama.UnityCliLoop.ToolContracts`. If your project contains C# custom tools written against the V2 API, upgrading to V3 *will* produce compile errors — this is expected, and the built-in migration wizard rewrites the affected files for you, so do not start fixing them by hand. See [Migrating Custom Tools and Skills to V3](migration-v2-to-v3.md).

--- a/Packages/src/Documentation~/whats-new-v3_ja.md
+++ b/Packages/src/Documentation~/whats-new-v3_ja.md
@@ -1,0 +1,72 @@
+# V3の新機能
+
+[English](whats-new-v3.md)
+
+V3では、npmで配布していたCLIをネイティブのGoバイナリに置き換えました。AIエージェントからUnityを操作するのに、Node.jsは不要になりました。通信方式もTCPポート管理から、macOS/LinuxではUnixドメインソケット、Windowsでは名前付きパイプに変わり、ポートの設定もポートの衝突もなくなりました。目玉となる新機能は `pause-point` です。ソースを編集することも再コンパイルすることもなく、任意の `file:line` でPlayModeを停止し、その瞬間のローカル変数・引数・インスタンスフィールドを取得できます。MCP対応とシェル補完は削除され、CLIとSkillsが唯一の連携方法になりました。
+
+## アップグレード方法
+
+ほとんどのユーザーにとって、アップグレードは2ステップで完了します。Unityパッケージのバージョンを上げ、`Window > Unity CLI Loop > Settings` を開いて **Install CLI**（または **Update CLI**）を押し、古いnpm版CLIをネイティブdispatcherに置き換えるだけです。インストーラは古いnpmパッケージを `npm uninstall -g uloop-cli` で自動削除しようとし、削除できなかった場合は手動で実行するコマンドを表示します。
+
+移行ガイドが必要なのは、独自の連携を作り込んでいる場合だけです。具体的には、V2の拡張APIで書いたC#カスタムツールがある場合か、`uloop` を呼び出す自作の `SKILL.md`・Markdownドキュメント・シェルスクリプト・PowerShellスクリプトがある場合です。該当する場合は、手作業で直し始める前に [カスタムツール／スキルのV3移行ガイド](migration-v2-to-v3_ja.md) を読んでください。
+
+## ハイライト
+
+- **ネイティブGo CLI、Node.js不要** — `uloop` はnpmパッケージではなくプラットフォーム別バイナリとして配布されます。V3プロジェクトを動かすのにNode.js 22以降は不要になりました。
+- **`pause-point` — コードに触れずにブレークポイント調査** — 任意のソース行でPlayModeを停止し、そのフレームの変数を読み取れます。`Debug.Log` を仕込む必要も再コンパイルも不要で、PlayMode実行中に仕掛けることもできます。
+- **ポート管理の廃止** — CLIはUnixドメインソケット（macOS/Linux）または名前付きパイプ（Windows）でUnityに接続します。設定すべきポートは存在せず、他のEditorインスタンスとポートが衝突することもありません。
+- **バージョン互換性はprotocol versionで保証** — CLIとUnityパッケージは整数のprotocol versionで合意します。組み合わせが不一致なら、実行時に不可解な動作をするのではなく、明確なメッセージで即座に失敗します。
+- **プロジェクト単位のCLIバージョン解決** — 各プロジェクトが必要なrunnerのバージョンを `.uloop/project-runner-pin.json` にpinするため、異なるバージョンの複数プロジェクトを1台のマシンで共存させられます。
+
+## 新しいツール
+
+### `pause-point` — 任意の行で止めてフレームを読む
+
+`pause-point` は、コンパイル済みのメソッドをソースの `file:line` の位置でパッチし、実行がその行に到達したときにUnityを停止します。バグ調査のためにソースを編集する必要も、再コンパイルする必要もありません。ヒット時のレスポンスには `CapturedVariables` が含まれます。これはメソッドのローカル変数・引数・`this` のインスタンスフィールドを、対象行が実行される直前に取得したもので、IDEのブレークポイントとまったく同じタイミングです。値はライブ参照ではなく、その時点の文字列として記録されるため、Unityが再開した後も証拠として有効なまま残ります。
+
+マーカーには3つのキャプチャモードがあります。`single-shot`（デフォルト）は最初のヒットで自動的に解除され、`continuous` はヒットのたびに停止して過去フレームの履歴を保持し、`trace` は停止せずにヒットだけを記録し続けます。watch式（`uloop enable-watch` / `uloop get-watch-values`）は、停止中のEditor Stepごとに自動で再評価されるため、値がフレーム単位でどう変化するかを追えます。なお、EditorのCode OptimizationモードはDebugである必要があります。Releaseの場合は、対処方法を示したメッセージとともに有効化が拒否されます。
+
+```bash
+# pause pointの仕掛け・入力の発火・ヒット待ちを1コマンドで実行
+uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seconds 30 \
+  --await --trigger "simulate-keyboard --action Press --key Space"
+
+# 現在のマーカー状態を確認し、クリアする
+uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"
+uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"
+```
+
+### `raycast` — Game View座標に何が当たるかを調べる
+
+`raycast` は `Camera.main` からGame Viewの座標へレイを飛ばし、3D物理で何にヒットするかを返します。座標系は `simulate-mouse-ui` と同じ左上原点なので、注釈付きスクリーンショットの座標をそのまま渡して、クリックする前に対象を確認できます。レスポンスには、ヒットしたGameObjectの名前とパス、レイヤー、距離、ヒット位置、ヒット法線が含まれます。
+
+ヒットした場合もしなかった場合も `CameraName` と `CameraPath` が返るので、想定外の `No physics hit` を診断するときはここを最初に見るのが近道です。シーン内の別のカメラに `MainCamera` タグが付いていると、そちらが `Camera.main` の解決に勝ってしまい、意図した視点からレイが飛んでいない場合があります。なお、これはUnity Physicsのレイキャストであり、UI EventSystemのレイキャストではありません。
+
+```bash
+uloop raycast --x 960 --y 540
+uloop raycast --x 960 --y 540 --layer-mask 1
+```
+
+> `set-game-view-size` もV3で追加されました。Game Viewのカスタム解像度を取得・設定でき（`uloop set-game-view-size --width 1920 --height 1080`）、`screenshot --capture-mode rendering` の座標系を実行ごとに安定させたいときに使えます。
+
+## CLI・配布方法の変更
+
+- **npmパッケージからネイティブバイナリへ** — CLIはnpm経由ではなく、署名済みのプラットフォーム別バイナリとして配布されます。V2の `uloop-cli` npmパッケージは不要になったので、インストーラが削除できなかった場合は `npm uninstall -g uloop-cli` で削除してください。
+- **2層構成** — `PATH` 上に置かれるグローバルな `uloop` dispatcherが1つあり、プロジェクトごとの `uloop-project-runner` に処理を委譲します。runnerのバージョンは各プロジェクトの `.uloop/project-runner-pin.json` から決まり、バージョン別のユーザーキャッシュへ自動的にダウンロードされます。そのため、あるプロジェクトを更新しても他のプロジェクトには影響しません。
+- **インストーラの真正性検証** — リリース成果物にはsigstoreのattestationが付いています。ドキュメント化されたインストール手順では、インストーラを実行する前に `gh attestation verify` で署名ワークフローとリリースタグのコミットに対して検証します。
+- **ランタイム出力の上限** — `.uloop/outputs/` の各サブフォルダは20ファイルまでに制限され、古いものから削除されます。スクリーンショット・テスト結果・ヒエラルキーダンプが無制限に溜まり続けることはなくなりました。
+- **V2プロジェクトへの自動委譲** — V3 dispatcherは、プロジェクトがまだV2パッケージに解決されていることを検出すると、対応するV2 `uloop-cli` リリースをバージョン別キャッシュへ導入し、コマンドを転送します。V2とV3のプロジェクトを併用する場合は、V3 dispatcherをインストールしたままにしておくのが正しい運用です。ただし委譲そのものはnpmを経由するため、Node.js 22以降が必要です。
+
+## V3で削除されたもの
+
+- **MCP接続** — 削除されました。CLIとバンドルSkillsを組み合わせて使ってください。MCPで公開していた機能はすべて `uloop` コマンドから利用できます。
+- **シェル補完** — 削除されました。既存のシェル設定がエラーにならないよう、`uloop completion` は何もしないスタブとしてのみ残っています。
+- **`capture-window`** — `screenshot` を使ってください。役割が統合され、さらにGame Viewのレンダリングキャプチャや要素の注釈機能が追加されています。
+- **`unity-search`, `get-unity-search-providers`, `get-provider-details`** — 削除されました。Unity Search APIが必要な場合は `execute-dynamic-code` から直接呼び出すか、通常のシーン内検索なら `find-game-objects` を使ってください。
+- **`execute-menu-item`, `get-menu-items`** — 削除されました。`execute-dynamic-code` で `EditorApplication.ExecuteMenuItem(...)` を呼び出してください。
+
+## 破壊的変更
+
+- **booleanオプションが値を取らなくなりました。** V2では `--flag true` や `--flag=false` を受け付けていましたが、V3では値なしのフラグ形式です。デフォルトがtrueのオプションには、代わりに否定形が用意されました。たとえば `uloop compile --wait-for-domain-reload false` は `uloop compile --no-wait-for-domain-reload` になり、`--wait-for-domain-reload true` は単に削除するだけです。各フラグのデフォルトは `uloop <command> --help` で確認できます（`default: enabled` / `default: disabled`）。
+- **コマンドの削除。** 上記で挙げたコマンドは廃止されました。それらを呼び出しているスクリプトやスキルは、代替手段に合わせて書き換える必要があります。
+- **カスタムツールAPIのnamespaceと型名が変わりました。** カスタムツールは `io.github.hatayama.UnityCliLoop.ToolContracts` 名前空間の `UnityCliLoopTool<TSchema, TResponse>` を継承する形になりました。V2 APIで書いたC#カスタムツールがプロジェクトにある場合、V3に上げると**必ずコンパイルエラーが発生します**。これは想定内の挙動で、内蔵の移行ウィザードが該当ファイルを自動で書き換えるので、手作業で直し始めないでください。詳細は [カスタムツール／スキルのV3移行ガイド](migration-v2-to-v3_ja.md) を参照してください。


### PR DESCRIPTION
## Why

release-please generates a separate changelog per component (unity-package, dispatcher, uloop-project-runner), and each one is just a list of commits. Nothing tells a V2 user what actually changed in V3, so this PR adds curated release notes to serve as the real "what's new" document.

## What

Adds two new files under `Packages/src/Documentation~/`:

- `whats-new-v3.md` (English)
- `whats-new-v3_ja.md` (Japanese, 1:1 with the English structure)

Contents: the native Go CLI replacing the npm package, the removal of port management in favour of a Unix domain socket / named pipe, `pause-point` and `raycast`, the dispatcher + project-runner-pin split, installer attestation verification, the `.uloop/outputs` 20-file cap, automatic delegation to V2 projects, everything removed in V3 with its replacement, and the breaking changes.

## Placement

They live under `Documentation~` rather than `docs/`. `docs/` holds developer-facing reference for the rules in `CLAUDE.md`; `Documentation~` is the UPM convention for package documentation and ships inside the OpenUPM tarball, so these notes reach package users next to `CHANGELOG.md`. Tilde-suffixed folders are ignored by Unity, so no `.meta` files are needed.

## Notes

- Every fact was taken from the source of truth in the repository (tool `SKILL.md` files, `first-party-v2-to-v3.md`, `OutputFileRetention.MAX_FILES_PER_DIRECTORY`, the CLI command registry), not from memory.
- The links to `migration-v2-to-v3.md` resolve once PR-2 lands on this integration branch.
- No version numbers are written into the body, so the notes do not need editing on every patch release.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

