### PR TITLE
docs: add custom tool and skill migration guide for V3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,6 @@
 *.json text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
+
+# Binary assets must never be run through end-of-line conversion.
+*.png -text

--- a/Packages/src/Documentation~/migration-v2-to-v3.md
+++ b/Packages/src/Documentation~/migration-v2-to-v3.md
@@ -1,0 +1,229 @@
+# Migrating Custom Tools and Skills to V3
+
+[日本語](migration-v2-to-v3_ja.md)
+
+> [!NOTE]
+> **Most users do not need this guide.** If you have no C# custom tools and no hand-written skills or scripts that call `uloop`, upgrading is just two steps: raise the Unity package version, then press **Install CLI** (or **Update CLI**) in `Window > Unity CLI Loop > Settings`. You are done — you can stop reading here. For what changed in V3, see [What's New in V3](whats-new-v3.md).
+
+## Who needs this guide
+
+Read on if either of these applies to your project:
+
+- **You have C# custom tools written against the V2 API** — classes deriving from the V2 tool base type, or anything else importing the `io.github.hatayama.uLoopMCP` namespace. Follow Step 1 through Step 3; the migration wizard rewrites them for you.
+- **You have `SKILL.md` files, Markdown docs, POSIX shell scripts, or PowerShell scripts that invoke `uloop`** — V3 changed the boolean option syntax and removed several commands, so existing invocations can silently break. Follow Step 4 onward.
+
+If both apply, work through the guide from the top in order.
+
+## What to expect
+
+**Upgrading a project that contains V2-API custom tools will produce compile errors. This is expected.** The V3 extension API lives in a new namespace with new type names, so V2 sources no longer compile. Do not start fixing those errors by hand — the built-in migration wizard scans the project and rewrites the affected files for you, and hand-edits made first only make its job harder.
+
+Before you begin, **commit your work or take a backup**. The wizard rewrites matching files in place, and its confirmation dialog says the same thing: *"Commit or back up your project first (VCS recommended)."* A version control system is the easiest way to review exactly what the wizard changed.
+
+## Step 1: Restart Unity and decline Safe Mode
+
+**Start by restarting the Unity Editor.** If you updated the package from Package Manager and Unity is still running, close it and reopen it anyway. The reason matters: the dialog that asks whether to enter Safe Mode only appears while the Editor is starting up, so if you stay in a running session you never see it and cannot follow the rest of this guide.
+
+On startup, Unity finds the compile errors from the V2 sources and asks whether to enter Safe Mode. **Press `Ignore` so that Unity starts up without entering Safe Mode.**
+
+**Why this matters:** Safe Mode loads only a whitelisted set of assemblies. The Unity CLI Loop editor extension is not on that whitelist, so in Safe Mode the package code never runs and **the migration window cannot open**. Declining Safe Mode is what makes the rest of this guide possible.
+
+> 📸 **SCREENSHOT NEEDED** — `images/migration-safe-mode-dialog.png`
+> Unity's Safe Mode confirmation dialog shown on startup, with the `Ignore` button visible.
+
+> [!WARNING]
+> If you previously turned off `Preferences > Asset Pipeline > Show Enter Safe Mode Dialog`, Unity enters Safe Mode **without asking**, and you will never get the chance to press `Ignore`. Turn that preference back on, then restart the Editor again.
+
+Entering Safe Mode by accident is recoverable. Because the package code does not run in Safe Mode, nothing is recorded about the migration state — restart Unity, press `Ignore`, and the wizard opens as described below.
+
+Launching from the CLI does not avoid this dialog. `uloop launch` shows the same prompt: Unity's `-ignorecompilererrors` switch does not suppress it in GUI mode.
+
+## Step 2: Let the wizard scan
+
+Once the Editor is up, the `Unity CLI Loop Migration` window **opens by itself and starts scanning**. This automatic open fires on the first startup after the package major version goes from V2 to V3, so it is a one-time event rather than something you can trigger again by restarting.
+
+> 📸 **SCREENSHOT NEEDED** — `images/migration-wizard-overview.png`
+> The `Unity CLI Loop Migration` window with both sections visible: `C# Source Structure Migration` and `AI Skill and Script Migration`.
+
+**Give the scan a moment to finish.** When compilation fails, Unity does not perform a domain reload, so the package polls for the failure state instead of reacting to a single callback. A short pause before the status text appears is normal — the window has not frozen.
+
+When the scan settles, the `C# Source Structure Migration` section reports what it found. Right after an automatic open, the status is phrased as a detection from the compile error:
+
+> Detected legacy V2 custom tool API usage from a compile error. Click Migrate to scan the project and update the affected files.
+
+and once a project scan has produced a file list:
+
+> Found 3 C# files that need V3 migration.
+
+> 📸 **SCREENSHOT NEEDED** — `images/migration-wizard-detected.png`
+> The wizard showing the detected state — a `Found {N} C# files that need V3 migration.` status with the `Migrate` button enabled.
+
+**If the window did not open on its own**, open it manually from `Window > Unity CLI Loop > Custom Tool Migration`.
+
+## Step 3: Press Migrate
+
+Press **`Migrate`**. A confirmation dialog titled `Migrate C# Sources?` appears, warning that the files are rewritten in place and that you should commit or back up first. Confirm with **`Migrate`**.
+
+> 📸 **SCREENSHOT NEEDED** — `images/migration-wizard-confirm-dialog.png`
+> The `Migrate C# Sources?` confirmation dialog, with the "Commit or back up your project first (VCS recommended)." warning readable.
+
+While it runs, the button reads `Migrating...` and the status line reports progress as `{n}/{N} steps complete.`. When it finishes you get:
+
+> Migration complete. No further C# migration is needed.
+
+At that point the rewritten sources compile, and the errors you saw on startup are gone.
+
+### What the status text and button labels mean
+
+| Status text | Meaning |
+|---|---|
+| `C# source migration status has not been checked.` | The project has not been scanned yet in this session. |
+| `Detected legacy V2 custom tool API usage from a compile error.` | The compile error indicates V2 API usage. Pressing `Migrate` runs the actual project scan and rewrites what it finds. |
+| `Found {N} C# files that need V3 migration.` | A project scan completed and found `{N}` files to rewrite. |
+| `No C# source structure migration is needed.` | The scan found nothing to rewrite. |
+| `Migration complete. No further C# migration is needed.` | The rewrite finished successfully. |
+
+| Button label | Meaning |
+|---|---|
+| `Migrate` | Ready to scan and rewrite. |
+| `Migrating...` | The rewrite is in progress. |
+| `Check required` | The status has not been checked yet; press it to scan. |
+| `Nothing to migrate` | The scan found no files needing migration. |
+
+### What the wizard rewrites
+
+- **Namespace** — `io.github.hatayama.uLoopMCP` becomes `io.github.hatayama.UnityCliLoop.ToolContracts` for tool contract types.
+- **Base types** — `AbstractUnityTool` becomes `UnityCliLoopTool<TSchema, TResponse>`, `BaseToolSchema` becomes `UnityCliLoopToolSchema`, and `BaseToolResponse` becomes `UnityCliLoopToolResponse`.
+- **Attribute** — `[McpTool]` becomes `[UnityCliLoopTool]`. The `Description` argument is dropped, while `DisplayDevelopmentOnly` and `RequiredSecuritySetting` are carried over.
+- **Assembly definition references** — `uLoopMCP.Editor` and `uLoopMCP.Runtime` references in your `.asmdef` files are repointed at the V3 assemblies.
+
+## Step 4: Migrate skills and scripts that call uloop
+
+The second section, `AI Skill and Script Migration`, covers the other half of the job: your `SKILL.md` files, Markdown docs, shell scripts, and PowerShell scripts that invoke `uloop`.
+
+> 📸 **SCREENSHOT NEEDED** — `images/migration-wizard-ai-skill.png`
+> The `AI Skill and Script Migration` section of the wizard, ideally with the `Prompt for your AI agent` foldout expanded.
+
+**This window does not rewrite those files itself.** It only installs and removes a temporary AI skill; your AI agent does the actual editing. The workflow is:
+
+1. Press **`Install Migration Skill`**. This installs a temporary skill named `v3-cli-invocation-migration` into your project.
+2. Expand the **`Prompt for your AI agent`** foldout and press **`Copy AI Prompt`**.
+3. Paste that prompt into your AI agent and let it run. The skill teaches the agent to search for `uloop` invocations, read the surrounding context, and update only genuine V2 CLI usage — leaving C# snippets, enum references, and unrelated JSON alone.
+4. Review the agent's changes. It reports which files it edited, which removed commands it found as migration candidates, and what you should verify by hand.
+
+## CLI option changes
+
+The AI agent applies these changes for you. This table is here so you can review its work — the canonical source is `Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md`.
+
+### Boolean argument rules
+
+V3 boolean options do not take a value. How a V2 invocation converts depends on the V3 option's default:
+
+| V2 form | V3 form |
+|---|---|
+| `--flag true` / `--flag=true` | `--flag`, when the V3 option is a positive default-false boolean |
+| `--flag false` / `--flag=false` | remove the option, when the V3 default is already false |
+| `--flag true` / `--flag=true` | remove the option, when the V3 default is already true |
+| `--flag false` / `--flag=false` | use the V3 negative option, when the V3 default is true |
+
+For any boolean not listed below, run `uloop <command> --help`: every V3 flag prints its default as `default: enabled` (true) or `default: disabled` (false).
+
+### Renamed first-party options
+
+| V2 command | V2 option | V3 replacement |
+|---|---|---|
+| `uloop compile` | `--force-recompile true` | `--force-recompile` |
+| `uloop compile` | `--force-recompile false` | remove |
+| `uloop compile` | `--wait-for-domain-reload true` or bare | remove |
+| `uloop compile` | `--wait-for-domain-reload false` | `--no-wait-for-domain-reload` |
+| `uloop compile` | `--reload-external-scene-changes true` | remove |
+| `uloop compile` | `--reload-external-scene-changes false` | `--stop-on-external-scene-changes` |
+| `uloop run-tests` | `--save-before-run true` or bare | remove |
+| `uloop run-tests` | `--save-before-run false` | `--fail-on-unsaved-changes` |
+| `uloop record-input` | `--show-overlay true` | remove |
+| `uloop record-input` | `--show-overlay false` | `--no-show-overlay` |
+| `uloop replay-input` | `--show-overlay true` | remove |
+| `uloop replay-input` | `--show-overlay false` | `--no-show-overlay` |
+| `uloop get-hierarchy` | `--include-components true` | remove |
+| `uloop get-hierarchy` | `--include-components false` | `--no-include-components` |
+| `uloop get-hierarchy` | `--include-inactive true` | remove |
+| `uloop get-hierarchy` | `--include-inactive false` | `--no-include-inactive` |
+| `uloop execute-dynamic-code` | `--compile-only true` | `--compile-only` |
+| `uloop execute-dynamic-code` | `--compile-only false` | remove |
+
+> [!WARNING]
+> Two of these option names are also **valid V3 syntax on a different command**, so never migrate them by name alone. Bare `--wait-for-domain-reload` is a valid default-false flag on `uloop execute-dynamic-code`, and bare `--include-inactive` is a valid default-false flag on `uloop find-game-objects`. Check which command an invocation belongs to before editing it.
+
+### Removed and renamed commands
+
+| V2 command | V3 handling |
+|---|---|
+| `uloop capture-window` | Renamed to `uloop screenshot`. |
+| `uloop unity-search` | Removed. Use `uloop execute-dynamic-code`, or `uloop find-game-objects` for ordinary scene lookups. |
+| `uloop get-unity-search-providers` | Removed. Use `uloop execute-dynamic-code`. |
+| `uloop get-provider-details` | Removed. Use `uloop execute-dynamic-code`. |
+| `uloop execute-menu-item` | Removed. Use `uloop execute-dynamic-code` with `EditorApplication.ExecuteMenuItem(...)`. |
+| `uloop get-menu-items` | Removed. Use `uloop execute-dynamic-code`. |
+
+The migration skill reports these as candidates rather than rewriting them, because the replacement depends on what your script was doing.
+
+## Step 5: Clean up the temporary skill
+
+Once your docs and scripts are migrated, remove the temporary skill. The window states this explicitly:
+
+> This skill is temporary. Remove it once your docs and scripts are migrated to V3 CLI syntax.
+
+Press **`Remove Migration Skill`** in the wizard, or remove it from the CLI for each target you installed it to:
+
+```bash
+uloop skills uninstall-v3-migration --claude
+uloop skills uninstall-v3-migration --codex
+```
+
+## Verify
+
+Work through these three checks:
+
+```bash
+# 1. The project compiles with no errors
+uloop compile
+
+# 2. Your custom tools are registered and callable
+uloop list
+```
+
+- `uloop compile` should report zero errors. Warnings unrelated to the migration are fine.
+- `uloop list` should include every custom tool you had before the upgrade, under the same tool names — the migration changes namespaces and base types, not your `ToolName` values.
+- Finally, run one of your own skills or scripts end to end and confirm the `uloop` invocations inside it still behave as expected. Option syntax errors surface immediately as a failed command rather than a silent no-op.
+
+## Manual migration reference
+
+If you prefer to migrate by hand, these are the concrete replacements the wizard performs. The legacy namespace is `io.github.hatayama.uLoopMCP`; the V3 tool contract namespace is `io.github.hatayama.UnityCliLoop.ToolContracts`.
+
+| V2 type | V3 type |
+|---|---|
+| `AbstractUnityTool` | `UnityCliLoopTool` |
+| `IUnityTool` | `IUnityCliLoopTool` |
+| `BaseToolSchema` | `UnityCliLoopToolSchema` |
+| `BaseToolResponse` | `UnityCliLoopToolResponse` |
+| `McpToolAttribute` (`[McpTool]`) | `UnityCliLoopToolAttribute` (`[UnityCliLoopTool]`) |
+| `McpConstants` | `UnityCliLoopConstants` |
+| `SecuritySettings` | `UnityCliLoopSecuritySetting` |
+| `ToolParameterSchemaGenerator` | `UnityCliLoopToolParameterSchemaGenerator` |
+| `ParameterValidationException` | `UnityCliLoopToolParameterValidationException` |
+| `CustomToolManager` | `UnityCliLoopToolRegistrar` |
+
+| V2 assembly reference | V3 assembly reference |
+|---|---|
+| `uLoopMCP.Editor` | `UnityCLILoop.Application` |
+| `uLoopMCP.Runtime` | `UnityCLILoop.Runtime` |
+
+## Troubleshooting
+
+**Unity entered Safe Mode.** The package code does not run there, so nothing was recorded and nothing was lost. Restart the Editor and press `Ignore` at the prompt. If you were never asked, re-enable `Preferences > Asset Pipeline > Show Enter Safe Mode Dialog` and restart again.
+
+**The wizard did not open automatically.** First confirm you actually restarted the Editor after updating the package — the automatic open happens during startup, on the first launch after the major version goes from V2 to V3. Open it manually from `Window > Unity CLI Loop > Custom Tool Migration`; everything in Step 2 onward works the same way from the manual route.
+
+**Compile errors remain after `Migrate` finishes.** Read the remaining errors before doing anything else: sources that mix custom logic with V2 API calls can need a manual touch-up that the rules do not cover. Use your VCS diff to see what the wizard changed, restore from your commit or backup if you want a clean slate, and work through the Manual migration reference above for whatever is left.
+
+**Your AI agent cannot see the temporary skill.** The skill is installed per target, so check that you installed it for the agent you are actually using (`--claude`, `--codex`, and so on) rather than a different one. Re-running `uloop skills install` for the right target refreshes the installed copies.

--- a/Packages/src/Documentation~/migration-v2-to-v3_ja.md
+++ b/Packages/src/Documentation~/migration-v2-to-v3_ja.md
@@ -1,0 +1,229 @@
+# カスタムツール／スキルのV3移行ガイド
+
+[English](migration-v2-to-v3.md)
+
+> [!NOTE]
+> **ほとんどのユーザーには、このガイドは不要です。** C#カスタムツールも、`uloop` を呼び出す自作のスキル／スクリプトも持っていないなら、アップグレードは2ステップで終わります。Unityパッケージのバージョンを上げ、`Window > Unity CLI Loop > Settings` で **Install CLI**（または **Update CLI**）を押すだけです。これで移行は完了なので、ここで読み終えて構いません。V3で何が変わったかは [V3の新機能](whats-new-v3_ja.md) を参照してください。
+
+## このガイドが必要な人
+
+次のどちらかに当てはまる場合は、続きを読んでください。
+
+- **V2 APIで書いたC#カスタムツールがある** — V2のツール基底型を継承したクラスや、`io.github.hatayama.uLoopMCP` 名前空間をimportしているコードがある場合です。Step 1〜Step 3に従ってください。移行ウィザードが自動で書き換えます。
+- **`uloop` を呼び出す `SKILL.md`・Markdownドキュメント・POSIXシェルスクリプト・PowerShellスクリプトがある** — V3ではbooleanオプションの書式が変わり、いくつかのコマンドが削除されたため、既存の呼び出しが気づかないうちに壊れる可能性があります。Step 4以降に従ってください。
+
+両方に当てはまる場合は、このガイドを上から順に進めてください。
+
+## 事前に知っておくこと
+
+**V2 APIのカスタムツールがあるプロジェクトをV3に上げると、必ずコンパイルエラーが発生します。これは想定内の挙動です。** V3の拡張APIは新しい名前空間と新しい型名になったため、V2のソースはそのままではコンパイルできません。**このエラーを手作業で直し始めないでください。** 内蔵の移行ウィザードがプロジェクトをスキャンして該当ファイルを書き換えます。先に手で編集してしまうと、ウィザードの処理をかえって難しくします。
+
+作業を始める前に、**commitするかバックアップを取ってください**。ウィザードは対象ファイルをその場で書き換えます。確認ダイアログにも同じ警告が表示されます（*"Commit or back up your project first (VCS recommended)."*）。ウィザードが何を変更したかを確認するには、バージョン管理システムを使うのが一番簡単です。
+
+## Step 1: Unityを再起動し、Safe Modeを拒否する
+
+**まずUnity Editorを再起動してください。** Package Managerから更新してUnityが起動したままの場合も、必ず一度閉じて開き直します。これには理由があります。Safe Modeに入るかを尋ねるダイアログは**Editorの起動時にしか表示されない**ため、起動したままのセッションではこのダイアログを見ることができず、この先の手順に進めません。
+
+起動時、UnityはV2ソースのコンパイルエラーを検出し、Safe Modeに入るかどうかを尋ねてきます。**`Ignore` を押して、Safe Modeに入らずに起動させてください。**
+
+**なぜ重要なのか:** Safe Modeでは、ホワイトリストに登録されたアセンブリだけが読み込まれます。Unity CLI Loopのエディタ拡張はこのホワイトリストに含まれないため、Safe Modeではパッケージのコードが動かず、**移行ウィンドウが開きません**。Safe Modeを拒否することが、この先の手順の前提になります。
+
+> 📸 **SCREENSHOT NEEDED** — `images/migration-safe-mode-dialog.png`
+> 起動時に表示される Safe Mode 確認ダイアログ。`Ignore` ボタンが見える状態。
+
+> [!WARNING]
+> `Preferences > Asset Pipeline > Show Enter Safe Mode Dialog` をOFFにしていると、Unityは**確認なしでSafe Modeに入ります**。この場合 `Ignore` を押す機会自体がありません。この設定をONに戻してから、Editorを再起動してください。
+
+誤ってSafe Modeに入ってしまっても、やり直せます。Safe Modeではパッケージのコードが動かないため、移行状態は何も記録されていません。Unityを再起動して `Ignore` を選べば、以下のとおりウィザードが開きます。
+
+CLIから起動してもこのダイアログは回避できません。`uloop launch` でも同じダイアログが出ます。Unityの仕様上、`-ignorecompilererrors` はGUIモードではこのダイアログを抑止しないためです。
+
+## Step 2: ウィザードのスキャンを待つ
+
+Editorが起動すると、`Unity CLI Loop Migration` ウィンドウが**自動的に開き、スキャンが始まります**。この自動オープンは、パッケージのメジャーバージョンがV2からV3になった最初の起動時に発火します。つまり一度きりのイベントで、再起動すればまた出せるというものではありません。
+
+> 📸 **SCREENSHOT NEEDED** — `images/migration-wizard-overview.png`
+> `Unity CLI Loop Migration` ウィンドウ全体。`C# Source Structure Migration` と `AI Skill and Script Migration` の2セクションが両方見える状態。
+
+**スキャンが終わるまで少し待ってください。** コンパイルが失敗している間、Unityはドメインリロードを行いません。そのためパッケージはコールバック1回に頼らず、失敗状態をポーリングして検出します。ステータスが表示されるまでに少し間があるのは正常な挙動で、ウィンドウが固まったわけではありません。
+
+スキャンが落ち着くと、`C# Source Structure Migration` セクションが結果を表示します。自動オープン直後は、コンパイルエラー起点の検出として次のように表示されます。
+
+> Detected legacy V2 custom tool API usage from a compile error. Click Migrate to scan the project and update the affected files.
+
+プロジェクトスキャンでファイル一覧が確定すると、次の表示になります。
+
+> Found 3 C# files that need V3 migration.
+
+> 📸 **SCREENSHOT NEEDED** — `images/migration-wizard-detected.png`
+> 移行対象を検出した状態のウィザード。`Found {N} C# files that need V3 migration.` のステータスが表示され、`Migrate` ボタンが押せる状態。
+
+**ウィンドウが自動で開かなかった場合**は、`Window > Unity CLI Loop > Custom Tool Migration` から手動で開いてください。
+
+## Step 3: Migrateを押す
+
+**`Migrate`** を押します。`Migrate C# Sources?` というタイトルの確認ダイアログが表示され、ファイルがその場で書き換えられること、先にcommitまたはバックアップを取るべきことが警告されます。**`Migrate`** で確定してください。
+
+> 📸 **SCREENSHOT NEEDED** — `images/migration-wizard-confirm-dialog.png`
+> `Migrate C# Sources?` 確認ダイアログ。"Commit or back up your project first (VCS recommended)." の警告文が読める状態。
+
+実行中はボタンが `Migrating...` になり、ステータス行に `{n}/{N} steps complete.` と進捗が表示されます。完了すると次のように表示されます。
+
+> Migration complete. No further C# migration is needed.
+
+この時点で書き換え後のソースはコンパイルが通り、起動時に出ていたエラーは解消しています。
+
+### ステータス文言とボタン表示の意味
+
+| ステータス文言 | 意味 |
+|---|---|
+| `C# source migration status has not been checked.` | このセッションではまだプロジェクトをスキャンしていない。 |
+| `Detected legacy V2 custom tool API usage from a compile error.` | コンパイルエラーからV2 APIの使用を検出した。`Migrate` を押すと実際のプロジェクトスキャンが走り、該当ファイルを書き換える。 |
+| `Found {N} C# files that need V3 migration.` | プロジェクトスキャンが完了し、書き換え対象が `{N}` 件見つかった。 |
+| `No C# source structure migration is needed.` | スキャンの結果、書き換える対象はなかった。 |
+| `Migration complete. No further C# migration is needed.` | 書き換えが正常に完了した。 |
+
+| ボタン表示 | 意味 |
+|---|---|
+| `Migrate` | スキャンと書き換えを実行できる状態。 |
+| `Migrating...` | 書き換えを実行中。 |
+| `Check required` | まだ状態が未チェック。押すとスキャンする。 |
+| `Nothing to migrate` | スキャンの結果、移行が必要なファイルはなかった。 |
+
+### ウィザードが書き換える内容
+
+- **名前空間** — ツールの契約型について、`io.github.hatayama.uLoopMCP` が `io.github.hatayama.UnityCliLoop.ToolContracts` になります。
+- **基底型** — `AbstractUnityTool` が `UnityCliLoopTool<TSchema, TResponse>` に、`BaseToolSchema` が `UnityCliLoopToolSchema` に、`BaseToolResponse` が `UnityCliLoopToolResponse` になります。
+- **属性** — `[McpTool]` が `[UnityCliLoopTool]` になります。`Description` 引数は削除され、`DisplayDevelopmentOnly` と `RequiredSecuritySetting` は引き継がれます。
+- **asmdefの参照** — `.asmdef` ファイル内の `uLoopMCP.Editor` と `uLoopMCP.Runtime` への参照が、V3のアセンブリに張り替えられます。
+
+## Step 4: uloopを呼び出すスキル・スクリプトを移行する
+
+2つ目のセクション `AI Skill and Script Migration` は、残り半分の作業を担当します。対象は、`uloop` を呼び出している `SKILL.md`・Markdownドキュメント・シェルスクリプト・PowerShellスクリプトです。
+
+> 📸 **SCREENSHOT NEEDED** — `images/migration-wizard-ai-skill.png`
+> ウィザードの `AI Skill and Script Migration` セクション。`Prompt for your AI agent` の折りたたみを開いた状態が望ましい。
+
+**このウィンドウ自身はファイルを書き換えません。** 行うのは一時AIスキルのインストールと削除だけで、実際の編集はAIエージェントが行います。手順は次のとおりです。
+
+1. **`Install Migration Skill`** を押します。`v3-cli-invocation-migration` という名前の一時スキルがプロジェクトにインストールされます。
+2. **`Prompt for your AI agent`** の折りたたみを開き、**`Copy AI Prompt`** を押します。
+3. コピーしたプロンプトをAIエージェントに貼り付けて実行させます。このスキルは、`uloop` の呼び出しを検索し、前後の文脈を確認したうえで、本物のV2 CLI使用箇所だけを更新する手順をエージェントに教えます。C#のスニペット、enum参照、無関係なJSONは書き換えません。
+4. エージェントの変更内容をレビューします。編集したファイル、移行候補として見つかった削除済みコマンド、手動で確認すべき箇所がレポートされます。
+
+## CLIオプションの変更点
+
+これらの変更はAIエージェントが自動で適用します。以下の表は、その結果を人間がレビューするための参照用です。正典は `Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md` です。
+
+### booleanオプションの変換ルール
+
+V3のbooleanオプションは値を取りません。V2の呼び出しをどう変換するかは、V3側オプションのデフォルト値によって決まります。
+
+| V2の書式 | V3の書式 |
+|---|---|
+| `--flag true` / `--flag=true` | V3オプションがデフォルトfalseの肯定形なら `--flag` |
+| `--flag false` / `--flag=false` | V3のデフォルトが既にfalseならオプションごと削除 |
+| `--flag true` / `--flag=true` | V3のデフォルトが既にtrueならオプションごと削除 |
+| `--flag false` / `--flag=false` | V3のデフォルトがtrueならV3の否定形オプションを使う |
+
+以下の表にないbooleanオプションは、`uloop <command> --help` で確認してください。V3の各フラグはデフォルト値が `default: enabled`（true）または `default: disabled`（false）として表示されます。
+
+### 名前が変わったfirst-partyオプション
+
+| V2コマンド | V2オプション | V3での置き換え |
+|---|---|---|
+| `uloop compile` | `--force-recompile true` | `--force-recompile` |
+| `uloop compile` | `--force-recompile false` | 削除 |
+| `uloop compile` | `--wait-for-domain-reload true` またはフラグのみ | 削除 |
+| `uloop compile` | `--wait-for-domain-reload false` | `--no-wait-for-domain-reload` |
+| `uloop compile` | `--reload-external-scene-changes true` | 削除 |
+| `uloop compile` | `--reload-external-scene-changes false` | `--stop-on-external-scene-changes` |
+| `uloop run-tests` | `--save-before-run true` またはフラグのみ | 削除 |
+| `uloop run-tests` | `--save-before-run false` | `--fail-on-unsaved-changes` |
+| `uloop record-input` | `--show-overlay true` | 削除 |
+| `uloop record-input` | `--show-overlay false` | `--no-show-overlay` |
+| `uloop replay-input` | `--show-overlay true` | 削除 |
+| `uloop replay-input` | `--show-overlay false` | `--no-show-overlay` |
+| `uloop get-hierarchy` | `--include-components true` | 削除 |
+| `uloop get-hierarchy` | `--include-components false` | `--no-include-components` |
+| `uloop get-hierarchy` | `--include-inactive true` | 削除 |
+| `uloop get-hierarchy` | `--include-inactive false` | `--no-include-inactive` |
+| `uloop execute-dynamic-code` | `--compile-only true` | `--compile-only` |
+| `uloop execute-dynamic-code` | `--compile-only false` | 削除 |
+
+> [!WARNING]
+> このうち2つのオプション名は、**別のコマンドではV3として正しい書式**なので、名前だけを見て一括置換してはいけません。`uloop execute-dynamic-code` ではフラグのみの `--wait-for-domain-reload` がデフォルトfalseの正しいV3フラグであり、`uloop find-game-objects` ではフラグのみの `--include-inactive` が同じくデフォルトfalseの正しいV3フラグです。編集する前に、その呼び出しがどのコマンドのものかを必ず確認してください。
+
+### 削除・改名されたコマンド
+
+| V2コマンド | V3での扱い |
+|---|---|
+| `uloop capture-window` | `uloop screenshot` に改名。 |
+| `uloop unity-search` | 削除。`uloop execute-dynamic-code` を使うか、通常のシーン内検索なら `uloop find-game-objects` を使う。 |
+| `uloop get-unity-search-providers` | 削除。`uloop execute-dynamic-code` を使う。 |
+| `uloop get-provider-details` | 削除。`uloop execute-dynamic-code` を使う。 |
+| `uloop execute-menu-item` | 削除。`uloop execute-dynamic-code` から `EditorApplication.ExecuteMenuItem(...)` を呼ぶ。 |
+| `uloop get-menu-items` | 削除。`uloop execute-dynamic-code` を使う。 |
+
+移行スキルはこれらを自動で書き換えず、移行候補として報告するだけです。スクリプトが何をしていたかによって適切な代替手段が変わるためです。
+
+## Step 5: 一時スキルを削除する
+
+ドキュメントとスクリプトの移行が終わったら、一時スキルを削除してください。画面にも明示されています。
+
+> This skill is temporary. Remove it once your docs and scripts are migrated to V3 CLI syntax.
+
+ウィザードの **`Remove Migration Skill`** を押すか、インストールした対象ごとにCLIから削除します。
+
+```bash
+uloop skills uninstall-v3-migration --claude
+uloop skills uninstall-v3-migration --codex
+```
+
+## 動作確認
+
+次の3点を確認してください。
+
+```bash
+# 1. プロジェクトがエラーなしでコンパイルできる
+uloop compile
+
+# 2. カスタムツールが登録され、呼び出せる
+uloop list
+```
+
+- `uloop compile` はエラー0件になるはずです。移行と無関係な警告は問題ありません。
+- `uloop list` には、アップグレード前に持っていたカスタムツールがすべて、同じツール名で表示されるはずです。移行で変わるのは名前空間と基底型であり、`ToolName` の値ではありません。
+- 最後に、自作のスキルやスクリプトを実際に一通り実行し、中の `uloop` 呼び出しが期待どおり動くことを確認してください。オプションの書式エラーは、無言で無視されるのではなくコマンドの失敗として即座に現れます。
+
+## 手動移行のリファレンス
+
+手作業で移行したい場合のために、ウィザードが行う具体的な置き換えを示します。旧名前空間は `io.github.hatayama.uLoopMCP`、V3のツール契約名前空間は `io.github.hatayama.UnityCliLoop.ToolContracts` です。
+
+| V2の型 | V3の型 |
+|---|---|
+| `AbstractUnityTool` | `UnityCliLoopTool` |
+| `IUnityTool` | `IUnityCliLoopTool` |
+| `BaseToolSchema` | `UnityCliLoopToolSchema` |
+| `BaseToolResponse` | `UnityCliLoopToolResponse` |
+| `McpToolAttribute`（`[McpTool]`） | `UnityCliLoopToolAttribute`（`[UnityCliLoopTool]`） |
+| `McpConstants` | `UnityCliLoopConstants` |
+| `SecuritySettings` | `UnityCliLoopSecuritySetting` |
+| `ToolParameterSchemaGenerator` | `UnityCliLoopToolParameterSchemaGenerator` |
+| `ParameterValidationException` | `UnityCliLoopToolParameterValidationException` |
+| `CustomToolManager` | `UnityCliLoopToolRegistrar` |
+
+| V2のアセンブリ参照 | V3のアセンブリ参照 |
+|---|---|
+| `uLoopMCP.Editor` | `UnityCLILoop.Application` |
+| `uLoopMCP.Runtime` | `UnityCLILoop.Runtime` |
+
+## トラブルシューティング
+
+**Safe Modeに入ってしまった。** Safe Modeではパッケージのコードが動かないため、何も記録されておらず、失われたものもありません。Editorを再起動し、ダイアログで `Ignore` を押してください。そもそもダイアログが出なかった場合は、`Preferences > Asset Pipeline > Show Enter Safe Mode Dialog` をONに戻してから再起動してください。
+
+**ウィザードが自動で開かない。** まず、パッケージ更新後にEditorを実際に再起動したかを確認してください。自動オープンは起動時、しかもメジャーバージョンがV2からV3になった最初の起動時に発火します。開かない場合は `Window > Unity CLI Loop > Custom Tool Migration` から手動で開いてください。手動で開いても、Step 2以降の手順はまったく同じです。
+
+**`Migrate` 実行後もコンパイルエラーが残る。** まず残っているエラーの内容を読んでください。カスタムロジックとV2 API呼び出しが混在しているソースは、置換ルールでカバーできず手直しが必要な場合があります。VCSのdiffでウィザードが何を変更したかを確認し、やり直したい場合はcommitやバックアップから戻したうえで、上記の「手動移行のリファレンス」を使って残りを対処してください。
+
+**AIエージェントから一時スキルが見えない。** このスキルは対象ごとにインストールされるため、実際に使っているエージェント向けにインストールしたか（`--claude`、`--codex` など）を確認してください。正しい対象を指定して `uloop skills install` を実行し直すと、インストール済みのコピーが更新されます。


### PR DESCRIPTION
## Why

Upgrading a project that contains V2-API custom tools **always** produces compile errors, because the extension API moved to a new namespace with new type names. A migration wizard that fixes this automatically already ships in the package, but nothing documents it — so users see the errors and start repairing sources by hand, which is exactly the wrong move.

## What

Adds `migration-v2-to-v3.md` and `migration-v2-to-v3_ja.md` under `Packages/src/Documentation~/`, scoped deliberately to **authors of custom tools and custom skills**. A `> [!NOTE]` at the top tells everyone else they can stop reading: for them the upgrade is just a package bump plus **Install CLI**.

The guide follows a single happy path: restart Unity → decline Safe Mode → let the wizard scan → press `Migrate` → migrate skills/scripts → clean up. Safe Mode must be declined because Safe Mode loads only whitelisted assemblies, and the Unity CLI Loop editor extension is not among them, so the migration window cannot open there.

Also marks `*.png` as binary in `.gitattributes`, since the repository applies `* text=auto eol=lf` to everything by default.

## Sources

Nothing here was written from memory. Wizard copy comes from `ThirdPartyToolMigrationWizardText.cs`, the old-to-new type/assembly table from `ThirdPartyToolMigrationRuleCatalog.cs` and `ThirdPartyToolMigrationAsmdefReferenceRules.cs`, and the CLI option tables from `first-party-v2-to-v3.md`. Only replacements that are actually confirmed in the rule catalog are listed.

## Screenshots needed

All five screenshots are still to be taken, and each spot is marked with a **visible** placeholder block (a quote block, not an HTML comment) so the intended image is obvious when reading the rendered page. They can be dropped into `Packages/src/Documentation~/images/` under these exact names, replacing the corresponding placeholder block in both the English and Japanese file:

| File name | Screen | Condition |
|---|---|---|
| `migration-safe-mode-dialog.png` | Unity's Safe Mode confirmation dialog on startup | `Ignore` button readable. OS screenshot tool — `uloop screenshot` cannot capture OS modals. |
| `migration-wizard-overview.png` | The whole `Unity CLI Loop Migration` window | Both `C# Source Structure Migration` and `AI Skill and Script Migration` sections visible. |
| `migration-wizard-detected.png` | Wizard with migration targets detected | Status reads `Found {N} C# file(s) that need V3 migration.` with `Migrate` enabled. Requires a project containing V2-API C# files. |
| `migration-wizard-confirm-dialog.png` | The `Migrate C# Sources?` confirmation dialog | The "Commit or back up your project first (VCS recommended)." warning readable. OS screenshot tool. |
| `migration-wizard-ai-skill.png` | The `AI Skill and Script Migration` section | Ideally with the `Prompt for your AI agent` foldout expanded. |

Screenshots 1-4 can all be captured in a single V2 to V3 upgrade run. The `v3-upgrade-smoke-test` skill reproduces that upgrade if you want a clean environment to shoot in. Please capture with the Editor in English so the UI strings match the ones quoted in the guide.

## Note

The `Ignore` button label came from a real-Editor observation rather than the C# reference (the dialog is native). Once screenshot 1 exists, please confirm the label matches; if it differs, the screenshot wins and the guide should be corrected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

