### PR TITLE
fix: Rename the global uloop launcher to dispatcher in user-facing text

### DIFF
--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -439,7 +439,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public async Task WaitForUninstallCompletionAsync_WhenTargetRemainsReportsTimeout()
         {
-            // Verifies uninstall completion reports the launcher path when deferred self-removal times out.
+            // Verifies uninstall completion reports the dispatcher path when deferred self-removal times out.
             string targetPath = "C:\\Users\\ExampleUser\\Programs\\uloop\\bin\\uloop.exe";
             int delayCount = 0;
 
@@ -463,7 +463,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public async Task WaitForUninstallCompletionAsync_WhenTargetIsRemovedReturnsSuccess()
         {
-            // Verifies uninstall completion succeeds as soon as deferred launcher self-removal finishes.
+            // Verifies uninstall completion succeeds as soon as deferred dispatcher self-removal finishes.
 
             CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
                 "C:\\Users\\ExampleUser\\Programs\\uloop\\bin\\uloop.exe",
@@ -486,7 +486,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void BuildUninstallCommand_OnMacRunsInstalledLauncher()
+        public void BuildUninstallCommand_OnMacRunsInstalledDispatcher()
         {
             // Verifies that editor uninstall delegates removal to the installed uloop command.
             NativeCliInstallCommand command = NativeCliCommandBuilder.BuildUninstallCommand(
@@ -499,7 +499,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void BuildUninstallCommand_OnWindowsRunsInstalledLauncher()
+        public void BuildUninstallCommand_OnWindowsRunsInstalledDispatcher()
         {
             // Verifies that Windows editor uninstall delegates removal to the installed uloop command.
             NativeCliInstallCommand command = NativeCliCommandBuilder.BuildUninstallCommand(

--- a/cli/common/clicore/command_registry.go
+++ b/cli/common/clicore/command_registry.go
@@ -37,14 +37,14 @@ var NativeCommands = []NativeCommandEntry{
 	{Name: PausePointStatusUserCommandName, Description: "Show the state of a named UloopPausePoint.Pause marker", Owner: RunnerOwned},
 	{Name: SkillsCommandName, Description: "List, install, or uninstall agent skills", Owner: DispatcherOwned},
 	{Name: CompletionCommand, Description: "Deprecated: shell completion has been removed; this command is now a no-op", Owner: DispatcherOwned},
-	{Name: InstallCommandName, Description: "Configure the global uloop launcher binary", Owner: DispatcherOwned},
-	{Name: UpdateCommandName, Description: "Update the global uloop launcher binary", Owner: DispatcherOwned},
-	{Name: UninstallCommandName, Description: "Remove the global uloop launcher binary", Owner: DispatcherOwned},
+	{Name: InstallCommandName, Description: "Configure the global uloop dispatcher binary", Owner: DispatcherOwned},
+	{Name: UpdateCommandName, Description: "Update the global uloop dispatcher binary", Owner: DispatcherOwned},
+	{Name: UninstallCommandName, Description: "Remove the global uloop dispatcher binary", Owner: DispatcherOwned},
 	{Name: VersionCommandName, Description: "Show the installed uloop version", Owner: DispatcherOwned},
 }
 
 // IsDispatcherOwnedCommandName reports whether a native command belongs to the
-// global launcher's process. This is the single source of truth for the
+// global dispatcher's process. This is the single source of truth for the
 // dispatcher/runner command split: the dispatcher handles these in-process, and
 // the project runner must reject them instead of executing them.
 func IsDispatcherOwnedCommandName(command string) bool {

--- a/cli/dispatcher/dispatchercontract/contract.go
+++ b/cli/dispatcher/dispatchercontract/contract.go
@@ -19,7 +19,7 @@ var contractFiles embed.FS
 var DispatcherCurrent = mustLoadDispatcherContract()
 
 type DispatcherContract struct {
-	// DispatcherVersion is the launcher release version. It moves only when the dispatcher
+	// DispatcherVersion is the dispatcher release version. It moves only when the dispatcher
 	// itself is released, not when project-local CLI releases move.
 	DispatcherVersion string `json:"dispatcherVersion"`
 }

--- a/cli/dispatcher/dispatchercontract/contract_test.go
+++ b/cli/dispatcher/dispatchercontract/contract_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestDispatcherContractProvidesRuntimeVersion(t *testing.T) {
-	// Verifies that the launcher owns a release version independent from project-local CLI releases.
+	// Verifies that the dispatcher owns a release version independent from project-local CLI releases.
 	clitest.RequireValidContractVersion(t, "dispatcherVersion", DispatcherCurrent.DispatcherVersion)
 }
 

--- a/cli/dispatcher/internal/dispatcher/bootstrap_platform_errors.go
+++ b/cli/dispatcher/internal/dispatcher/bootstrap_platform_errors.go
@@ -14,7 +14,7 @@ func unsupportedPlatformError(message string, context clierrors.ErrorContext) (c
 			context,
 			[]string{
 				"Run `uloop update` on macOS or Windows.",
-				"Install the latest uloop launcher manually on this platform.",
+				"Install the latest uloop dispatcher manually on this platform.",
 			}), true
 	case installUnsupportedOSMessage:
 		return invalidArgumentExecutionError(
@@ -30,7 +30,7 @@ func unsupportedPlatformError(message string, context clierrors.ErrorContext) (c
 			context,
 			[]string{
 				"Run `uloop uninstall` on macOS or Windows.",
-				"Remove the uloop launcher binary manually on this platform.",
+				"Remove the uloop dispatcher binary manually on this platform.",
 			}), true
 	default:
 		return clierrors.CLIError{}, false

--- a/cli/dispatcher/internal/dispatcher/dispatcher_bootstrap_routing_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_bootstrap_routing_test.go
@@ -16,7 +16,7 @@ import (
 // project pin, so each test runs from an empty working directory where any
 // accidental forwarding would fail with a pin resolution error.
 
-// Verifies the global launcher reports dispatcher identity fields in JSON version output.
+// Verifies the global dispatcher reports dispatcher identity fields in JSON version output.
 func TestRunDispatcherVersionJSONReportsDispatcherIdentity(t *testing.T) {
 	t.Chdir(t.TempDir())
 
@@ -102,7 +102,7 @@ func TestRunDispatcherUpdateRunsInDispatcherProcess(t *testing.T) {
 	if !updateExecuted {
 		t.Fatal("expected update to run in the dispatcher process")
 	}
-	if !strings.Contains(stdout.String(), "Updating global uloop launcher") {
+	if !strings.Contains(stdout.String(), "Updating global uloop dispatcher") {
 		t.Fatalf("update output mismatch: %s", stdout.String())
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/dispatcher_bootstrap_routing_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_bootstrap_routing_test.go
@@ -16,7 +16,7 @@ import (
 // project pin, so each test runs from an empty working directory where any
 // accidental forwarding would fail with a pin resolution error.
 
-// Verifies the global dispatcher reports dispatcher identity fields in JSON version output.
+// Verifies the global uloop binary reports dispatcher identity fields in JSON version output.
 func TestRunDispatcherVersionJSONReportsDispatcherIdentity(t *testing.T) {
 	t.Chdir(t.TempDir())
 

--- a/cli/dispatcher/internal/dispatcher/dispatcher_process.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_process.go
@@ -22,7 +22,7 @@ func tryHandleProjectScopeHelpRequest(args []string, projectPath string, stdout 
 
 func tryHandleDispatcherInfoRequest(args []string, stdout io.Writer) (bool, int) {
 	if len(args) == 0 || clicore.IsHelpRequest(args) {
-		printLauncherHelp(stdout)
+		printDispatcherHelp(stdout)
 		return true, 0
 	}
 	if clicore.IsVersionJSONRequest(args) {

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -271,7 +271,7 @@ func TestRunDispatcherLaunchOptionsDoNotRequireProjectPin(t *testing.T) {
 }
 
 func TestRunDispatcherVersionUsesDispatcherVersion(t *testing.T) {
-	// Verifies the global dispatcher reports its own dispatcher release version.
+	// Verifies `uloop --version` reports the dispatcher release version instead of the project runner version.
 	t.Chdir(t.TempDir())
 
 	var stdout bytes.Buffer

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -271,7 +271,7 @@ func TestRunDispatcherLaunchOptionsDoNotRequireProjectPin(t *testing.T) {
 }
 
 func TestRunDispatcherVersionUsesDispatcherVersion(t *testing.T) {
-	// Verifies the global launcher reports its own dispatcher release version.
+	// Verifies the global dispatcher reports its own dispatcher release version.
 	t.Chdir(t.TempDir())
 
 	var stdout bytes.Buffer
@@ -469,7 +469,7 @@ func TestEnforceDispatcherFreshnessMarksFailedOptionalUpdateChecked(t *testing.T
 }
 
 func TestEnforceDispatcherFreshnessReportsOptionalUpdateVersionChange(t *testing.T) {
-	// Verifies optional dispatcher self-updates tell users which launcher version will run next.
+	// Verifies optional dispatcher self-updates tell users which dispatcher version will run next.
 	t.Setenv(nativepath.CacheDirEnvName, t.TempDir())
 	deps, restoreDispatcherUpdateHooks := stubDispatcherUpdateHooks(t, "9.9.9")
 	defer restoreDispatcherUpdateHooks()

--- a/cli/dispatcher/internal/dispatcher/dispatcher_update_version.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_update_version.go
@@ -71,20 +71,20 @@ func writeOptionalDispatcherUpdateCompletion(stderr io.Writer, fromVersion strin
 	}
 	clicore.WriteFormat(
 		stderr,
-		"uloop: dispatcher updated from %s to %s. Future uloop commands will use the updated launcher.\n",
+		"uloop: dispatcher updated from %s to %s. Future uloop commands will use the updated dispatcher.\n",
 		normalizedFromVersion,
 		normalizedToVersion)
 }
 
 func writeManualDispatcherUpdateCompletion(stdout io.Writer, fromVersion string, toVersion string) {
 	if toVersion == "" {
-		clicore.WriteLine(stdout, "uloop launcher update completed.")
+		clicore.WriteLine(stdout, "uloop dispatcher update completed.")
 		return
 	}
 	normalizedFromVersion, normalizedToVersion, changed := normalizedDispatcherUpdateVersions(fromVersion, toVersion)
 	if !changed {
-		clicore.WriteLine(stdout, "uloop launcher is already up to date at "+normalizedToVersion+".")
+		clicore.WriteLine(stdout, "uloop dispatcher is already up to date at "+normalizedToVersion+".")
 		return
 	}
-	clicore.WriteLine(stdout, "uloop launcher updated from "+normalizedFromVersion+" to "+normalizedToVersion+".")
+	clicore.WriteLine(stdout, "uloop dispatcher updated from "+normalizedFromVersion+" to "+normalizedToVersion+".")
 }

--- a/cli/dispatcher/internal/dispatcher/help_test.go
+++ b/cli/dispatcher/internal/dispatcher/help_test.go
@@ -13,15 +13,15 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/clitest"
 )
 
-// Tests that launcher help lists native commands and live-tool discovery guidance without baked-in tools.
-func TestPrintLauncherHelpListsNativeCommandsAndLiveToolGuidance(t *testing.T) {
+// Tests that dispatcher help lists native commands and live-tool discovery guidance without baked-in tools.
+func TestPrintDispatcherHelpListsNativeCommandsAndLiveToolGuidance(t *testing.T) {
 	var stdout bytes.Buffer
 
-	printLauncherHelp(&stdout)
+	printDispatcherHelp(&stdout)
 
 	output := stdout.String()
 	for _, expected := range []string{
-		"Dispatcher launcher. Finds the Unity project, then dispatches live Unity tool commands.",
+		"Dispatcher. Finds the Unity project, then dispatches live Unity tool commands.",
 		"Native commands:",
 		"  launch",
 		"  focus-window",

--- a/cli/dispatcher/internal/dispatcher/install.go
+++ b/cli/dispatcher/internal/dispatcher/install.go
@@ -52,7 +52,7 @@ func tryHandleInstallRequest(ctx context.Context, args []string, stdout io.Write
 		return true, 1
 	}
 
-	clicore.WriteLine(stdout, "Configuring global uloop launcher...")
+	clicore.WriteLine(stdout, "Configuring global uloop dispatcher...")
 	command := exec.CommandContext(ctx, installCommand.Name, installCommand.Args...)
 	command.Stdout = stdout
 	var installerStderr bytes.Buffer
@@ -153,7 +153,7 @@ func printInstallHelp(stdout io.Writer) {
 	clicore.WriteLine(stdout, "Usage:")
 	clicore.WriteLine(stdout, "  uloop install [--dir <install-dir>]")
 	clicore.WriteLine(stdout, "")
-	clicore.WriteLine(stdout, "Configures the global uloop launcher after the installer places the binary.")
+	clicore.WriteLine(stdout, "Configures the global uloop dispatcher after the installer places the binary.")
 	clicore.WriteLine(stdout, "Set ULOOP_INSTALL_DIR or pass --dir to choose the install directory.")
 	clicore.WriteLine(stdout, "On Windows, updates User PATH and removes legacy npm uloop-cli launchers.")
 	clicore.WriteLine(stdout, "On macOS, updates shell PATH and removes legacy npm uloop-cli launchers.")

--- a/cli/dispatcher/internal/dispatcher/run_help.go
+++ b/cli/dispatcher/internal/dispatcher/run_help.go
@@ -43,11 +43,11 @@ func printHelpForResolvedProject(stdout io.Writer, explicitProjectPath string) {
 	printMainHelp(stdout, clicontract.ProjectRunnerVersion(), nativeCLIDescription, cache, ok)
 }
 
-func printLauncherHelp(stdout io.Writer) {
+func printDispatcherHelp(stdout io.Writer) {
 	printMainHelp(
 		stdout,
 		dispatcherVersion,
-		"Dispatcher launcher. Finds the Unity project, then dispatches live Unity tool commands.",
+		"Dispatcher. Finds the Unity project, then dispatches live Unity tool commands.",
 		clicore.ToolsCache{},
 		false)
 }

--- a/cli/dispatcher/internal/dispatcher/uninstall.go
+++ b/cli/dispatcher/internal/dispatcher/uninstall.go
@@ -51,7 +51,7 @@ func tryHandleUninstallRequest(ctx context.Context, args []string, stdout io.Wri
 		return true, 1
 	}
 
-	clicore.WriteLine(stdout, "Uninstalling global uloop launcher...")
+	clicore.WriteLine(stdout, "Uninstalling global uloop dispatcher...")
 	command := exec.CommandContext(ctx, uninstallCommand.Name, uninstallCommand.Args...)
 	command.Stdout = stdout
 	command.Stderr = stderr
@@ -72,9 +72,9 @@ func tryHandleUninstallRequest(ctx context.Context, args []string, stdout io.Wri
 	}
 
 	if uninstallCommand.Deferred {
-		clicore.WriteFormat(stdout, "Scheduled uloop launcher removal: %s\n", uninstallCommand.TargetPath)
+		clicore.WriteFormat(stdout, "Scheduled uloop dispatcher removal: %s\n", uninstallCommand.TargetPath)
 	} else {
-		clicore.WriteFormat(stdout, "Removed uloop launcher: %s\n", uninstallCommand.TargetPath)
+		clicore.WriteFormat(stdout, "Removed uloop dispatcher: %s\n", uninstallCommand.TargetPath)
 	}
 	writeUninstallPathCompletion(stdout, runtime.GOOS)
 	return true, 0
@@ -93,7 +93,7 @@ func printUninstallHelp(stdout io.Writer) {
 	clicore.WriteLine(stdout, "Usage:")
 	clicore.WriteLine(stdout, "  uloop uninstall")
 	clicore.WriteLine(stdout, "")
-	clicore.WriteLine(stdout, "Removes the global uloop launcher binary from the install directory.")
+	clicore.WriteLine(stdout, "Removes the global uloop dispatcher binary from the install directory.")
 	clicore.WriteLine(stdout, "Set ULOOP_INSTALL_DIR to uninstall from a custom install directory.")
 	clicore.WriteLine(stdout, "On Windows, also removes the package-owned install directory from User PATH.")
 	clicore.WriteLine(stdout, "On macOS, PATH settings are not changed automatically.")

--- a/cli/dispatcher/internal/dispatcher/update.go
+++ b/cli/dispatcher/internal/dispatcher/update.go
@@ -53,7 +53,7 @@ func tryHandleUpdateRequest(ctx context.Context, args []string, stdout io.Writer
 		return true, 1
 	}
 
-	clicore.WriteLine(stdout, "Updating global uloop launcher...")
+	clicore.WriteLine(stdout, "Updating global uloop dispatcher...")
 	if err := updateRunCommand(ctx, updateCommand, stdout, stderr); err != nil {
 		clierrors.WriteErrorEnvelope(stderr, clierrors.CLIError{
 			ErrorCode:   clierrors.ErrorCodeInternalError,

--- a/cli/dispatcher/internal/dispatcher/update_test.go
+++ b/cli/dispatcher/internal/dispatcher/update_test.go
@@ -324,7 +324,7 @@ func TestUpdateExecutionArgsRunsDownloadedInstallerFile(t *testing.T) {
 }
 
 func TestTryHandleUpdateRequestReportsVersionChange(t *testing.T) {
-	// Verifies manual dispatcher updates tell users which launcher version was installed.
+	// Verifies manual dispatcher updates tell users which dispatcher version was installed.
 	skipWhenNativeUpdateIsUnsupported(t)
 	restoreUpdateHooks := stubManualUpdateHooks(t, "9.9.9")
 	defer restoreUpdateHooks()
@@ -336,7 +336,7 @@ func TestTryHandleUpdateRequestReportsVersionChange(t *testing.T) {
 	if !handled || code != 0 {
 		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
 	}
-	expected := "uloop launcher updated from " + dispatcherVersion + " to 9.9.9."
+	expected := "uloop dispatcher updated from " + dispatcherVersion + " to 9.9.9."
 	if !bytes.Contains(stdout.Bytes(), []byte(expected)) {
 		t.Fatalf("update output mismatch: %s", stdout.String())
 	}
@@ -346,7 +346,7 @@ func TestTryHandleUpdateRequestReportsVersionChange(t *testing.T) {
 }
 
 func TestTryHandleUpdateRequestReportsAlreadyCurrentVersion(t *testing.T) {
-	// Verifies manual dispatcher updates explain when the selected release matches the installed launcher.
+	// Verifies manual dispatcher updates explain when the selected release matches the installed dispatcher.
 	skipWhenNativeUpdateIsUnsupported(t)
 	restoreUpdateHooks := stubManualUpdateHooks(t, dispatcherVersion)
 	defer restoreUpdateHooks()
@@ -358,7 +358,7 @@ func TestTryHandleUpdateRequestReportsAlreadyCurrentVersion(t *testing.T) {
 	if !handled || code != 0 {
 		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
 	}
-	expected := "uloop launcher is already up to date at " + dispatcherVersion + "."
+	expected := "uloop dispatcher is already up to date at " + dispatcherVersion + "."
 	if !bytes.Contains(stdout.Bytes(), []byte(expected)) {
 		t.Fatalf("update output mismatch: %s", stdout.String())
 	}

--- a/cli/dispatcher/internal/install/command_test.go
+++ b/cli/dispatcher/internal/install/command_test.go
@@ -624,7 +624,7 @@ func TestPosixInstallScriptSilencesLegacyFailureWhenLegacyShimRemains(t *testing
 }
 
 func TestPosixInstallScriptSkipsDefaultNpmCleanupForInstallPrefix(t *testing.T) {
-	// Verifies default npm cleanup does not remove the freshly installed native launcher.
+	// Verifies default npm cleanup does not remove the freshly installed native dispatcher.
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX shell setup is not available on Windows")
 	}

--- a/cli/dispatcher/internal/nativepath/path.go
+++ b/cli/dispatcher/internal/nativepath/path.go
@@ -34,7 +34,7 @@ func DefaultEnvironment() Environment {
 	}
 }
 
-// ResolveInstallDir returns the explicit, environment, or OS default launcher directory.
+// ResolveInstallDir returns the explicit, environment, or OS default dispatcher directory.
 func ResolveInstallDir(goos string, explicitInstallDir string, environment Environment) (string, error) {
 	if explicitInstallDir != "" {
 		return explicitInstallDir, nil
@@ -45,7 +45,7 @@ func ResolveInstallDir(goos string, explicitInstallDir string, environment Envir
 	return DefaultInstallDir(goos, environment)
 }
 
-// DefaultInstallDir returns the OS default package-owned launcher directory.
+// DefaultInstallDir returns the OS default package-owned dispatcher directory.
 func DefaultInstallDir(goos string, environment Environment) (string, error) {
 	switch goos {
 	case "darwin":
@@ -96,7 +96,7 @@ func CacheRoot(goos string, environment Environment) (string, error) {
 	}
 }
 
-// CommandPath joins a launcher command name to an install directory using target OS separators.
+// CommandPath joins a dispatcher command name to an install directory using target OS separators.
 func CommandPath(goos string, installDir string, posixCommandName string, windowsCommandName string) string {
 	trimmedInstallDir := TrimInstallDir(goos, installDir)
 	if goos == "windows" {

--- a/cli/dispatcher/internal/uninstall/command_test.go
+++ b/cli/dispatcher/internal/uninstall/command_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCommandForDarwinRemovesUloopFromInstallDirectory(t *testing.T) {
-	// Verifies macOS uninstall removes the launcher binary from the selected install directory.
+	// Verifies macOS uninstall removes the dispatcher binary from the selected install directory.
 	command, err := CommandForOS("darwin", Options{
 		InstallDir: "/Users/ExampleUser/.local/bin",
 		CurrentPID: 1234,
@@ -41,7 +41,7 @@ func TestCommandForDarwinRemovesUloopFromInstallDirectory(t *testing.T) {
 }
 
 func TestCommandForWindowsSchedulesRemovalAfterCurrentProcessExits(t *testing.T) {
-	// Verifies Windows uninstall defers deletion until the running launcher process exits.
+	// Verifies Windows uninstall defers deletion until the running dispatcher process exits.
 	command, err := CommandForOS("windows", Options{
 		InstallDir: `C:\Users\ExampleUser\AppData\Local\Programs\uloop\bin`,
 		CurrentPID: 5678,
@@ -202,8 +202,8 @@ func decodePowerShellCommandForTest(t *testing.T, encodedCommand string) string 
 	return string(utf16.Decode(utf16Values))
 }
 
-func TestCommandForWindowsRemovesUserPathBeforeDeletingLauncher(t *testing.T) {
-	// Verifies Unity does not observe launcher removal before persistent PATH cleanup finishes.
+func TestCommandForWindowsRemovesUserPathBeforeDeletingDispatcher(t *testing.T) {
+	// Verifies Unity does not observe dispatcher removal before persistent PATH cleanup finishes.
 	deletionScript := windowsDeletionScript(
 		`C:\Users\ExampleUser\AppData\Local\Programs\uloop\bin\uloop.exe`,
 		5678)

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "4a146ae2b32c8ea65ce2c81cfb254c825ef856b7"
+  "sharedInputsHash": "417686b615796ec8240c7bb104c4abd43c76dceb"
 }

--- a/cli/project-runner/internal/projectrunner/runner_usage.go
+++ b/cli/project-runner/internal/projectrunner/runner_usage.go
@@ -12,7 +12,7 @@ import (
 // tryHandleRunnerInfoRequest answers the project runner's own identity
 // requests. Version output must stay here because the dispatcher forwards
 // project-scoped version queries to the pinned runner, while help output is
-// kept minimal: the full help UX is owned by the global uloop launcher.
+// kept minimal: the full help UX is owned by the global uloop dispatcher.
 func tryHandleRunnerInfoRequest(args []string, stdout io.Writer) (bool, int) {
 	if len(args) == 0 || clicore.IsHelpRequest(args) {
 		printRunnerUsage(stdout)
@@ -30,12 +30,12 @@ func tryHandleRunnerInfoRequest(args []string, stdout io.Writer) (bool, int) {
 }
 
 // printRunnerUsage keeps direct runner help minimal so the help UX lives in
-// exactly one binary: interactive use always goes through the global launcher.
+// exactly one binary: interactive use always goes through the global dispatcher.
 func printRunnerUsage(stdout io.Writer) {
 	clicore.WriteLine(stdout, "Usage:")
 	clicore.WriteLine(stdout, "  uloop-project-runner <command> [options]")
 	clicore.WriteLine(stdout, "")
-	clicore.WriteLine(stdout, "This binary executes Unity project commands forwarded by the global `uloop` launcher.")
+	clicore.WriteLine(stdout, "This binary executes Unity project commands forwarded by the global `uloop` dispatcher.")
 	clicore.WriteLine(stdout, "Run `uloop --help` for the full command list and command help.")
 }
 
@@ -43,10 +43,10 @@ func dispatcherOwnedCommandError(command string) clierrors.CLIError {
 	return clierrors.CLIError{
 		ErrorCode:   clierrors.ErrorCodeInvalidArgument,
 		Phase:       clierrors.ErrorPhaseArgumentParsing,
-		Message:     "The `" + command + "` command is handled by the global uloop launcher, not by the project runner binary.",
+		Message:     "The `" + command + "` command is handled by the global uloop dispatcher, not by the project runner binary.",
 		Retryable:   false,
 		SafeToRetry: false,
 		Command:     command,
-		NextActions: []string{"Run `uloop " + command + "` so the global uloop launcher handles it."},
+		NextActions: []string{"Run `uloop " + command + "` so the global uloop dispatcher handles it."},
 	}
 }

--- a/cli/project-runner/internal/projectrunner/runner_usage_test.go
+++ b/cli/project-runner/internal/projectrunner/runner_usage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Verifies the project runner refuses dispatcher-owned bootstrap and completion
-// commands and points the caller at the global uloop launcher.
+// commands and points the caller at the global uloop dispatcher.
 func TestRunProjectLocalRejectsDispatcherOwnedCommands(t *testing.T) {
 	t.Chdir(t.TempDir())
 
@@ -28,8 +28,8 @@ func TestRunProjectLocalRejectsDispatcherOwnedCommands(t *testing.T) {
 		if code != 1 {
 			t.Fatalf("%s: expected rejection exit code, got %d stdout=%s", command, code, stdout.String())
 		}
-		if !strings.Contains(stderr.String(), "global uloop launcher") {
-			t.Fatalf("%s: rejection must point at the global uloop launcher: %s", command, stderr.String())
+		if !strings.Contains(stderr.String(), "global uloop dispatcher") {
+			t.Fatalf("%s: rejection must point at the global uloop dispatcher: %s", command, stderr.String())
 		}
 		if !strings.Contains(stderr.String(), command) {
 			t.Fatalf("%s: rejection must name the rejected command: %s", command, stderr.String())
@@ -38,7 +38,7 @@ func TestRunProjectLocalRejectsDispatcherOwnedCommands(t *testing.T) {
 }
 
 // Verifies the project runner keeps its direct help output minimal and defers
-// the full help UX to the global uloop launcher.
+// the full help UX to the global uloop dispatcher.
 func TestRunProjectLocalHelpPrintsRunnerUsage(t *testing.T) {
 	t.Chdir(t.TempDir())
 
@@ -58,13 +58,13 @@ func TestRunProjectLocalHelpPrintsRunnerUsage(t *testing.T) {
 			t.Fatalf("%v: runner usage must name the runner binary: %s", args, stdout.String())
 		}
 		if !strings.Contains(stdout.String(), "uloop --help") {
-			t.Fatalf("%v: runner usage must defer to the launcher help: %s", args, stdout.String())
+			t.Fatalf("%v: runner usage must defer to the dispatcher help: %s", args, stdout.String())
 		}
 	}
 }
 
 // Verifies command-level help requests on the runner print the minimal usage
-// instead of executing the command or duplicating the launcher help UX.
+// instead of executing the command or duplicating the dispatcher help UX.
 func TestRunProjectLocalCommandHelpPrintsRunnerUsage(t *testing.T) {
 	t.Chdir(t.TempDir())
 
@@ -76,7 +76,7 @@ func TestRunProjectLocalCommandHelpPrintsRunnerUsage(t *testing.T) {
 		t.Fatalf("compile --help failed: code=%d stderr=%s", code, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "uloop --help") {
-		t.Fatalf("command help must defer to the launcher help: %s", stdout.String())
+		t.Fatalf("command help must defer to the dispatcher help: %s", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "--force-recompile") {
 		t.Fatalf("command help must not duplicate the full tool help: %s", stdout.String())

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "74b6da6b39dd0b0a13391fd355f14d3a373d7678"
+  "sharedInputsHash": "d40ac2627a8c1782cc77db9c76d45054df44a20e"
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -483,7 +483,7 @@ function Invoke-CompatibilityWindowsInstall {
         [string]$ExpectedUloopPath
     )
 
-    Write-Host "Configuring global uloop launcher..."
+    Write-Host "Configuring global uloop dispatcher..."
     Set-UserPathWithInstallDirectoryFirst -Directory $Directory
     Invoke-AllLegacyNpmPackageRemoval -ExpectedUloopPath $ExpectedUloopPath | Out-Null
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -399,7 +399,7 @@ test_uloop_native_install_supported() {
 invoke_uloop_native_install() {
   uloop_path=$1
 
-  echo "Configuring global uloop launcher..."
+  echo "Configuring global uloop dispatcher..."
   "$uloop_path" install --dir "$INSTALL_DIR"
 }
 


### PR DESCRIPTION
## Summary
- User-facing CLI text now calls the global `uloop` binary a **dispatcher**, matching `docs/glossary.md`
- Avoids confusing that binary with `uloop launch` (Unity Editor launch)

## User Impact
- Before: `uloop update` / install / uninstall / help said "launcher", which is not a glossary term and can be misread as the Unity launch command
- After: those messages say "dispatcher" instead; legacy npm `uloop-cli launchers` cleanup wording is unchanged

## Changes
- Reword dispatcher / project-runner / installer user-facing strings, help, and related comments/tests from `launcher` → `dispatcher`
- Rename `printLauncherHelp` → `printDispatcherHelp` and matching test identifiers
- Refresh `shared-inputs-stamp.json` for both components after touching shared release inputs
- Do **not** change legacy npm launcher cleanup strings, `removeLegacyLaunchers`, `uloop launch`, or unrelated `SKILL.md` / changelog history

## Verification
- `scripts/check-go-cli.sh` — pass
- `scripts/test-install-release-filter.sh` — pass
- `scripts/test-stamp-release-inputs.sh` — pass
- `dist/darwin-arm64/uloop --help` starts with `Dispatcher. Finds the Unity project, ...`
- `uloop install --help` / `uloop uninstall --help` use dispatcher wording; legacy npm launcher lines remain
- `uloop compile` — 0 errors / 0 warnings
- Remaining `launcher` hits are only the intentional exclusions (legacy npm cleanup, `removeLegacyLaunchers`, etc.)

### Known pre-existing test failure (not caused by this PR)
- `NativeCliInstallerTests`: **32 / 33 passed**
- Only failure: `GetInstallCommand_RemoteBootstrapsEmitProgressLinesInStageOrder`
- Same failure reproduces on a clean `origin/v3-beta` tree with this PR's changes stashed
- Root cause: POSIX `ManualCommand` is wrapped via `BuildLoginShellPosixInstallScriptCommand`, which escapes inner single quotes through `QuotePosixShellValue`, so `IndexOf("echo 'Downloading installer script...'")` returns `-1`. Production output is correct; the assertion is wrong. Unrelated to the launcher→dispatcher rename

### Suggested follow-up (out of scope here)
- Fix the **test**, not production strings: assert against the pre-wrap POSIX command, or escape the expected substring with the same `QuotePosixShellValue` rules. Do not change the production `echo` progress text to make the brittle assertion pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

