### PR TITLE
chore: Fail CI on high-confidence C# dead code and remove leftover readiness probes

### DIFF
--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -1,0 +1,45 @@
+name: Dead Code
+
+on:
+  pull_request:
+    branches: [ main, v3-beta ]
+    paths:
+      - 'Packages/src/**/*.cs'
+      - 'tools/UnityCliLoop.DeadCodeScanner/**'
+      - 'tests/UnityCliLoop.DeadCodeScanner.Tests/**'
+      - 'scripts/check-dead-code.sh'
+      - '.github/workflows/dead-code.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dead-code:
+    name: Dead Code Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Test dead code scanner
+        run: dotnet test tests/UnityCliLoop.DeadCodeScanner.Tests/UnityCliLoop.DeadCodeScanner.Tests.csproj --configuration Release
+
+      - name: Scan for dead code
+        run: >
+          scripts/check-dead-code.sh
+          --root .
+          --scope public
+          --include-types true
+          --include-members true
+          --include-locals true
+          --include-test-only true
+          --include-kept false
+          --format table
+          --fail-on high-confidence

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeForegroundWarmupRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeForegroundWarmupRunner.cs
@@ -32,30 +32,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return true;
         }
 
-        internal static async Task<bool> TryRunBackgroundSequenceAsync(
-            IDynamicCodeExecutionRuntime runtime,
-            bool yieldToForegroundRequests,
-            CancellationToken ct)
-        {
-            System.Diagnostics.Debug.Assert(runtime != null, "runtime must not be null");
-
-            // Why: background probes must match the foreground sequence so whichever path succeeds
-            // first marks the same execution shape as ready.
-            foreach (string warmupCode in ExecuteDynamicCodeReadinessProbe.CreateReturnStringProbeCodes())
-            {
-                DynamicCodeExecutionRequest request = CreateRequest(
-                    warmupCode,
-                    yieldToForegroundRequests);
-                (bool entered, ExecutionResult result) = await runtime.TryExecuteIfIdleAsync(request, ct).ConfigureAwait(false);
-                if (!entered || !result.Success)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
         private static DynamicCodeExecutionRequest CreateRequest(
             string code,
             bool yieldToForegroundRequests)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/ExecuteDynamicCodeReadinessProbe.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/ExecuteDynamicCodeReadinessProbe.cs
@@ -4,11 +4,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     // otherwise one path can look ready while the user's first return-string execution is still cold.
     public static class ExecuteDynamicCodeReadinessProbe
     {
-        public static string CreatePrimaryReturnStringProbeCode()
-        {
-            return DynamicCodeForegroundWarmupSnippets.ReturnStringShapes[0];
-        }
-
         public static string[] CreateReturnStringProbeCodes()
         {
             string[] source = DynamicCodeForegroundWarmupSnippets.ReturnStringShapes;

--- a/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
@@ -36,12 +36,5 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             ExecuteDynamicCodeEditorStartup.ResetServerScopedServicesBeforeDomainReload();
         }
-
-        public static string CreateExecuteDynamicCodeReadinessProbeCode()
-        {
-            // Why: composition root can only depend on the bundled-tool facade assembly,
-            // so the dynamic-code assembly keeps ownership of the actual probe source shape.
-            return ExecuteDynamicCodeReadinessProbe.CreatePrimaryReturnStringProbeCode();
-        }
     }
 }

--- a/docs/dead-code-scanner.md
+++ b/docs/dead-code-scanner.md
@@ -17,6 +17,18 @@ For a broader member/local-variable pass, run:
 dotnet run --project tools/UnityCliLoop.DeadCodeScanner -- --scope public --include-types true --include-members true --include-locals true --include-test-only true --include-kept false --format table
 ```
 
+## CI gate
+
+`.github/workflows/dead-code.yml` runs automatically on pull requests that
+touch `Packages/src/**/*.cs`, the scanner itself, its tests, or
+`scripts/check-dead-code.sh`.
+
+The gate uses `--fail-on high-confidence`, so CI fails only for
+`Unused`, `UnusedPrivateMember`, and `UnusedLocal`.
+
+`PublicCandidate` and `TestOnly` do not fail CI. Those findings need
+manual review of non-C# references and cannot be decided mechanically.
+
 ## Interpreting the output
 
 Interpret scanner output conservatively:

--- a/docs/dead-code-scanner.md
+++ b/docs/dead-code-scanner.md
@@ -20,8 +20,8 @@ dotnet run --project tools/UnityCliLoop.DeadCodeScanner -- --scope public --incl
 ## CI gate
 
 `.github/workflows/dead-code.yml` runs automatically on pull requests that
-touch `Packages/src/**/*.cs`, the scanner itself, its tests, or
-`scripts/check-dead-code.sh`.
+target `main` or `v3-beta` and touch `Packages/src/**/*.cs`, the scanner
+itself, its tests, `scripts/check-dead-code.sh`, or the workflow file.
 
 The gate uses `--fail-on high-confidence`, so CI fails only for
 `Unused`, `UnusedPrivateMember`, and `UnusedLocal`.

--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/CommandLineOptionsTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/CommandLineOptionsTests.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using UnityCliLoop.DeadCodeScanner;
+
+namespace UnityCliLoop.DeadCodeScanner.Tests
+{
+    [TestFixture]
+    public sealed class CommandLineOptionsTests
+    {
+        // Verifies that --fail-on high-confidence enables the CI fail flag and --fail-on none leaves it off.
+        [Test]
+        public void Parse_WhenFailOnIsHighConfidenceOrNone_ShouldSetFailOnHighConfidenceFlag()
+        {
+            ScanOptions highConfidenceOptions = CommandLineOptions.Parse(new[]
+            {
+                "--fail-on",
+                "high-confidence"
+            });
+            ScanOptions noneOptions = CommandLineOptions.Parse(new[]
+            {
+                "--fail-on",
+                "none"
+            });
+
+            Assert.That(highConfidenceOptions.FailOnHighConfidence, Is.True);
+            Assert.That(noneOptions.FailOnHighConfidence, Is.False);
+        }
+    }
+}

--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
@@ -107,6 +107,19 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 && issue.FullName.Contains("TestOnlyFactory", StringComparison.Ordinal)), Is.True);
         }
 
+        // Verifies that default-scope unused private findings are treated as high-confidence deletion candidates for the CI gate.
+        [Test]
+        public async Task ScanAsync_WhenUsingDefaultPrivateScope_ShouldReportHighConfidenceDeletionCandidates()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = ScanOptions.Default(_rootPath);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue => issue.IsHighConfidenceDeletionCandidate()), Is.True);
+        }
+
         // Verifies that Unity or reflection entry points can be reported separately when requested.
         [Test]
         public async Task ScanAsync_WhenIncludingKeptSymbols_ShouldReportUnityToolAsKept()


### PR DESCRIPTION
## Summary
- Pull requests that touch package C# (or the scanner itself) now fail CI when high-confidence dead code is introduced.
- Three leftover execute-dynamic-code readiness probe helpers with zero callers are removed.

## User Impact
- Before: the dead-code scanner existed but never ran in CI, so unused C# symbols could land unnoticed.
- After: `Unused` / `UnusedPrivateMember` / `UnusedLocal` findings fail the new Dead Code Gate. `PublicCandidate` and `TestOnly` still require manual review and do not fail CI.

## Changes
- Add `.github/workflows/dead-code.yml` (scanner unit tests + `--fail-on high-confidence` scan; no advisory artifacts).
- Remove:
  - `DynamicCodeForegroundWarmupRunner.TryRunBackgroundSequenceAsync` — never had a caller since introduction.
  - `FirstPartyToolsEditorStartup.CreateExecuteDynamicCodeReadinessProbeCode` — leftover after commit `7e45f1e7` intentionally switched the Editor readiness probe from `execute-dynamic-code` to `get-version` so user-disabled tools cannot block startup. Rewiring the old path would reverse that design; deletion is correct.
  - `ExecuteDynamicCodeReadinessProbe.CreatePrimaryReturnStringProbeCode` — only called by the deleted helper above; removed in the same change.
- Document the CI gate in `docs/dead-code-scanner.md`.

## Out of scope
- Issue #1987 task 1 (`[UnityCliLoopKeep(reason)]`) is intentionally not included. There are no remaining intentional-keep call sites after this cleanup, public API shape cannot be renamed later, and a keep attribute can hide stale symbols instead of forcing review. Follow-up triage of `PublicCandidate` findings will decide whether any keep mechanism is needed.

## Verification
- `scripts/check-dead-code.sh ... --fail-on high-confidence` → exit 0
- Before/after scan counts on `origin/v3-beta`: 244 → 242 (`PublicCandidate` 187 → 185)
- `dotnet test tests/UnityCliLoop.DeadCodeScanner.Tests/...` → Passed 4 / Failed 0
- `cd cli/release-automation && go test ./internal/architecture -run 'TestWorkflowActions|TestPullRequestWorkflow' -count=1` → ok
- `dist/darwin-arm64/uloop compile` → ErrorCount 0, WarningCount 0

Refs #1987


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

