### PR TITLE
fix: Match escaped POSIX progress lines in NativeCliInstallerTests

### DIFF
--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -139,15 +139,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 false,
                 "/bin/zsh");
 
-            AssertProgressLinesInStageOrder(posixCommand.ManualCommand, "echo");
-            AssertProgressLinesInStageOrder(windowsCommand.ManualCommand, "Write-Output");
+            AssertProgressLinesInStageOrder(
+                posixCommand.ManualCommand,
+                message => EscapeInnerPosixSingleQuotes($"echo '{message}'"));
+            AssertProgressLinesInStageOrder(
+                windowsCommand.ManualCommand,
+                message => $"Write-Output '{message}'");
         }
 
-        private static void AssertProgressLinesInStageOrder(string manualCommand, string printCommand)
+        // Why: POSIX ManualCommand is wrapped by BuildLoginShellPosixInstallScriptCommand into
+        // /bin/sh -c '<inner>', which escapes each inner single quote as '"'"'. Expected progress
+        // substrings must apply the same transform or IndexOf will miss the escaped echo lines.
+        private static string EscapeInnerPosixSingleQuotes(string value)
         {
-            int downloadIndex = manualCommand.IndexOf($"{printCommand} 'Downloading installer script...'", System.StringComparison.Ordinal);
-            int verifyIndex = manualCommand.IndexOf($"{printCommand} 'Verifying installer script digest...'", System.StringComparison.Ordinal);
-            int startIndex = manualCommand.IndexOf($"{printCommand} 'Starting install script...'", System.StringComparison.Ordinal);
+            return value.Replace("'", "'\"'\"'");
+        }
+
+        private static void AssertProgressLinesInStageOrder(
+            string manualCommand,
+            System.Func<string, string> buildExpectedProgressLine)
+        {
+            int downloadIndex = manualCommand.IndexOf(
+                buildExpectedProgressLine("Downloading installer script..."),
+                System.StringComparison.Ordinal);
+            int verifyIndex = manualCommand.IndexOf(
+                buildExpectedProgressLine("Verifying installer script digest..."),
+                System.StringComparison.Ordinal);
+            int startIndex = manualCommand.IndexOf(
+                buildExpectedProgressLine("Starting install script..."),
+                System.StringComparison.Ordinal);
 
             Assert.That(downloadIndex, Is.GreaterThanOrEqualTo(0));
             Assert.That(verifyIndex, Is.GreaterThan(downloadIndex));


### PR DESCRIPTION
## Summary
- Fix the flaky EditMode assertion that failed to find POSIX installer progress lines after login-shell quoting.
- Keep production install progress output unchanged so Unity's progress label behavior stays correct.

## User Impact
- Before: `NativeCliInstallerTests.GetInstallCommand_RemoteBootstrapsEmitProgressLinesInStageOrder` failed on clean `v3-beta` even though installer progress output was already correct.
- After: the test matches the escaped POSIX `ManualCommand` form and the suite passes (33/33) without changing user-facing install progress text.

## Changes
- Teach the test helper to build expected progress substrings via a caller-supplied function.
- For POSIX, apply the same `'` → `'"'"'` escape used by login-shell wrapping; Windows keeps `Write-Output '...'`.
- Do not modify `NativeCliCommandBuilder` or any production progress strings.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount 0, WarningCount 0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "NativeCliInstallerTests" --project-path "$(git rev-parse --show-toplevel)"` → Success true, PassedCount 33, FailedCount 0

Fixes #1996


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

