### PR TITLE
fix: Classify Assets asmdef and compiler-pattern symbols accurately

### DIFF
--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
@@ -173,17 +173,27 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
         }
 
         /// <summary>
-        /// Verifies that compiler-bound awaiter members are not reported as PublicCandidate.
+        /// Verifies that compiler-bound awaiter members are kept as KeptByUnityOrReflection
+        /// and are not reported as PublicCandidate.
         /// </summary>
         [Test]
-        public async Task ScanAsync_WhenAwaitPatternMembersHaveNoDirectReferences_ShouldNotReportPublicCandidate()
+        public async Task ScanAsync_WhenAwaitPatternMembersHaveNoDirectReferences_ShouldReportKeptAndNotPublicCandidate()
         {
             DeadCodeScanner scanner = new();
-            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: false);
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: true);
 
             System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
                 await scanner.ScanAsync(options, CancellationToken.None);
 
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("SampleAwaitable.Awaiter.IsCompleted", StringComparison.Ordinal)), Is.True);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("SampleAwaitable.Awaiter.GetResult", StringComparison.Ordinal)), Is.True);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("SampleAwaitable.GetAwaiter", StringComparison.Ordinal)), Is.True);
             Assert.That(issues.Any(issue =>
                 issue.Category == DeadCodeCategory.PublicCandidate
                 && issue.FullName.Contains("SampleAwaitable.Awaiter.IsCompleted", StringComparison.Ordinal)), Is.False);
@@ -196,17 +206,21 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
         }
 
         /// <summary>
-        /// Verifies that the IsExternalInit polyfill type is not reported as PublicCandidate.
+        /// Verifies that the IsExternalInit polyfill type is kept as KeptByUnityOrReflection
+        /// and is not reported as PublicCandidate.
         /// </summary>
         [Test]
-        public async Task ScanAsync_WhenIsExternalInitPolyfillHasNoDirectReferences_ShouldNotReportPublicCandidate()
+        public async Task ScanAsync_WhenIsExternalInitPolyfillHasNoDirectReferences_ShouldReportKeptAndNotPublicCandidate()
         {
             DeadCodeScanner scanner = new();
-            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: false);
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: true);
 
             System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
                 await scanner.ScanAsync(options, CancellationToken.None);
 
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("IsExternalInit", StringComparison.Ordinal)), Is.True);
             Assert.That(issues.Any(issue =>
                 issue.Category == DeadCodeCategory.PublicCandidate
                 && issue.FullName.Contains("IsExternalInit", StringComparison.Ordinal)), Is.False);

--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
@@ -151,12 +151,89 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 && issue.FullName.Contains("UsedProductionApi", StringComparison.Ordinal)), Is.True);
         }
 
+        /// <summary>
+        /// Verifies that an internal production member referenced through InternalsVisibleTo from an
+        /// Assets asmdef is classified as TestOnly instead of PublicCandidate.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenInternalMemberIsReferencedViaAssetsAsmdefInternalsVisibleTo_ShouldReportTestOnly()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: false);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.TestOnly
+                && issue.FullName.Contains("CreateForTesting", StringComparison.Ordinal)), Is.True);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("CreateForTesting", StringComparison.Ordinal)), Is.False);
+        }
+
+        /// <summary>
+        /// Verifies that compiler-bound awaiter members are not reported as PublicCandidate.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenAwaitPatternMembersHaveNoDirectReferences_ShouldNotReportPublicCandidate()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: false);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("SampleAwaitable.Awaiter.IsCompleted", StringComparison.Ordinal)), Is.False);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("SampleAwaitable.Awaiter.GetResult", StringComparison.Ordinal)), Is.False);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("SampleAwaitable.GetAwaiter", StringComparison.Ordinal)), Is.False);
+        }
+
+        /// <summary>
+        /// Verifies that the IsExternalInit polyfill type is not reported as PublicCandidate.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenIsExternalInitPolyfillHasNoDirectReferences_ShouldNotReportPublicCandidate()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: false);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("IsExternalInit", StringComparison.Ordinal)), Is.False);
+        }
+
+        private static ScanOptions CreatePublicScopeOptions(string rootPath, bool includeKept)
+        {
+            return new ScanOptions(
+                rootPath,
+                ScanScope.Public,
+                includeTypes: true,
+                includeMembers: true,
+                includeLocals: false,
+                includeTestOnly: true,
+                includeKept,
+                ReportFormat.Table,
+                failOnHighConfidence: false);
+        }
+
         private static void CreateSampleRepository(string rootPath)
         {
             string packageDirectory = Path.Combine(rootPath, "Packages", "src", "Editor", "Sample");
             string assetsDirectory = Path.Combine(rootPath, "Assets", "Tests");
+            string assetsTestAsmdefDirectory = Path.Combine(assetsDirectory, "Editor");
             Directory.CreateDirectory(packageDirectory);
             Directory.CreateDirectory(assetsDirectory);
+            Directory.CreateDirectory(assetsTestAsmdefDirectory);
 
             WriteFile(
                 Path.Combine(packageDirectory, "Sample.asmdef"),
@@ -178,6 +255,9 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 Path.Combine(packageDirectory, "SampleCode.cs"),
                 """
                 using System;
+                using System.Runtime.CompilerServices;
+
+                [assembly: InternalsVisibleTo("Sample.Tests")]
 
                 namespace Sample
                 {
@@ -227,6 +307,40 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                     public sealed class TestOnlyFactory
                     {
                     }
+
+                    public sealed class InternalVisibleApi
+                    {
+                        internal static int CreateForTesting()
+                        {
+                            return 1;
+                        }
+                    }
+
+                    public struct SampleAwaitable
+                    {
+                        public Awaiter GetAwaiter() => new();
+
+                        public struct Awaiter : INotifyCompletion
+                        {
+                            public bool IsCompleted => true;
+
+                            public void GetResult()
+                            {
+                            }
+
+                            public void OnCompleted(Action continuation)
+                            {
+                                continuation();
+                            }
+                        }
+                    }
+                }
+
+                namespace System.Runtime.CompilerServices
+                {
+                    public sealed class IsExternalInit
+                    {
+                    }
                 }
                 """);
             WriteFile(
@@ -239,6 +353,36 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                         public object Create()
                         {
                             return new Sample.TestOnlyFactory();
+                        }
+                    }
+                }
+                """);
+            WriteFile(
+                Path.Combine(assetsTestAsmdefDirectory, "Sample.Tests.asmdef"),
+                """
+                {
+                  "name": "Sample.Tests",
+                  "references": ["Sample.Editor"],
+                  "includePlatforms": ["Editor"],
+                  "versionDefines": []
+                }
+                """);
+            WriteFile(
+                Path.Combine(assetsTestAsmdefDirectory, "Sample.Tests.asmdef.meta"),
+                """
+                fileFormatVersion: 2
+                guid: 22222222222222222222222222222222
+                """);
+            WriteFile(
+                Path.Combine(assetsTestAsmdefDirectory, "SampleInternalUsage.cs"),
+                """
+                namespace SampleConsumer
+                {
+                    public sealed class SampleInternalUsage
+                    {
+                        public int Create()
+                        {
+                            return Sample.InternalVisibleApi.CreateForTesting();
                         }
                     }
                 }

--- a/tools/UnityCliLoop.DeadCodeScanner/AsmdefWorkspaceBuilder.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/AsmdefWorkspaceBuilder.cs
@@ -28,7 +28,12 @@ namespace UnityCliLoop.DeadCodeScanner
         public WorkspaceBuildResult Build(string rootPath)
         {
             string editorRoot = Path.Combine(rootPath, "Packages", "src", "Editor");
-            IReadOnlyList<AsmdefProjectInfo> asmdefs = LoadAsmdefs(editorRoot);
+            string assetsRoot = Path.Combine(rootPath, "Assets");
+            IReadOnlyList<AsmdefProjectInfo> productionAsmdefs = LoadAsmdefs(editorRoot);
+            IReadOnlyList<AsmdefProjectInfo> assetsAsmdefs = Directory.Exists(assetsRoot)
+                ? LoadAsmdefs(assetsRoot)
+                : Array.Empty<AsmdefProjectInfo>();
+
             Dictionary<string, ProjectId> projectIdsByName = new(StringComparer.Ordinal);
             Dictionary<string, ProjectId> projectIdsByGuid = new(StringComparer.OrdinalIgnoreCase);
             Dictionary<ProjectId, ProjectAnalysisInfo> projectInfoById = new();
@@ -36,8 +41,56 @@ namespace UnityCliLoop.DeadCodeScanner
             Solution solution = workspace.CurrentSolution;
             ImmutableArray<MetadataReference> metadataReferences = CreateMetadataReferences();
 
+            solution = AddAsmdefProjects(
+                solution,
+                productionAsmdefs,
+                isProduction: true,
+                projectIdsByName,
+                projectIdsByGuid,
+                projectInfoById,
+                metadataReferences);
+            ProjectId[] productionProjectIds = projectInfoById
+                .Where(pair => pair.Value.IsProduction)
+                .Select(pair => pair.Key)
+                .ToArray();
+
+            solution = AddAsmdefProjects(
+                solution,
+                assetsAsmdefs,
+                isProduction: false,
+                projectIdsByName,
+                projectIdsByGuid,
+                projectInfoById,
+                metadataReferences);
+
+            AsmdefProjectInfo[] allAsmdefs = productionAsmdefs.Concat(assetsAsmdefs).ToArray();
+            solution = AddAsmdefProjectReferences(solution, allAsmdefs, projectIdsByName, projectIdsByGuid);
+            solution = AddOrphanAssetsProject(
+                assetsRoot,
+                assetsAsmdefs,
+                solution,
+                productionProjectIds,
+                projectInfoById,
+                metadataReferences);
+            return new WorkspaceBuildResult(solution, projectInfoById);
+        }
+
+        private static Solution AddAsmdefProjects(
+            Solution solution,
+            IReadOnlyList<AsmdefProjectInfo> asmdefs,
+            bool isProduction,
+            Dictionary<string, ProjectId> projectIdsByName,
+            Dictionary<string, ProjectId> projectIdsByGuid,
+            Dictionary<ProjectId, ProjectAnalysisInfo> projectInfoById,
+            ImmutableArray<MetadataReference> metadataReferences)
+        {
             foreach (AsmdefProjectInfo asmdef in asmdefs)
             {
+                if (projectIdsByName.ContainsKey(asmdef.Name))
+                {
+                    throw new InvalidOperationException($"Duplicate asmdef assembly name: {asmdef.Name}");
+                }
+
                 ProjectId projectId = ProjectId.CreateNewId(asmdef.Name);
                 projectIdsByName[asmdef.Name] = projectId;
                 string guid = ReadAsmdefGuid(asmdef.DirectoryPath, asmdef.Name);
@@ -57,7 +110,7 @@ namespace UnityCliLoop.DeadCodeScanner
                     metadataReferences: metadataReferences);
 
                 solution = solution.AddProject(projectInfo);
-                projectInfoById[projectId] = new ProjectAnalysisInfo(projectId, isProduction: true);
+                projectInfoById[projectId] = new ProjectAnalysisInfo(projectId, isProduction);
 
                 foreach (string sourceFile in asmdef.SourceFiles)
                 {
@@ -67,14 +120,17 @@ namespace UnityCliLoop.DeadCodeScanner
                 }
             }
 
-            solution = AddAsmdefProjectReferences(solution, asmdefs, projectIdsByName, projectIdsByGuid);
-            solution = AddAssetsProject(rootPath, solution, projectIdsByName.Values.ToArray(), projectInfoById, metadataReferences);
-            return new WorkspaceBuildResult(solution, projectInfoById);
+            return solution;
         }
 
-        private static IReadOnlyList<AsmdefProjectInfo> LoadAsmdefs(string editorRoot)
+        private static IReadOnlyList<AsmdefProjectInfo> LoadAsmdefs(string rootDirectory)
         {
-            string[] asmdefPaths = Directory.GetFiles(editorRoot, "*.asmdef", SearchOption.AllDirectories)
+            if (!Directory.Exists(rootDirectory))
+            {
+                return Array.Empty<AsmdefProjectInfo>();
+            }
+
+            string[] asmdefPaths = Directory.GetFiles(rootDirectory, "*.asmdef", SearchOption.AllDirectories)
                 .OrderBy(path => path, StringComparer.Ordinal)
                 .ToArray();
             List<AsmdefProjectInfo> projects = new();
@@ -85,7 +141,7 @@ namespace UnityCliLoop.DeadCodeScanner
             foreach (string asmdefPath in asmdefPaths)
             {
                 AsmdefJson json = ReadAsmdefJson(asmdefPath);
-                string directoryPath = Path.GetDirectoryName(asmdefPath) ?? editorRoot;
+                string directoryPath = Path.GetDirectoryName(asmdefPath) ?? rootDirectory;
                 string[] sourceFiles = Directory.GetFiles(directoryPath, "*.cs", SearchOption.AllDirectories)
                     .Where(path => IsOwnedByAsmdefDirectory(path, directoryPath, asmdefDirectories))
                     .OrderBy(path => path, StringComparer.Ordinal)
@@ -191,23 +247,29 @@ namespace UnityCliLoop.DeadCodeScanner
             return projectIdsByName.TryGetValue(reference, out ProjectId? namedProjectId) ? namedProjectId : null;
         }
 
-        private static Solution AddAssetsProject(
-            string rootPath,
+        // Why: Unity puts leftover Assets scripts into Assembly-CSharp(-Editor); keep that fallback so
+        // files outside any Assets asmdef still contribute non-production references.
+        private static Solution AddOrphanAssetsProject(
+            string assetsRoot,
+            IReadOnlyList<AsmdefProjectInfo> assetsAsmdefs,
             Solution solution,
             ProjectId[] productionProjectIds,
             Dictionary<ProjectId, ProjectAnalysisInfo> projectInfoById,
             ImmutableArray<MetadataReference> metadataReferences)
         {
-            string assetsRoot = Path.Combine(rootPath, "Assets");
             if (!Directory.Exists(assetsRoot))
             {
                 return solution;
             }
 
-            string[] sourceFiles = Directory.GetFiles(assetsRoot, "*.cs", SearchOption.AllDirectories)
+            HashSet<string> ownedSourceFiles = assetsAsmdefs
+                .SelectMany(asmdef => asmdef.SourceFiles)
+                .ToHashSet(StringComparer.Ordinal);
+            string[] orphanSourceFiles = Directory.GetFiles(assetsRoot, "*.cs", SearchOption.AllDirectories)
+                .Where(path => !ownedSourceFiles.Contains(path))
                 .OrderBy(path => path, StringComparer.Ordinal)
                 .ToArray();
-            if (sourceFiles.Length == 0)
+            if (orphanSourceFiles.Length == 0)
             {
                 return solution;
             }
@@ -230,7 +292,7 @@ namespace UnityCliLoop.DeadCodeScanner
                 solution = solution.AddProjectReference(projectId, new ProjectReference(productionProjectId));
             }
 
-            foreach (string sourceFile in sourceFiles)
+            foreach (string sourceFile in orphanSourceFiles)
             {
                 DocumentId documentId = DocumentId.CreateNewId(projectId, sourceFile);
                 SourceText sourceText = SourceText.From(File.ReadAllText(sourceFile));

--- a/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
@@ -59,12 +59,36 @@ namespace UnityCliLoop.DeadCodeScanner
             "OnValidate"
         };
 
+        private static readonly HashSet<string> AwaiterMemberNames = new(StringComparer.Ordinal)
+        {
+            "IsCompleted",
+            "GetResult",
+            "OnCompleted",
+            "UnsafeOnCompleted"
+        };
+
         public static KeeperDecision Classify(ISymbol symbol)
         {
             string attributeReason = FindKeptAttributeReason(symbol);
             if (!string.IsNullOrEmpty(attributeReason))
             {
                 return KeeperDecision.Keep(attributeReason);
+            }
+
+            // Why: the C# compiler resolves init accessors by this exact type name, so Roslyn
+            // reference search never sees call sites even though deleting the polyfill breaks builds.
+            if (IsCompilerRequiredIsExternalInit(symbol))
+            {
+                return KeeperDecision.Keep(
+                    "Type is the compiler-required IsExternalInit polyfill for init accessors.");
+            }
+
+            // Why: await expressions bind GetAwaiter/IsCompleted/GetResult/OnCompleted by name;
+            // SymbolFinder therefore reports zero references for these members.
+            if (IsCompilerRequiredAwaitPatternMember(symbol))
+            {
+                return KeeperDecision.Keep(
+                    "Member is part of the compiler-bound awaiter pattern.");
             }
 
             if (symbol is INamedTypeSymbol namedType && HasKeptBaseType(namedType))
@@ -96,6 +120,71 @@ namespace UnityCliLoop.DeadCodeScanner
             }
 
             return KeeperDecision.Scan();
+        }
+
+        private static bool IsCompilerRequiredIsExternalInit(ISymbol symbol)
+        {
+            if (symbol is not INamedTypeSymbol typeSymbol)
+            {
+                return false;
+            }
+
+            if (!string.Equals(typeSymbol.Name, "IsExternalInit", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            string containingNamespace = typeSymbol.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+            return string.Equals(
+                containingNamespace,
+                "System.Runtime.CompilerServices",
+                StringComparison.Ordinal);
+        }
+
+        private static bool IsCompilerRequiredAwaitPatternMember(ISymbol symbol)
+        {
+            if (symbol is IMethodSymbol getAwaiterMethod
+                && string.Equals(getAwaiterMethod.Name, "GetAwaiter", StringComparison.Ordinal))
+            {
+                return IsAwaiterType(getAwaiterMethod.ReturnType);
+            }
+
+            if (!AwaiterMemberNames.Contains(symbol.Name) || symbol.ContainingType == null)
+            {
+                return false;
+            }
+
+            return IsAwaiterType(symbol.ContainingType);
+        }
+
+        private static bool IsAwaiterType(ITypeSymbol typeSymbol)
+        {
+            foreach (INamedTypeSymbol interfaceType in typeSymbol.AllInterfaces)
+            {
+                if (!IsCompilerServicesAwaiterInterface(interfaceType))
+                {
+                    continue;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsCompilerServicesAwaiterInterface(INamedTypeSymbol interfaceType)
+        {
+            if (!string.Equals(interfaceType.Name, "INotifyCompletion", StringComparison.Ordinal)
+                && !string.Equals(interfaceType.Name, "ICriticalNotifyCompletion", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            string containingNamespace = interfaceType.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+            return string.Equals(
+                containingNamespace,
+                "System.Runtime.CompilerServices",
+                StringComparison.Ordinal);
         }
 
         private static string FindKeptAttributeReason(ISymbol symbol)

--- a/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
@@ -159,17 +159,7 @@ namespace UnityCliLoop.DeadCodeScanner
 
         private static bool IsAwaiterType(ITypeSymbol typeSymbol)
         {
-            foreach (INamedTypeSymbol interfaceType in typeSymbol.AllInterfaces)
-            {
-                if (!IsCompilerServicesAwaiterInterface(interfaceType))
-                {
-                    continue;
-                }
-
-                return true;
-            }
-
-            return false;
+            return typeSymbol.AllInterfaces.Any(IsCompilerServicesAwaiterInterface);
         }
 
         private static bool IsCompilerServicesAwaiterInterface(INamedTypeSymbol interfaceType)


### PR DESCRIPTION
## Summary

- Load each `Assets/**/*.asmdef` as its own Roslyn project (real assembly names such as `UnityCLILoop.Tests.Editor`) so `InternalsVisibleTo` friend assemblies resolve and test-only internals classify as `TestOnly` instead of `PublicCandidate`.
- Keep orphan `Assets/**/*.cs` files (no owning asmdef) in `Assets.NonProduction` as before.
- Treat compiler-bound awaiter members (`GetAwaiter` / `IsCompleted` / `GetResult` / `OnCompleted` / `UnsafeOnCompleted`) and the `System.Runtime.CompilerServices.IsExternalInit` polyfill as `KeptByUnityOrReflection` by structure, not by allowlist.
- Add scanner regression tests for IVT → `TestOnly`, await pattern, and `IsExternalInit` (positive `KeptByUnityOrReflection` assertions with `includeKept: true`).

## User Impact

Developers and CI reviewing dead-code findings get accurate `PublicCandidate` / `TestOnly` classification for internals used from Assets test assemblies, and no longer see false `PublicCandidate` hits for awaiter / `IsExternalInit` compiler patterns. Runtime Unity/CLI behavior is unchanged.

## Scan counts (same flags as CI gate scan, without `--fail-on`)

| Metric | Before | After |
|---|---:|---:|
| Total issues | 242 | 238 |
| `PublicCandidate` | 185 | 111 |
| `TestOnly` | 57 | 127 |
| bucket1 internal `PublicCandidate` | 76 | 18 |
| bucket2 public (non-ToolContracts) | 95 | 81 |
| bucket3 public ToolContracts | 14 | 12 |

### Regression check (TestOnly → PublicCandidate)

Compared before/after JSON by `FullName`:

- `TestOnly` → `PublicCandidate`: **0**
- `TestOnly` disappeared entirely: **0**
- `PublicCandidate` → `TestOnly` improvements: **69**

No reverse-flow regressions from tightening Assets project references.

## Test plan

- [x] `dotnet test tests/UnityCliLoop.DeadCodeScanner.Tests/UnityCliLoop.DeadCodeScanner.Tests.csproj` — Passed 9 / Failed 0
- [x] `scripts/check-dead-code.sh ... --fail-on high-confidence` — exit 0
- [x] `dist/darwin-arm64/uloop compile` — ErrorCount 0 / WarningCount 0
- [x] `dist/darwin-arm64/uloop run-tests --test-mode EditMode` — 2 failures also reproduce on this branch with the scanner changes stashed; **`NativeCliInstallerTests` / `ToolSkillSynchronizerTests` already fail on `origin/v3-beta` and are unrelated to this PR** (tracked in #2001)
