### PR TITLE
fix: Include Packages/src Runtime asmdefs in dead-code production scan

### DIFF
--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
@@ -173,6 +173,26 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
         }
 
         /// <summary>
+        /// Verifies that Packages/src/Runtime asmdefs are loaded as production and scanned for
+        /// unreferenced public symbols.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenRuntimeAsmdefDefinesUnreferencedPublicType_ShouldReportPublicCandidate()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: false);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.SymbolKind == "type"
+                && issue.FullName.Contains("UnreferencedRuntimeApi", StringComparison.Ordinal)
+                && issue.AssemblyName == "Sample.Runtime"), Is.True);
+        }
+
+        /// <summary>
         /// Verifies that compiler-bound awaiter members are kept as KeptByUnityOrReflection
         /// and are not reported as PublicCandidate.
         /// </summary>
@@ -243,9 +263,11 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
         private static void CreateSampleRepository(string rootPath)
         {
             string packageDirectory = Path.Combine(rootPath, "Packages", "src", "Editor", "Sample");
+            string runtimeDirectory = Path.Combine(rootPath, "Packages", "src", "Runtime", "SampleRuntime");
             string assetsDirectory = Path.Combine(rootPath, "Assets", "Tests");
             string assetsTestAsmdefDirectory = Path.Combine(assetsDirectory, "Editor");
             Directory.CreateDirectory(packageDirectory);
+            Directory.CreateDirectory(runtimeDirectory);
             Directory.CreateDirectory(assetsDirectory);
             Directory.CreateDirectory(assetsTestAsmdefDirectory);
 
@@ -353,6 +375,32 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 namespace System.Runtime.CompilerServices
                 {
                     public sealed class IsExternalInit
+                    {
+                    }
+                }
+                """);
+            WriteFile(
+                Path.Combine(runtimeDirectory, "SampleRuntime.asmdef"),
+                """
+                {
+                  "name": "Sample.Runtime",
+                  "references": [],
+                  "includePlatforms": [],
+                  "versionDefines": []
+                }
+                """);
+            WriteFile(
+                Path.Combine(runtimeDirectory, "SampleRuntime.asmdef.meta"),
+                """
+                fileFormatVersion: 2
+                guid: 33333333333333333333333333333333
+                """);
+            WriteFile(
+                Path.Combine(runtimeDirectory, "RuntimeCode.cs"),
+                """
+                namespace Sample.Runtime
+                {
+                    public sealed class UnreferencedRuntimeApi
                     {
                     }
                 }

--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
@@ -193,6 +193,29 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
         }
 
         /// <summary>
+        /// Verifies that a Runtime internal member referenced from an Editor assembly through
+        /// InternalsVisibleTo is not reported as any finding.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenRuntimeInternalMemberIsReferencedFromEditorViaInternalsVisibleTo_ShouldNotReportFinding()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: false);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.FullName.Contains("RuntimeInternalUsedByEditor", StringComparison.Ordinal)), Is.False);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("RuntimeInternalUsedByEditor", StringComparison.Ordinal)), Is.False);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.TestOnly
+                && issue.FullName.Contains("RuntimeInternalUsedByEditor", StringComparison.Ordinal)), Is.False);
+        }
+
+        /// <summary>
         /// Verifies that compiler-bound awaiter members are kept as KeptByUnityOrReflection
         /// and are not reported as PublicCandidate.
         /// </summary>
@@ -276,7 +299,7 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 """
                 {
                   "name": "Sample.Editor",
-                  "references": [],
+                  "references": ["GUID:33333333333333333333333333333333"],
                   "includePlatforms": ["Editor"],
                   "versionDefines": []
                 }
@@ -320,6 +343,7 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                             usedField++;
                             int unusedLocal = 1;
                             UsedPrivateMethod();
+                            usedField += Sample.Runtime.RuntimeInternalApi.RuntimeInternalUsedByEditor();
                         }
 
                         private void UsedPrivateMethod()
@@ -380,7 +404,7 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 }
                 """);
             WriteFile(
-                Path.Combine(runtimeDirectory, "SampleRuntime.asmdef"),
+                Path.Combine(runtimeDirectory, "Sample.Runtime.asmdef"),
                 """
                 {
                   "name": "Sample.Runtime",
@@ -390,7 +414,7 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 }
                 """);
             WriteFile(
-                Path.Combine(runtimeDirectory, "SampleRuntime.asmdef.meta"),
+                Path.Combine(runtimeDirectory, "Sample.Runtime.asmdef.meta"),
                 """
                 fileFormatVersion: 2
                 guid: 33333333333333333333333333333333
@@ -398,10 +422,22 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
             WriteFile(
                 Path.Combine(runtimeDirectory, "RuntimeCode.cs"),
                 """
+                using System.Runtime.CompilerServices;
+
+                [assembly: InternalsVisibleTo("Sample.Editor")]
+
                 namespace Sample.Runtime
                 {
                     public sealed class UnreferencedRuntimeApi
                     {
+                    }
+
+                    public static class RuntimeInternalApi
+                    {
+                        internal static int RuntimeInternalUsedByEditor()
+                        {
+                            return 1;
+                        }
                     }
                 }
                 """);

--- a/tools/UnityCliLoop.DeadCodeScanner/AsmdefWorkspaceBuilder.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/AsmdefWorkspaceBuilder.cs
@@ -27,9 +27,11 @@ namespace UnityCliLoop.DeadCodeScanner
 
         public WorkspaceBuildResult Build(string rootPath)
         {
-            string editorRoot = Path.Combine(rootPath, "Packages", "src", "Editor");
+            // Why: production code lives under both Editor and Runtime; loading only Editor
+            // drops Runtime asmdefs so IVT/friend references and Runtime finding coverage break.
+            string packageSrcRoot = Path.Combine(rootPath, "Packages", "src");
             string assetsRoot = Path.Combine(rootPath, "Assets");
-            IReadOnlyList<AsmdefProjectInfo> productionAsmdefs = LoadAsmdefs(editorRoot);
+            IReadOnlyList<AsmdefProjectInfo> productionAsmdefs = LoadAsmdefs(packageSrcRoot);
             IReadOnlyList<AsmdefProjectInfo> assetsAsmdefs = Directory.Exists(assetsRoot)
                 ? LoadAsmdefs(assetsRoot)
                 : Array.Empty<AsmdefProjectInfo>();


### PR DESCRIPTION
## Summary

- Expand production asmdef discovery from `Packages/src/Editor` to `Packages/src`, so `UnityCLILoop.Runtime` and `UnityCLILoop.PausePoints.Runtime` are scanned as production projects.
- Editor/Assets asmdefs that reference those Runtime assemblies by GUID can now resolve them (and PausePoints IVT friend names can match).
- Add a regression test that an unreferenced public type under `Packages/src/Runtime` is reported as `PublicCandidate`.

## User Impact

Dead-code review covers Runtime package code and stops missing references that previously failed to bind because Runtime projects were absent from the Roslyn workspace. Runtime Unity/CLI behavior is unchanged.

## Scan counts (post-#2000 → this PR)

| Metric | Before | After |
|---|---:|---:|
| Total issues | 238 | 261 |
| `PublicCandidate` | 111 | 113 |
| `TestOnly` | 127 | 148 |
| high-confidence (`Unused` / `UnusedPrivateMember` / `UnusedLocal`) | 0 | **0** |
| Findings under `Packages/src/Runtime` | 0 | 23 |

### Regression check (TestOnly → PublicCandidate)

- `TestOnly` → `PublicCandidate`: **0**
- `TestOnly` disappeared: **0**

### Runtime reference resolution

- Production findings now use assembly names `UnityCLILoop.Runtime` / `UnityCLILoop.PausePoints.Runtime`.
- Multiple Editor and Assets asmdefs GUID-reference those assemblies; after this change, Runtime symbols referenced only from tests classify as `TestOnly` (IVT/friend edges effective), which matches the TestOnly increase (+21).

## Test plan

- [x] `dotnet test tests/UnityCliLoop.DeadCodeScanner.Tests/...` — Passed 10 / Failed 0
- [x] `scripts/check-dead-code.sh ... --fail-on high-confidence` — exit 0
- [x] `dist/darwin-arm64/uloop compile` — ErrorCount 0 / WarningCount 0
- [ ] Full EditMode suite not re-run; known unrelated failures tracked in #2001


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

