### PR TITLE
chore: Set persist-credentials false on pull-request workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Go
@@ -111,6 +112,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
@@ -163,6 +166,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Validate Unity Package structure
         run: |

--- a/.github/workflows/code-complexity.yml
+++ b/.github/workflows/code-complexity.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
 
     - name: Setup Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
@@ -98,6 +100,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
 
     - name: Setup Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           # Full history is required so the change-detection step can diff the
           # PR head against its base.
           fetch-depth: 0

--- a/cli/release-automation/internal/architecture/github_actions_security_test.go
+++ b/cli/release-automation/internal/architecture/github_actions_security_test.go
@@ -61,6 +61,32 @@ func TestPullRequestWorkflowsDisableSetupGoCache(t *testing.T) {
 	}
 }
 
+// Tests that checkout does not persist GITHUB_TOKEN in pull request workflows.
+func TestPullRequestWorkflowsDisableCredentialPersistence(t *testing.T) {
+	repositoryRoot := findRepositoryRoot(t)
+	violations := []string{}
+	for _, workflowPath := range workflowFilePaths(t, repositoryRoot) {
+		lines := readWorkflowLines(t, workflowPath)
+		if !workflowRunsOnPullRequest(lines) {
+			continue
+		}
+		for lineIndex, line := range lines {
+			actionRef, ok := parseUsesAction(line)
+			if !ok || actionRepository(actionRef) != "actions/checkout" {
+				continue
+			}
+			if stepContains(lines, lineIndex, "persist-credentials: false") {
+				continue
+			}
+			violations = append(violations, workflowViolation(repositoryRoot, workflowPath, lineIndex, actionRef, "set persist-credentials: false for checkout in pull request workflows"))
+		}
+	}
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("pull request checkout credential persistence policy violations:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
 // Tests that pull request workflow cache actions are guarded behind trusted Unity secrets.
 func TestPullRequestWorkflowCacheActionsRequireTrustedUnitySecrets(t *testing.T) {
 	repositoryRoot := findRepositoryRoot(t)

--- a/docs/github-actions-security.md
+++ b/docs/github-actions-security.md
@@ -19,3 +19,10 @@ Use `cache: false` for `actions/setup-go` in workflows triggered by
 
 Unity `actions/cache` steps in pull request workflows must stay behind the Unity
 license secret guard so forked pull requests cannot use those cache entries.
+
+`actions/checkout` steps in workflows triggered by `pull_request` or
+`pull_request_target` must set `persist-credentials: false`. By default checkout
+writes `GITHUB_TOKEN` into the local Git config, so any repository script or test
+that the workflow runs from the pull request branch can read it. Release
+workflows that genuinely push back to the repository are the only place where
+credential persistence is appropriate.


### PR DESCRIPTION
## Summary

- Pull-request CI runs no longer leave `GITHUB_TOKEN` where code from the pull-request branch can read it.
- A new architecture test blocks any future pull-request workflow from reintroducing the leak.

## User Impact

Before: `actions/checkout` defaults to writing `GITHUB_TOKEN` into the local Git config
(`http.<host>.extraheader`). Every pull-request workflow that then executes repository-controlled
code — tests, linters, `go run ./cmd/...`, shell scripts — gave that code a readable path to the
token. `dead-code.yml` was hardened in #1995, but the other pull-request workflows were not.

After: no pull-request workflow persists credentials, so a malicious or compromised change on a
pull-request branch cannot read the workflow token out of Git config. Nothing else changes for
contributors — CI behaves exactly as before.

## Changes

- Set `persist-credentials: false` on every `actions/checkout` step in `build-and-test.yml`,
  `code-complexity.yml`, `security-scan.yml`, `unity-compile-check-and-test-runner.yml`, and
  `pr-title.yml`.
- `pr-title.yml` was not listed in the issue, but it is triggered by `pull_request` and runs
  repository code (`go run ./cmd/check-pr-title`), so it meets the same condition and is fixed here.
- None of these workflows run `git push` / `git fetch` / `git tag` after checkout, so nothing
  depended on the persisted token. `github/codeql-action/*` authenticates through the API token in
  the environment, not through Git config.
- Add `TestPullRequestWorkflowsDisableCredentialPersistence`, mirroring the existing setup-go cache
  and Unity cache guards, so the rule is enforced instead of remembered.
- Document the rule and its rationale in `docs/github-actions-security.md`.

Release workflows that genuinely push back to the repository are deliberately left untouched.

## Verification

Written test-first: the new test initially failed with all 8 offending checkout steps listed, and
passes after the workflow changes.

```bash
cd cli/release-automation
go test ./internal/architecture -run 'TestWorkflowActions|TestPullRequestWorkflow' -count=1   # ok

scripts/check-go-cli.sh   # all modules ok, 0 lint issues

ruby -ryaml -e 'ARGV.each { |p| YAML.load_file(p) }' .github/workflows/*.yml   # 13 files parse
```

The workflows touched here all run on this pull request, so their green status is the end-to-end
check that nothing after checkout depends on the removed credentials.

Closes #1998


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

