### PR TITLE
chore: Remove unreferenced internal PublicCandidate members

### DIFF
--- a/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
@@ -142,16 +142,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
             ServiceValue = service ?? throw new ArgumentNullException(nameof(service));
         }
 
-        internal static void AddToolsChangedHandler(Action handler)
-        {
-            Service.OnToolsChanged += handler;
-        }
-
-        internal static void RemoveToolsChangedHandler(Action handler)
-        {
-            Service.OnToolsChanged -= handler;
-        }
-
         public static UnityCliLoopToolRegistrarService Service
         {
             get

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationApiDetectionRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationApiDetectionRules.cs
@@ -188,32 +188,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             return RegexMatchesCode(source, CurrentToolContractsNamespaceRegex);
         }
 
-        public static bool ContainsLegacyDomainMetadataApi(string source)
-        {
-            Debug.Assert(source != null, "source must not be null");
-
-            return RegexMatchesCode(source, LegacyDomainMetadataRegex) ||
-                ContainsLegacyDomainHelperApiForAssembly(
-                    source,
-                    hasLegacyAssemblySource: ContainsLegacyToolMigrationMarker(source),
-                    legacyAssemblyAliases: Array.Empty<string>());
-        }
-
-        public static bool ContainsLegacyDomainHelperApiForAssembly(
-            string source,
-            bool hasLegacyAssemblySource,
-            string[] legacyAssemblyAliases)
-        {
-            Debug.Assert(source != null, "source must not be null");
-            Debug.Assert(legacyAssemblyAliases != null, "legacyAssemblyAliases must not be null");
-
-            string[] legacyNamespaceAliases = GetCombinedLegacyNamespaceAliases(source, legacyAssemblyAliases);
-            return ContainsLegacyDomainHelperReference(
-                source,
-                hasLegacyAssemblySource,
-                legacyNamespaceAliases);
-        }
-
         public static bool ContainsCurrentDomainMetadataApi(string source)
         {
             Debug.Assert(source != null, "source must not be null");
@@ -324,19 +298,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 canMigrateBareLegacyEditorWindowCaptureUtility,
                 assemblyDeclaredTypeNames,
                 requiresTimeoutArgumentMigration: true);
-        }
-
-        public static bool ContainsCurrentFirstPartyScreenshotApi(string source)
-        {
-            Debug.Assert(source != null, "source must not be null");
-
-            bool hasCurrentFirstPartyToolsNamespaceUsage =
-                RegexMatchesCode(source, CurrentFirstPartyToolsNamespaceRegex);
-            return ContainsCurrentFirstPartyScreenshotApiForAssembly(
-                source,
-                hasCurrentFirstPartyToolsNamespaceUsage,
-                Array.Empty<string>(),
-                Array.Empty<string>());
         }
 
         public static bool ContainsCurrentFirstPartyScreenshotApiForAssembly(

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationDomainDetectionRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationDomainDetectionRules.cs
@@ -158,43 +158,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             return false;
         }
 
-        public static bool ContainsLegacyDomainHelperReference(
-            string source,
-            bool canMigrateBareLegacyDomainHelper,
-            string[] aliases)
-        {
-            Debug.Assert(source != null, "source must not be null");
-            Debug.Assert(aliases != null, "aliases must not be null");
-
-            CodeTextMask codeTextMask = CodeTextMask.Create(source);
-            foreach (TypeReplacementRule rule in DomainTypeReplacementRules)
-            {
-                Regex fullyQualifiedRegex = new(
-                    $@"(?:(?:global::)?{Regex.Escape(LegacyNamespace)}\.){Regex.Escape(rule.LegacyName)}\b",
-                    RegexOptions.Compiled);
-                if (RegexMatchesCode(source, fullyQualifiedRegex))
-                {
-                    return true;
-                }
-
-                foreach (string alias in aliases)
-                {
-                    if (ContainsAliasQualifiedName(source, alias, rule.LegacyName))
-                    {
-                        return true;
-                    }
-                }
-
-                if (canMigrateBareLegacyDomainHelper &&
-                    ContainsLegacyAssemblyScopedTypeName(source, codeTextMask, rule.LegacyName))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         public static bool ContainsCurrentDomainHelperApi(string source)
         {
             Debug.Assert(source != null, "source must not be null");

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/DynamicCompilationHealthMonitor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/DynamicCompilationHealthMonitor.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Threading;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -13,7 +12,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private static readonly object ReportedIssueLock = new();
         private static readonly HashSet<string> ReportedIssues = new(System.StringComparer.Ordinal);
-        private static readonly AsyncLocal<string> ConsoleDiagnosticSource = new();
 
         public static void ReportFastPathUnavailable(
             string editorPath,
@@ -91,11 +89,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string humanNote,
             string aiTodo)
         {
-            string effectiveIssueKey = CreateEffectiveIssueKey(issueKey);
-
             lock (ReportedIssueLock)
             {
-                if (!ReportedIssues.Add(effectiveIssueKey))
+                if (!ReportedIssues.Add(issueKey))
                 {
                     return;
                 }
@@ -116,11 +112,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string message,
             object context)
         {
-            string effectiveIssueKey = CreateEffectiveIssueKey(issueKey);
-
             lock (ReportedIssueLock)
             {
-                if (!ReportedIssues.Add(effectiveIssueKey))
+                if (!ReportedIssues.Add(issueKey))
                 {
                     return;
                 }
@@ -129,75 +123,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             VibeLogger.LogInfo(operation, message, context);
         }
 
-        private static string CreateEffectiveIssueKey(string issueKey)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(issueKey), "issueKey must not be empty");
-
-            if (string.IsNullOrEmpty(ConsoleDiagnosticSource.Value))
-            {
-                return issueKey;
-            }
-
-            return $"{issueKey}::source::{ConsoleDiagnosticSource.Value}";
-        }
-
-        internal static System.IDisposable UseConsoleDiagnosticSource(string source)
-        {
-            if (string.IsNullOrEmpty(source))
-            {
-                return EmptyDisposable.Instance;
-            }
-
-            string previousSource = ConsoleDiagnosticSource.Value;
-            ConsoleDiagnosticSource.Value = source;
-            return new ConsoleDiagnosticSourceScope(previousSource);
-        }
-
         private static string FormatConsoleErrorMessage(string operation, string message, object context)
         {
             Debug.Assert(!string.IsNullOrEmpty(operation), "operation must not be empty");
             Debug.Assert(!string.IsNullOrEmpty(message), "message must not be empty");
 
-            string diagnosticSourceLine = string.IsNullOrEmpty(ConsoleDiagnosticSource.Value)
-                ? string.Empty
-                : $"\ndiagnostic_source: {ConsoleDiagnosticSource.Value}";
-
             if (context == null)
             {
-                return $"[{UnityCliLoopConstants.PROJECT_NAME}] {message}\noperation: {operation}{diagnosticSourceLine}";
+                return $"[{UnityCliLoopConstants.PROJECT_NAME}] {message}\noperation: {operation}";
             }
 
-            return $"[{UnityCliLoopConstants.PROJECT_NAME}] {message}\noperation: {operation}{diagnosticSourceLine}\ncontext: {context}";
-        }
-
-        /// <summary>
-        /// Provides Console Diagnostic Source Scope behavior for Unity CLI Loop.
-        /// </summary>
-        private sealed class ConsoleDiagnosticSourceScope : System.IDisposable
-        {
-            private readonly string _previousSource;
-
-            public ConsoleDiagnosticSourceScope(string previousSource)
-            {
-                _previousSource = previousSource;
-            }
-
-            public void Dispose()
-            {
-                ConsoleDiagnosticSource.Value = _previousSource;
-            }
-        }
-
-        /// <summary>
-        /// Provides Empty Disposable behavior for Unity CLI Loop.
-        /// </summary>
-        private sealed class EmptyDisposable : System.IDisposable
-        {
-            public static readonly EmptyDisposable Instance = new EmptyDisposable();
-
-            public void Dispose()
-            {
-            }
+            return $"[{UnityCliLoopConstants.PROJECT_NAME}] {message}\noperation: {operation}\ncontext: {context}";
         }
 
         internal static void ResetForTests()
@@ -206,8 +142,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 ReportedIssues.Clear();
             }
-
-            ConsoleDiagnosticSource.Value = null;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
@@ -214,11 +214,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             get { return GetRegistry().CommandEntryPointResolver; }
         }
 
-        internal static RegistryDynamicCodeExecutorFactory ExecutorFactory
-        {
-            get { return GetRegistry().ExecutorFactory; }
-        }
-
         internal static IExecuteDynamicCodeUseCase GetExecuteDynamicCodeUseCase()
         {
             return GetRegistry().GetExecuteDynamicCodeUseCase();

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
@@ -265,21 +265,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Shutdown();
         }
 
-        internal static Action<Process, string> SwapCompileRequestSenderForTests(Action<Process, string> sender)
-        {
-            return ServiceValue.SwapCompileRequestSenderForTests(sender);
-        }
-
         internal static Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]>
             SwapWorkerAssemblyCompilerForTests(
                 Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]> compiler)
         {
             return ServiceValue.SwapWorkerAssemblyCompilerForTests(compiler);
-        }
-
-        internal static void SetResponseTimeoutMillisecondsForTests(int timeoutMilliseconds)
-        {
-            ServiceValue.SetResponseTimeoutMillisecondsForTests(timeoutMilliseconds);
         }
 
         private static void Shutdown()

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
@@ -70,16 +70,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        internal void SetResponseTimeoutMillisecondsForTests(int timeoutMilliseconds)
-        {
-            Debug.Assert(timeoutMilliseconds > 0, "timeoutMilliseconds must be positive");
-
-            _coordination.ExecuteWithStateLock(() =>
-            {
-                _responseTimeoutMilliseconds = timeoutMilliseconds;
-            });
-        }
-
         internal bool HasLiveProcessLocked()
         {
             AssertStateLockHeld();
@@ -329,15 +319,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             Func<ProcessStartInfo, Process> previous = _startProcess;
             _startProcess = starter;
-            return previous;
-        }
-
-        internal Action<Process, string> SwapCompileRequestSenderForTests(Action<Process, string> sender)
-        {
-            Debug.Assert(sender != null, "sender must not be null");
-
-            Action<Process, string> previous = _sendCompileRequest;
-            _sendCompileRequest = sender;
             return previous;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
@@ -20,7 +20,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private readonly SharedRoslynCompilerWorkerSessionCoordination _coordination = new();
         private Func<ProcessStartInfo, Process> _startProcess = ProcessStartHelper.TryStart;
-        private Action<Process, string> _sendCompileRequest = SendCompileRequestCore;
         private Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]>
             _compileWorkerAssemblyForTests;
         private Process _workerProcess;
@@ -104,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal void SendCompileRequestLocked(string requestFilePath)
         {
             AssertStateLockHeld();
-            _sendCompileRequest(_workerProcess, requestFilePath);
+            SendCompileRequestCore(_workerProcess, requestFilePath);
         }
 
         internal StreamReader GetOutputReaderLocked()

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs
@@ -17,7 +17,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static volatile bool _resolved;
         private static MethodInfo _cancelTestRunMethod;
         private static MethodInfo _isRunActiveMethod;
-        private static string _resolveLog;
 
         /// <summary>
         /// True when CancelTestRun(string) was resolved.
@@ -94,7 +93,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     TestRunnerApiCancelMethodLookup.Resolve(typeof(TestRunnerApi));
                 _cancelTestRunMethod = cancel;
                 _isRunActiveMethod = isRunActive;
-                _resolveLog = log;
                 _resolved = true;
 
                 if (!string.IsNullOrEmpty(log))

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs
@@ -20,20 +20,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static string _resolveLog;
 
         /// <summary>
-        /// Resets cached lookup state for unit tests.
-        /// </summary>
-        internal static void ResetResolvedStateForTests()
-        {
-            lock (ResolveLock)
-            {
-                _resolved = false;
-                _cancelTestRunMethod = null;
-                _isRunActiveMethod = null;
-                _resolveLog = null;
-            }
-        }
-
-        /// <summary>
         /// True when CancelTestRun(string) was resolved.
         /// </summary>
         internal static bool HasCancelTestRun
@@ -54,15 +40,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 EnsureResolved();
                 return _isRunActiveMethod != null;
-            }
-        }
-
-        internal static string ResolveLogForTests
-        {
-            get
-            {
-                EnsureResolved();
-                return _resolveLog;
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Application/MouseInputState.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Application/MouseInputState.cs
@@ -278,11 +278,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             ServiceValue.ReleaseAllButtons();
         }
-
-        internal static ButtonControl GetButtonControl(Mouse mouse, RuntimeMouseButton button)
-        {
-            return ServiceValue.GetButtonControl(mouse, button);
-        }
     }
 }
 #endif

--- a/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
@@ -140,11 +140,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return Task.Run(() => DetectCliInstallationBlocking(platform, ct), ct);
         }
 
-        internal static string DetectCliVersionBlocking(RuntimePlatform platform, CancellationToken ct)
-        {
-            return DetectCliInstallationBlocking(platform, ct).Version;
-        }
-
         internal static CliInstallationDetection DetectCliInstallationBlocking(RuntimePlatform platform, CancellationToken ct)
         {
             CliInstallationDetection packageOwnedDetection = DetectPackageOwnedCliInstallationBlocking(platform, ct);

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -138,19 +138,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return ThirdPartyToolMigrationApiDetectionRules.ContainsCurrentToolContractsApi(source);
         }
 
-        internal static bool ContainsLegacyDomainMetadataApi(string source)
-        {
-            return ThirdPartyToolMigrationApiDetectionRules.ContainsLegacyDomainMetadataApi(source);
-        }
-
-        internal static bool ContainsLegacyDomainHelperApiForAssembly(
-            string source,
-            bool hasLegacyAssemblySource,
-            string[] legacyAssemblyAliases)
-        {
-            return ThirdPartyToolMigrationApiDetectionRules.ContainsLegacyDomainHelperApiForAssembly(source, hasLegacyAssemblySource, legacyAssemblyAliases);
-        }
-
         internal static bool ContainsCurrentDomainMetadataApi(string source)
         {
             return ThirdPartyToolMigrationApiDetectionRules.ContainsCurrentDomainMetadataApi(source);
@@ -203,11 +190,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string[] assemblyDeclaredTypeNames)
         {
             return ThirdPartyToolMigrationApiDetectionRules.ContainsLegacyEditorWindowCaptureUtilityTimeoutMigrationForAssembly(source, hasLegacyAssemblySource, hasAssemblyScopedCurrentToolContractsUsing, hasAssemblyScopedCurrentFirstPartyToolsUsing, legacyAssemblyAliases, currentFirstPartyToolsAssemblyAliases, assemblyDeclaredTypeNames);
-        }
-
-        internal static bool ContainsCurrentFirstPartyScreenshotApi(string source)
-        {
-            return ThirdPartyToolMigrationApiDetectionRules.ContainsCurrentFirstPartyScreenshotApi(source);
         }
 
         internal static bool ContainsCurrentFirstPartyScreenshotApiForAssembly(

--- a/Packages/src/Editor/Infrastructure/Utils/NodeEnvironmentResolver.cs
+++ b/Packages/src/Editor/Infrastructure/Utils/NodeEnvironmentResolver.cs
@@ -177,8 +177,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return null;
         }
 
-        private const string PATH_START_MARKER = "__PATH_START__";
-        private const string PATH_END_MARKER = "__PATH_END__";
         private const string WHICH_START_MARKER = "__WHICH_START__";
         private const string WHICH_END_MARKER = "__WHICH_END__";
         private const string POSIX_FALLBACK_SHELL_PATH = "/bin/sh";
@@ -186,28 +184,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string DIRECTORY_SERVICE_USERS_PATH_PREFIX = "/Users/";
         private const string DIRECTORY_SERVICE_USER_SHELL_ATTRIBUTE = "UserShell";
         private const string DIRECTORY_SERVICE_USER_SHELL_PREFIX = DIRECTORY_SERVICE_USER_SHELL_ATTRIBUTE + ":";
-
-        // Uses markers to extract PATH value, ignoring any banner/echo output from shell startup files
-        internal static string GetLoginShellPathAtPlatform(RuntimePlatform platform)
-        {
-            if (IsWindowsEditor(platform))
-            {
-                return null;
-            }
-
-            string shell = GetUserShell();
-            ProcessStartInfo startInfo = new()            {
-                FileName = shell,
-                Arguments = "-l -i -c \"echo " + PATH_START_MARKER + "; printenv PATH; echo " + PATH_END_MARKER + "\"",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true
-            };
-
-            string output = ExecuteAndGetOutput(startInfo);
-            return ExtractBetweenMarkers(output, PATH_START_MARKER, PATH_END_MARKER);
-        }
 
         internal static string ExtractBetweenMarkers(string output, string startMarker, string endMarker)
         {

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -176,11 +176,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 || installState == SkillInstallState.Outdated;
         }
 
-        internal static bool HasFiniteSize(Vector2 size)
-        {
-            return ThirdPartyToolMigrationWizardWindowResizer.HasFiniteSize(size);
-        }
-
         internal static bool ShouldReportMigrationProgress(
             long lastReportTimestamp,
             long currentTimestamp,

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
@@ -21,7 +21,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private readonly Foldout _installSpecificTargetFoldout;
         private readonly VisualElement _groupSkillsRow;
         private readonly Toggle _groupSkillsToggle;
-        private readonly Label _groupSkillsLabel;
         private readonly EnumField _skillsTargetField;
         private readonly Button _refreshSkillsStateButton;
         private readonly Button _installSelectedSkillsButton;
@@ -51,7 +50,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _installSpecificTargetFoldout = root.Q<Foldout>("install-specific-target-foldout");
             _groupSkillsRow = root.Q<VisualElement>("group-skills-row");
             _groupSkillsToggle = root.Q<Toggle>("group-skills-toggle");
-            _groupSkillsLabel = root.Q<Label>("group-skills-label");
             _skillsTargetField = root.Q<EnumField>("skills-target-field");
             _installSelectedSkillsButton = root.Q<Button>("install-selected-skills-button");
 
@@ -63,7 +61,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             Debug.Assert(_installSpecificTargetFoldout != null, "install-specific-target-foldout must not be null");
             Debug.Assert(_groupSkillsRow != null, "group-skills-row must not be null");
             Debug.Assert(_groupSkillsToggle != null, "group-skills-toggle must not be null");
-            Debug.Assert(_groupSkillsLabel != null, "group-skills-label must not be null");
             Debug.Assert(_skillsTargetField != null, "skills-target-field must not be null");
             Debug.Assert(_installSelectedSkillsButton != null, "install-selected-skills-button must not be null");
 
@@ -76,7 +73,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 ?? throw new System.ArgumentNullException(nameof(_installSpecificTargetFoldout));
             _ = _groupSkillsRow ?? throw new System.ArgumentNullException(nameof(_groupSkillsRow));
             _ = _groupSkillsToggle ?? throw new System.ArgumentNullException(nameof(_groupSkillsToggle));
-            _ = _groupSkillsLabel ?? throw new System.ArgumentNullException(nameof(_groupSkillsLabel));
             _ = _skillsTargetField ?? throw new System.ArgumentNullException(nameof(_skillsTargetField));
             _ = _installSelectedSkillsButton
                 ?? throw new System.ArgumentNullException(nameof(_installSelectedSkillsButton));

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
@@ -35,10 +35,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal event System.Action<SkillsTarget> OnTargetChanged;
         internal event System.Action<bool> OnGroupSkillsChanged;
 
-        internal Toggle GroupSkillsToggle => _groupSkillsToggle;
-        internal Label GroupSkillsLabel => _groupSkillsLabel;
-        internal VisualElement GroupSkillsRow => _groupSkillsRow;
-
         internal SkillsSetupPanelView(VisualElement panelRoot, Button refreshSkillsStateButton)
         {
             Debug.Assert(panelRoot != null, "panelRoot must not be null");


### PR DESCRIPTION
## Summary

- Delete all 18 remaining `internal` `PublicCandidate` symbols (bucket1 after scanner accuracy fixes).
- Cascade-delete test-only facades / diagnostic-source helpers / Domain forwarders that existed only for those entry points.
- Result: `PublicCandidate` **113 → 95**, `internal` PublicCandidate **18 → 0**, high-confidence **0**.

## User Impact

No intentional product behavior change. Removes unused internal APIs and dead test seams that had zero C# callers after Assets/Runtime asmdef accuracy work.

## Decision table (bucket1)

| Symbol | Decision | Notes |
|---|---|---|
| `SkillsSetupPanelView.GroupSkillsToggle/Label/Row` | Delete | Internal UI shims; UXML binds by element name to fields |
| `SharedRoslynCompilerWorkerHost.SwapCompileRequestSenderForTests` | Delete | Test seam; also removed Session counterpart |
| `SharedRoslynCompilerWorkerHost.SetResponseTimeoutMillisecondsForTests` | Delete | Test seam; also removed Session counterpart; production timeout field kept |
| `TestRunnerApiCancelBridge.ResetResolvedStateForTests` | Delete | Test seam; production resolve cache kept |
| `TestRunnerApiCancelBridge.ResolveLogForTests` | Delete | Test seam; `_resolveLog` still used for warnings |
| `UnityCliLoopToolRegistrar.Add/RemoveToolsChangedHandler` | Delete (pair) | Unused static facades; `ToolSettingsUseCase` talks to service event directly |
| `ThirdPartyToolMigrationRules.ContainsLegacyDomainMetadataApi` | Delete | Unused Rules→Domain forwarder |
| `ThirdPartyToolMigrationRules.ContainsLegacyDomainHelperApiForAssembly` | Delete | Unused Rules→Domain forwarder |
| `ThirdPartyToolMigrationRules.ContainsCurrentFirstPartyScreenshotApi` | Delete | Unused Rules→Domain forwarder; `*ForAssembly` kept (still used) |
| + Domain `ContainsLegacyDomainMetadataApi` / `ContainsLegacyDomainHelperApiForAssembly` / `ContainsCurrentFirstPartyScreenshotApi` / `ContainsLegacyDomainHelperReference` | Delete (cascade) | Orphaned when Rules forwarders removed; catalog/regex still used elsewhere |
| `CliInstallationDetector.DetectCliVersionBlocking` | Delete | Unused `.Version` shim; `DetectCliInstallationBlocking` / Async path kept |
| `DynamicCodeServices.ExecutorFactory` (static) | Delete | Unused static facade; registry instance property still used in production |
| `DynamicCompilationHealthMonitor.UseConsoleDiagnosticSource` | Delete | Unused; removed AsyncLocal + scope helpers that only served it |
| `MouseInputState.GetButtonControl` (static facade) | Delete | Unused static; service instance method + `MouseButtonControlResolver` kept |
| `ThirdPartyToolMigrationWizardWindow.HasFiniteSize` | Delete | Unused Window shim; Resizer implementation kept |
| `NodeEnvironmentResolver.GetLoginShellPathAtPlatform` | Delete | Unused PATH probe; `TryWhichCommand` uses `GetUserShell` directly |

## Test plan

- [x] `scripts/check-dead-code.sh ... --fail-on high-confidence` — exit 0
- [x] Rescan: PublicCandidate 95 / internal 0 / high-confidence 0
- [x] `dist/darwin-arm64/uloop compile` — ErrorCount 0 / WarningCount 0
- [x] `dist/darwin-arm64/uloop run-tests --test-mode EditMode` — FailedCount 2, same known failures as #2001 (`NativeCliInstallerTests` / `ToolSkillSynchronizerTests`); unrelated to this PR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

