### PR TITLE
chore: Remove unreferenced ExecuteDynamicCode PublicCandidate members

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionFacadeTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionFacadeTests.cs
@@ -183,11 +183,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 };
             }
 
-            public ExecutionStatistics GetStatistics()
-            {
-                return new ExecutionStatistics();
-            }
-
             public void Dispose()
             {
                 DisposeCallCount++;

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutorPoolTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutorPoolTests.cs
@@ -130,11 +130,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 });
             }
 
-            public ExecutionStatistics GetStatistics()
-            {
-                return new ExecutionStatistics();
-            }
-
             public void Dispose()
             {
                 DisposeCallCount++;

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/CompilationRequest.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/CompilationRequest.cs
@@ -38,9 +38,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public enum AssemblyLoadingMode
     {
-        /// <summary>Reference only selected assemblies</summary>
-        SelectiveReference,
-        
         /// <summary>Add all assemblies</summary>
         AllAssemblies
     }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/CompilationResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/CompilationResult.cs
@@ -63,12 +63,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         None,
 
         /// <summary>Compilation Error</summary>
-        CompilationError,
-
-        /// <summary>Dynamic Assembly Addition Failed</summary>
-        DynamicAssemblyFailed,
-
-        /// <summary>Using Statement Addition Failed</summary>
-        UsingStatementFailed
+        CompilationError
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
@@ -204,11 +204,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return RegistryValue;
         }
 
-        internal static IDynamicCodeSourcePreparationService SourcePreparationService
-        {
-            get { return GetRegistry().SourcePreparationService; }
-        }
-
         internal static CompiledCommandEntryPointResolver CommandEntryPointResolver
         {
             get { return GetRegistry().CommandEntryPointResolver; }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCompilationTimingFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCompilationTimingFormatter.cs
@@ -7,8 +7,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class DynamicCompilationTimingFormatter
     {
-        private const string CacheHitTimingEntry = "[Perf] CacheHit: true";
-
         public static List<string> CreateCompilationTimings(
             double referenceResolutionMilliseconds,
             double buildMilliseconds,
@@ -27,14 +25,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 timings.Add(backendTimingEntry);
             }
 
-            return timings;
-        }
-
-        public static List<string> CreateCachedCompilationTimings(
-            DynamicCompilationBackendKind backendKind = DynamicCompilationBackendKind.Unknown)
-        {
-            List<string> timings = CreateCompilationTimings(0, 0, 0, backendKind);
-            timings.Add(CacheHitTimingEntry);
             return timings;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
@@ -25,6 +25,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string ErrorMessage { get; set; }
 
         /// <summary>
+        /// Error message alias for ErrorMessage.
+        /// Why keep: documented tool-response JSON field (Skill/SKILL.md); agents and CLI read it.
+        /// </summary>
+        public string Error
+        {
+            get => ErrorMessage;
+            set => ErrorMessage = value;
+        }
+
+        /// <summary>
         /// Code formatted for compilation
         /// (After extracting/moving using statements and applying class/method wrapping)
         /// Allows checking the actual compiled code during debugging

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
@@ -23,14 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         
         /// <summary>Error message (on failure)</summary>
         public string ErrorMessage { get; set; }
-        
-        /// <summary>Error message (alias for ErrorMessage)</summary>
-        public string Error 
-        { 
-            get => ErrorMessage; 
-            set => ErrorMessage = value; 
-        }
-        
+
         /// <summary>
         /// Code formatted for compilation
         /// (After extracting/moving using statements and applying class/method wrapping)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -58,11 +58,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             );
         }
 
-        public void Cancel()
-        {
-            _executionSlot.Cancel();
-        }
-
         public async Task<ExecutionResult> ExecuteAsync(ExecutionContext context)
         {
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunnerExecutionSlot.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunnerExecutionSlot.cs
@@ -39,11 +39,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return true;
         }
 
-        public void Cancel()
-        {
-            _cancellationTokenSource?.Cancel();
-        }
-
         /// <summary>
         /// Ends the execution slot even when undo collapse throws.
         /// Why nested finally: collapse can throw on a torn-down editor; the running flag must clear.

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutor.cs
@@ -16,15 +16,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly IDynamicCompilationService _compiler;
         private readonly ICompiledCommandInvoker _invoker;
         private readonly IDynamicCodeSourcePreparationService _sourcePreparationService;
-        private readonly ExecutionStatistics _statistics;
-        private readonly object _statsLock = new();
-
-        public DynamicCodeExecutor(
-            IDynamicCompilationService compiler,
-            ICompiledCommandInvoker invoker)
-            : this(compiler, invoker, DynamicCodeServices.SourcePreparationService)
-        {
-        }
 
         internal DynamicCodeExecutor(
             IDynamicCompilationService compiler,
@@ -34,7 +25,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _compiler = compiler ?? throw new ArgumentNullException(nameof(compiler));
             _invoker = invoker ?? throw new ArgumentNullException(nameof(invoker));
             _sourcePreparationService = sourcePreparationService ?? throw new ArgumentNullException(nameof(sourcePreparationService));
-            _statistics = new ExecutionStatistics();
         }
 
         public async Task<ExecutionResult> ExecuteCodeAsync(
@@ -103,36 +93,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     compileTotalStopwatch.Elapsed.TotalMilliseconds);
                 AppendCompilationAdvisories(executionResult.Logs, compilationResult.AdvisoryLogs);
 
-                UpdateStatistics(executionResult, totalStopwatch.Elapsed);
                 return executionResult;
             }
             catch (OperationCanceledException)
             {
-                ExecutionResult cancelledResult = CreateCancelledResult(totalStopwatch.Elapsed);
-                UpdateStatistics(cancelledResult, totalStopwatch.Elapsed);
-                return cancelledResult;
+                return CreateCancelledResult(totalStopwatch.Elapsed);
             }
             catch (Exception ex)
             {
                 ExecutionResult failureResult = CreateUnexpectedErrorResult(ex, totalStopwatch.Elapsed);
-                UpdateStatistics(failureResult, totalStopwatch.Elapsed);
                 LogUnexpectedExecutionException(ex, correlationId, totalStopwatch.ElapsedMilliseconds);
                 return failureResult;
-            }
-        }
-
-        public ExecutionStatistics GetStatistics()
-        {
-            lock (_statsLock)
-            {
-                return new ExecutionStatistics
-                {
-                    TotalExecutions = _statistics.TotalExecutions,
-                    SuccessfulExecutions = _statistics.SuccessfulExecutions,
-                    FailedExecutions = _statistics.FailedExecutions,
-                    AverageExecutionTime = _statistics.AverageExecutionTime,
-                    CompilationErrors = _statistics.CompilationErrors
-                };
             }
         }
 
@@ -155,16 +126,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Namespace = DynamicCodeConstants.DEFAULT_NAMESPACE
             };
 
-            CompilationResult result = await _compiler.CompileAsync(request, ct).ConfigureAwait(false);
-            if (!result.Success)
-            {
-                lock (_statsLock)
-                {
-                    _statistics.CompilationErrors++;
-                }
-            }
-
-            return result;
+            return await _compiler.CompileAsync(request, ct).ConfigureAwait(false);
         }
 
         private ExecutionResult TryCreateCompilationFailureResult(
@@ -264,28 +226,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             destination.AddRange(advisoryLogs);
-        }
-
-        private void UpdateStatistics(ExecutionResult result, TimeSpan executionTime)
-        {
-            lock (_statsLock)
-            {
-                _statistics.TotalExecutions++;
-                if (result.Success)
-                {
-                    _statistics.SuccessfulExecutions++;
-                }
-                else
-                {
-                    _statistics.FailedExecutions++;
-                }
-
-                double totalMilliseconds =
-                    _statistics.AverageExecutionTime.TotalMilliseconds * (_statistics.TotalExecutions - 1);
-                totalMilliseconds += executionTime.TotalMilliseconds;
-                _statistics.AverageExecutionTime =
-                    TimeSpan.FromMilliseconds(totalMilliseconds / _statistics.TotalExecutions);
-            }
         }
 
         private static Dictionary<string, object> BuildExecutionParameters(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutorStub.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutorStub.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,13 +10,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class DynamicCodeExecutorStub : IDynamicCodeExecutor
     {
-        private readonly ExecutionStatistics _statistics;
-
-        public DynamicCodeExecutorStub()
-        {
-            _statistics = new ExecutionStatistics();
-        }
-
         /// <summary>Execute code asynchronously (always returns a Roslyn required error)</summary>
         public Task<ExecutionResult> ExecuteCodeAsync(
             string code,
@@ -27,19 +19,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool compileOnly = false)
         {
             return Task.FromResult(CreateCompilationProviderUnavailableResult());
-        }
-
-        /// <summary>Retrieve execution statistics</summary>
-        public ExecutionStatistics GetStatistics()
-        {
-            return new ExecutionStatistics
-            {
-                TotalExecutions = _statistics.TotalExecutions,
-                SuccessfulExecutions = _statistics.SuccessfulExecutions,
-                FailedExecutions = _statistics.FailedExecutions,
-                AverageExecutionTime = _statistics.AverageExecutionTime,
-                CompilationErrors = _statistics.CompilationErrors
-            };
         }
 
         public void Dispose()
@@ -52,8 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 Success = false,
                 ErrorMessage = "COMPILATION_PROVIDER_UNAVAILABLE: No compilation provider is registered. Check initialization.",
-                ExecutionTime = TimeSpan.Zero,
-                Statistics = _statistics
+                ExecutionTime = TimeSpan.Zero
             };
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/IDynamicCodeExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/IDynamicCodeExecutor.cs
@@ -17,28 +17,5 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CancellationToken cancellationToken = default,
             bool compileOnly = false
         );
-
-
-
-        ExecutionStatistics GetStatistics();
-    }
-
-    /// <summary>Execution statistics</summary>
-    public class ExecutionStatistics
-    {
-        /// <summary>Total execution count</summary>
-        public int TotalExecutions { get; set; }
-
-        /// <summary>Successful execution count</summary>
-        public int SuccessfulExecutions { get; set; }
-
-        /// <summary>Failed execution count</summary>
-        public int FailedExecutions { get; set; }
-
-        /// <summary>Average execution time</summary>
-        public TimeSpan AverageExecutionTime { get; set; }
-
-        /// <summary>Compilation error count</summary>
-        public int CompilationErrors { get; set; }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Models/ExecutionResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Models/ExecutionResult.cs
@@ -28,9 +28,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>Logs</summary>
         public List<string> Logs { get; set; } = new();
 
-        /// <summary>Execution Statistics</summary>
-        public ExecutionStatistics Statistics { get; set; }
-
         /// <summary>
         /// Structured compilation errors when compilation failed.
         /// Preserved to enable rich diagnostics formatting at the tool layer.


### PR DESCRIPTION
## Summary

- Triage the 16 `PublicCandidate` symbols in `UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor` (bucket2).
- Delete the 9 members with zero Roslyn / non-C# references, including boy-scout cascades that became write-only after those deletions.
- Keep 7 members: 6 `ShouldSerialize*` methods (Newtonsoft.Json naming convention + contract tests) and `Error` (documented tool-response JSON field in Skill/SKILL.md).

## Decision table

| Symbol | Decision | Reason |
|---|---|---|
| `AssemblyLoadingMode.SelectiveReference` | **Delete** | Unused enum member; `AssemblyMode` is documented as ignored |
| `CompilationFailureReason.DynamicAssemblyFailed` | **Delete** | Never assigned / compared |
| `CompilationFailureReason.UsingStatementFailed` | **Delete** | Never assigned / compared |
| `DynamicCompilationTimingFormatter.CreateCachedCompilationTimings` | **Delete** | Zero callers |
| `ExecuteDynamicCodeResponse.Error` | **Keep** | Documented tool response field (`Skill/SKILL.md:65`); serialized into `uloop execute-dynamic-code` JSON for agents/CLI |
| `ExecuteDynamicCodeResponse.ShouldSerializeTimings` | **Keep** | Newtonsoft.Json convention + `ExecuteDynamicCodeUseCaseTests` serialization contract |
| `ExecuteDynamicCodeResponse.ShouldSerializeEmitTimingsInJsonResponse` | **Keep** | Same |
| `ExecuteDynamicCodeResponse.ShouldSerializeDomainReloadWaitRequired` | **Keep** | Same |
| `ExecuteDynamicCodeResponse.ShouldSerializeNextActions` | **Keep** | Same |
| `ExecuteDynamicCodeResponse.ShouldSerializeEditorPaused` | **Keep** | Same |
| `ExecuteDynamicCodeResponse.ShouldSerializeActivePausePointId` | **Keep** | Same |
| `CommandRunner.Cancel` | **Delete** | Zero callers; cancellation goes through `CancellationToken` |
| `DynamicCodeExecutor(IDynamicCompilationService, ICompiledCommandInvoker)` | **Delete** | Unused public ctor; factory/tests use the 3-arg internal ctor |
| `IDynamicCodeExecutor.GetStatistics` | **Delete** | Zero callers |
| `DynamicCodeExecutor.GetStatistics` | **Delete** | Interface impl only |
| `DynamicCodeExecutorStub.GetStatistics` | **Delete** | Interface impl only |

## Boy-scout / cascade deletions (not in the original 16)

| Leftover | Why removed |
|---|---|
| `CommandRunnerExecutionSlot.Cancel` | Only called from deleted `CommandRunner.Cancel` |
| `CacheHitTimingEntry` | Only used by deleted `CreateCachedCompilationTimings` |
| `DynamicCodeExecutor` stats path (`_statistics`, `_statsLock`, `UpdateStatistics`, compile-error counter) | Only served deleted `GetStatistics` |
| `ExecutionStatistics` type + `ExecutionResult.Statistics` | Became unread after `GetStatistics` removal |
| `DynamicCodeExecutorStub` `_statistics` field | Only fed deleted stats surface |
| `DynamicCodeServices.SourcePreparationService` static wrapper | Only referenced by the deleted 2-arg public ctor |
| Test fakes' `GetStatistics` methods | Required by deleted interface member |

## Counts

| Metric | Before | After |
|---|---|---|
| PublicCandidate total | 95 | 86 |
| ExecuteDynamicCode PublicCandidate | 16 | 7 (`Error` + 6 `ShouldSerialize*`) |
| High-confidence findings | 0 | 0 |

## Test plan

- [x] `scripts/check-dead-code.sh` → no high-confidence candidates
- [x] `uloop compile` → Success, 0 errors / 0 warnings
- [x] `uloop run-tests --filter-type regex --filter-value DynamicCodeToolTests` → 236 passed / 0 failed
- [ ] Advisor final review
