### PR TITLE
chore: Remove unreferenced Domain/Application/Infrastructure/Presentation PublicCandidates

### DIFF
--- a/Packages/src/Editor/Application/CliSetupApplicationService.cs
+++ b/Packages/src/Editor/Application/CliSetupApplicationService.cs
@@ -155,11 +155,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
             return _cliInstallationDetector.IsCliVisibleFromShellAsync(platform, ct);
         }
 
-        public void InvalidateCliCache()
-        {
-            _cliInstallationDetector.InvalidateCache();
-        }
-
         public string GetMinimumRequiredCliVersion()
         {
             // Why: v3 setup installs the global dispatcher and reads the minimum from the package pin JSON
@@ -177,26 +172,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
         public bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform)
         {
             return _nativeCliInstaller.HasPackageOwnedCurrentUserInstall(platform);
-        }
-
-        public bool IsCliVersionLessThan(string leftVersion, string rightVersion)
-        {
-            return CliVersionComparer.IsVersionLessThan(leftVersion, rightVersion);
-        }
-
-        public bool IsCliVersionGreaterThan(string leftVersion, string rightVersion)
-        {
-            return CliVersionComparer.IsVersionGreaterThan(leftVersion, rightVersion);
-        }
-
-        public bool IsCliVersionGreaterThanOrEqual(string leftVersion, string rightVersion)
-        {
-            return CliVersionComparer.IsVersionGreaterThanOrEqual(leftVersion, rightVersion);
-        }
-
-        public bool IsCliVersionEqual(string leftVersion, string rightVersion)
-        {
-            return CliVersionComparer.IsVersionEqual(leftVersion, rightVersion);
         }
 
         public async Task<CliInstallResult> InstallGlobalCliAsync(

--- a/Packages/src/Editor/Application/UnityCliLoopServerApplicationService.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopServerApplicationService.cs
@@ -61,10 +61,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
         void AddServerStateChangedHandler(Action handler);
 
         void RemoveServerStateChangedHandler(Action handler);
-
-        void AddServerStartedHandler(Action handler);
-
-        void RemoveServerStartedHandler(Action handler);
     }
 
     /// <summary>
@@ -234,16 +230,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
         public void RemoveServerStateChangedHandler(Action handler)
         {
             _controller.RemoveServerStateChangedHandler(handler);
-        }
-
-        public void AddServerStartedHandler(Action handler)
-        {
-            _controller.AddServerStartedHandler(handler);
-        }
-
-        public void RemoveServerStartedHandler(Action handler)
-        {
-            _controller.RemoveServerStartedHandler(handler);
         }
     }
 }

--- a/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
@@ -174,20 +174,5 @@ namespace io.github.hatayama.UnityCliLoop.Application
         {
             return Service.IsCustomToolRegistered(toolName);
         }
-
-        public static UnityCliLoopToolRegistry TryGetRegistry()
-        {
-            return Service.TryGetRegistry();
-        }
-
-        public static string GetDebugInfo()
-        {
-            return Service.GetDebugInfo();
-        }
-
-        public static void NotifyToolChanges()
-        {
-            Service.NotifyToolChanges();
-        }
     }
 }

--- a/Packages/src/Editor/Application/UnityCliLoopUIConstants.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopUIConstants.cs
@@ -8,7 +8,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
     {
         // Tool Settings
         public const string TOOL_SETTINGS_MENU_PATH = "Window > Unity CLI Loop > Settings";
-        public const string CLI_COMMAND_REFERENCE_URL = "https://github.com/hatayama/unity-cli-loop#direct-cli-usage-advanced";
         public const string PROJECT_REPOSITORY_URL = "https://github.com/hatayama/unity-cli-loop";
     }
 }

--- a/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
@@ -22,13 +22,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
             _migrationPort = migrationPort ?? throw new ArgumentNullException(nameof(migrationPort));
         }
 
-        public ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            return _migrationPort.PreviewMigration(projectRoot);
-        }
-
         public Task<ThirdPartyToolMigrationPreview> PreviewMigrationAsync(
             string projectRoot,
             IProgress<ThirdPartyToolMigrationProgress> progress,
@@ -53,13 +46,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
             return _migrationPort.HasMigrationTargetsAsync(projectRoot, ct);
-        }
-
-        public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            return _migrationPort.ApplyMigration(projectRoot);
         }
 
         public Task<ThirdPartyToolMigrationResult> ApplyMigrationAsync(

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -32,14 +32,11 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string POSIX_PATH_SEPARATOR = ":";
         public const string WINDOWS_PATH_SEPARATOR = ";";
         public const string DISPATCHER_RELEASE_TAG_PREFIX = "dispatcher-v";
-        public const string BETA_VERSION_MARKER = "-beta.";
         public const string SKILL_DIR_PREFIX = "uloop-";
         public const string TEMPORARY_SKILLS_DIR_NAME = "TemporarySkills~";
         public const string V3_CLI_INVOCATION_MIGRATION_SKILL_NAME = "v3-cli-invocation-migration";
         public const string UNITY_PACKAGES_DIR_NAME = "Packages";
         public const string PACKAGE_SOURCE_DIR_NAME = "src";
-        public const string CLI_LAYOUT_CONTRACT_FILE_NAME = "layout-contract.json";
-        public const string CLI_CONTRACT_FILE_NAME = "contract.json";
         public const string GLOBAL_UNIX_COMMAND_NAME = EXECUTABLE_NAME;
         public const string GLOBAL_WINDOWS_COMMAND_NAME = EXECUTABLE_NAME + ".exe";
     }

--- a/Packages/src/Editor/Domain/IUnityCliLoopEditorSettingsPort.cs
+++ b/Packages/src/Editor/Domain/IUnityCliLoopEditorSettingsPort.cs
@@ -12,10 +12,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         void SaveSettings(UnityCliLoopEditorSettingsData settings);
         void UpdateSettings(Func<UnityCliLoopEditorSettingsData, UnityCliLoopEditorSettingsData> transform);
         string GetLastSeenSetupWizardVersion();
-        void SetLastSeenSetupWizardVersion(string version);
         bool GetSuppressSetupWizardAutoShow();
         void SetSuppressSetupWizardAutoShow(bool suppressAutoShow);
-        void SetShowUnityCliLoopSecuritySetting(bool showUnityCliLoopSecuritySetting);
         void SetShowToolSettings(bool showToolSettings);
         void SetInstallSkillsFlat(bool installSkillsFlat);
     }

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationDomainDetectionRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationDomainDetectionRules.cs
@@ -158,14 +158,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             return false;
         }
 
-        public static bool ContainsCurrentDomainHelperApi(string source)
-        {
-            Debug.Assert(source != null, "source must not be null");
-
-            bool hasCurrentDomainNamespaceUsage = RegexMatchesCode(source, CurrentDomainNamespaceRegex);
-            return ContainsCurrentDomainHelperApiForAssembly(source, hasCurrentDomainNamespaceUsage);
-        }
-
         public static bool ContainsCurrentDomainHelperApiForAssembly(
             string source,
             bool canUseBareCurrentDomainType)

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleCatalog.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleCatalog.cs
@@ -33,7 +33,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string DescriptionAttributeArgumentName = "Description";
         public const string DisplayDevelopmentOnlyAttributeArgumentName = "DisplayDevelopmentOnly";
         public const string RequiredSecuritySettingAttributeArgumentName = "RequiredSecuritySetting";
-        public const string LegacySecuritySettingsTypeName = "SecuritySettings";
         public const string CurrentSecuritySettingTypeName = "UnityCliLoopSecuritySetting";
         public const string LegacyEditorDelayTypeName = "EditorDelay";
         public const string LegacyEditorDelayMethodName = "DelayFrame";

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
@@ -395,16 +395,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             _serverLifecycleRegistry.ServerStateChanged -= handler;
         }
-
-        public void AddServerStartedHandler(Action handler)
-        {
-            _serverLifecycleRegistry.ServerStarted += handler;
-        }
-
-        public void RemoveServerStartedHandler(Action handler)
-        {
-            _serverLifecycleRegistry.ServerStarted -= handler;
-        }
     }
 
 }

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsRepository.cs
@@ -121,14 +121,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return GetSettings().lastSeenSetupWizardVersion ?? string.Empty;
         }
 
-        public void SetLastSeenSetupWizardVersion(string version)
-        {
-            string normalizedVersion = version ?? string.Empty;
-            UnityCliLoopEditorSettingsData settings = GetSettings();
-            UnityCliLoopEditorSettingsData updatedSettings = settings with { lastSeenSetupWizardVersion = normalizedVersion };
-            SaveSettings(updatedSettings);
-        }
-
         public bool GetSuppressSetupWizardAutoShow()
         {
             return GetSettings().suppressSetupWizardAutoShow;
@@ -139,13 +131,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             UnityCliLoopEditorSettingsData settings = GetSettings();
             UnityCliLoopEditorSettingsData updatedSettings = settings with { suppressSetupWizardAutoShow = suppressAutoShow };
             SaveSettings(updatedSettings);
-        }
-
-        public void SetShowUnityCliLoopSecuritySetting(bool showUnityCliLoopSecuritySetting)
-        {
-            UnityCliLoopEditorSettingsData settings = GetSettings();
-            UnityCliLoopEditorSettingsData newSettings = settings with { showUnityCliLoopSecuritySetting = showUnityCliLoopSecuritySetting };
-            SaveSettings(newSettings);
         }
 
         public void SetShowToolSettings(bool showToolSettings)

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallationDetector.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallationDetector.cs
@@ -11,22 +11,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public sealed class SkillInstallationDetector
     {
-        public bool AreSkillsInstalled(string targetDir)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
-
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return AreSkillsInstalledInAnyLayout(projectRoot, targetDir);
-        }
-
-        public bool AreSkillsInstalled(string targetDir, bool groupSkillsUnderUnityCliLoop)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
-
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return AreSkillsInstalledForLayout(projectRoot, targetDir, groupSkillsUnderUnityCliLoop);
-        }
-
         internal bool AreSkillsInstalledInAnyLayout(string projectRoot, string targetDir)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -79,22 +79,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return false;
         }
 
-        public static List<SkillTargetInfo> DetectTargetsForLayout(bool groupSkillsUnderUnityCliLoop)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            return DetectTargetsForLayoutAtProjectRoot(projectRoot, groupSkillsUnderUnityCliLoop);
-        }
-
-        public static List<SkillTargetInfo> DetectTargetsForLayoutFast(bool groupSkillsUnderUnityCliLoop)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            return DetectTargetsForLayoutFastAtProjectRoot(projectRoot, groupSkillsUnderUnityCliLoop);
-        }
-
         internal static List<SkillTargetInfo> DetectTargetsForLayoutAtProjectRoot(
             string projectRoot,
             bool groupSkillsUnderUnityCliLoop)

--- a/Packages/src/Editor/Infrastructure/Utils/NodeEnvironmentResolver.cs
+++ b/Packages/src/Editor/Infrastructure/Utils/NodeEnvironmentResolver.cs
@@ -13,16 +13,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     {
         private const int PROCESS_TIMEOUT_MS = 5000;
 
-        /// <summary>
-        /// Finds an executable path using platform-appropriate resolution.
-        /// On Windows, resolves .cmd shims via 'where' command.
-        /// On Unix, resolves via login shell 'which' command.
-        /// </summary>
-        public static string FindExecutablePath(string executableName)
-        {
-            return FindExecutablePathAtPlatform(executableName, UnityEngine.Application.platform);
-        }
-
         internal static string FindExecutablePathAtPlatform(string executableName, RuntimePlatform platform)
         {
             if (IsWindowsEditor(platform))

--- a/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
+++ b/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
@@ -1,10 +1,9 @@
+using System;
+
 using io.github.hatayama.UnityCliLoop.Application;
-using io.github.hatayama.UnityCliLoop.Domain;
 
 namespace io.github.hatayama.UnityCliLoop.Presentation
 {
-    using System;
-
     public readonly struct SkillsTargetSelection
     {
         public readonly string DisplayName;
@@ -45,6 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             };
         }
 
+        // Why keep: EditMode tests assert this mapping; production UI currently uses Resolve only.
         public static bool IsInstalled(CliSetupData data, SkillsTarget target)
         {
             return target switch
@@ -54,11 +54,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 SkillsTarget.Agents => data.IsAgentsSkillsInstalled,
                 _ => false
             };
-        }
-
-        public static SkillInstallState GetInstallState(CliSetupData data, SkillsTarget target)
-        {
-            return data.SelectedTarget == target ? data.SelectedTargetInstallState : SkillInstallState.Missing;
         }
     }
 }

--- a/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
+++ b/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
@@ -1,9 +1,9 @@
-using System;
-
 using io.github.hatayama.UnityCliLoop.Application;
 
 namespace io.github.hatayama.UnityCliLoop.Presentation
 {
+    using System;
+
     public readonly struct SkillsTargetSelection
     {
         public readonly string DisplayName;
@@ -44,7 +44,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             };
         }
 
-        // Why keep: EditMode tests assert this mapping; production UI currently uses Resolve only.
         public static bool IsInstalled(CliSetupData data, SkillsTarget target)
         {
             return target switch

--- a/Packages/src/Editor/Presentation/UIToolkit/Bindings/ViewDataBinder.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Bindings/ViewDataBinder.cs
@@ -10,54 +10,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     /// </summary>
     public static class ViewDataBinder
     {
-        public static void BindToggle(Toggle toggle, Func<bool> getter, Action<bool> onChanged)
-        {
-            toggle.SetValueWithoutNotify(getter());
-            toggle.RegisterValueChangedCallback(evt => onChanged(evt.newValue));
-        }
-
-        public static void BindIntegerField(IntegerField field, Func<int> getter, Action<int> onChanged)
-        {
-            field.SetValueWithoutNotify(getter());
-            field.RegisterValueChangedCallback(evt => onChanged(evt.newValue));
-        }
-
-        public static void BindEnumField<T>(EnumField field, Func<T> getter, Action<T> onChanged) where T : Enum
-        {
-            field.Init(getter());
-            field.RegisterValueChangedCallback(evt =>
-            {
-                if (evt.newValue is T newValue)
-                {
-                    onChanged(newValue);
-                }
-            });
-        }
-
-        public static void BindFoldout(Foldout foldout, Func<bool> getter, Action<bool> onChanged)
-        {
-            foldout.SetValueWithoutNotify(getter());
-            foldout.RegisterValueChangedCallback(evt => onChanged(evt.newValue));
-        }
-
-        public static void BindButton(Button button, Action onClick)
-        {
-            button.clicked += onClick;
-        }
-
-        public static void BindLabel(Label label, Action<Label> onClick)
-        {
-            label.RegisterCallback<ClickEvent>(evt => onClick(label));
-        }
-
         public static void UpdateToggle(Toggle toggle, bool value)
         {
             toggle.SetValueWithoutNotify(value);
-        }
-
-        public static void UpdateIntegerField(IntegerField field, int value)
-        {
-            field.SetValueWithoutNotify(value);
         }
 
         public static void UpdateEnumField<T>(EnumField field, T value) where T : Enum
@@ -73,24 +28,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         public static void SetVisible(VisualElement element, bool visible)
         {
             element.style.display = visible ? DisplayStyle.Flex : DisplayStyle.None;
-        }
-
-        public static void SetEnabled(VisualElement element, bool enabled)
-        {
-            element.SetEnabled(enabled);
-        }
-
-        public static void AddModifierClass(VisualElement element, string baseClass, string modifier, bool condition)
-        {
-            string modifierClass = $"{baseClass}--{modifier}";
-            if (condition)
-            {
-                element.AddToClassList(modifierClass);
-            }
-            else
-            {
-                element.RemoveFromClassList(modifierClass);
-            }
         }
 
         public static void ToggleClass(VisualElement element, string className, bool condition)

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsModel.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsModel.cs
@@ -71,13 +71,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         }
 
         /// <summary>
-        /// Save current UI state to persistent settings
-        /// </summary>
-        public void SaveToSettings()
-        {
-        }
-
-        /// <summary>
         /// Load state from persistent settings (formerly from SessionState)
         /// </summary>
         public void LoadFromSessionState()
@@ -108,17 +101,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         }
 
         /// <summary>
-        /// Exit post-compile mode
-        /// </summary>
-        public void DisablePostCompileMode()
-        {
-            UpdateRuntimeState(runtime => new RuntimeState(
-                isPostCompileMode: false,
-                needsRepaint: runtime.NeedsRepaint,
-                lastServerRunning: runtime.LastServerRunning));
-        }
-
-        /// <summary>
         /// Mark that UI repaint is needed
         /// </summary>
         public void RequestRepaint()
@@ -141,31 +123,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         }
 
         // UIState-specific update methods with persistence
-
-        /// <summary>
-        /// Update MainScrollPosition setting
-        /// </summary>
-        public void UpdateMainScrollPosition(Vector2 position)
-        {
-            UpdateUIState(ui => new UIState(
-                mainScrollPosition: position,
-                showUnityCliLoopSecuritySetting: ui.ShowUnityCliLoopSecuritySetting,
-                showToolSettings: ui.ShowToolSettings,
-                showConfiguration: ui.ShowConfiguration));
-        }
-
-        /// <summary>
-        /// Update ShowUnityCliLoopSecuritySetting setting with persistence
-        /// </summary>
-        public void UpdateShowUnityCliLoopSecuritySetting(bool show)
-        {
-            UpdateUIState(ui => new UIState(
-                mainScrollPosition: ui.MainScrollPosition,
-                showUnityCliLoopSecuritySetting: show,
-                showToolSettings: ui.ShowToolSettings,
-                showConfiguration: ui.ShowConfiguration));
-            _editorSettingsPort.SetShowUnityCliLoopSecuritySetting(show);
-        }
 
         public void UpdateShowToolSettings(bool show)
         {


### PR DESCRIPTION
## Summary

- Triage 44 `PublicCandidate` symbols in Domain / Application / Infrastructure / Presentation (bucket2 core).
- Delete 39 members with zero production refs after Skill / `cli/` / JSON-wire checks.
- Keep 5 `*.type` properties on `JsonRpcErrorData` subclasses: serialized into JSON-RPC `error.data` and classified by the Go CLI.

## Decision table — Keep (5)

| Symbol | Reason |
|---|---|
| `JsonRpcErrorData.type` | Abstract JSON-RPC error discriminator; Newtonsoft serializes into `error.data` |
| `InternalErrorData.type` | Override → `internal_error`; Go reads `data["type"]` |
| `SecurityBlockedErrorData.type` | Override → `security_blocked` |
| `ServerBusyErrorData.type` | Override → `server_busy` |
| `CliUpdateRequiredErrorData.type` | Override → `cli_update_required` |

## Decision table — Delete (39)

| Assembly | Symbol | Reason |
|---|---|---|
| Application | `CliSetupApplicationService.InvalidateCliCache` | Zero callers (detector `InvalidateCache` still used elsewhere) |
| Application | `CliSetupApplicationService.IsCliVersionLessThan/GreaterThan/GreaterThanOrEqual/Equal` | Thin unused wrappers over `CliVersionComparer` |
| Application | `UnityCliLoopServerApplicationService.Add/RemoveServerStartedHandler` | Zero callers |
| Application | `UnityCliLoopToolRegistrar.TryGetRegistry/GetDebugInfo/NotifyToolChanges` (static) | Dead Application facade; public extension API lives in ToolContracts |
| Application | `UnityCliLoopUIConstants.CLI_COMMAND_REFERENCE_URL` | Unused; UI opens `PROJECT_REPOSITORY_URL` |
| Application | `ThirdPartyToolMigrationUseCase.PreviewMigration/ApplyMigration` (sync) | Callers use Async variants |
| Domain | `CliConstants.BETA_VERSION_MARKER` | Unused C# constant (install scripts use their own literals) |
| Domain | `CliConstants.CLI_LAYOUT_CONTRACT_FILE_NAME` / `CLI_CONTRACT_FILE_NAME` | Unused C# constants |
| Domain | `IUnityCliLoopEditorSettingsPort.SetLastSeenSetupWizardVersion` | Zero callers; wizard uses `UpdateSettings` |
| Domain | `ThirdPartyToolMigrationDomainDetectionRules.ContainsCurrentDomainHelperApi` | Unused wrapper; `…ForAssembly` remains |
| Domain | `ThirdPartyToolMigrationRuleCatalog.LegacySecuritySettingsTypeName` | Unused; rules hard-code the string |
| Infrastructure | `UnityCliLoopEditorSettingsRepository.SetLastSeenSetupWizardVersion` | Orphan port impl |
| Infrastructure | `SkillInstallationDetector.AreSkillsInstalled` (both overloads) | Zero production callers; tests use internal layout helpers |
| Infrastructure | `ToolSkillSynchronizer.DetectTargetsForLayout/Fast` | Unused wrappers; `…AtProjectRoot` remains |
| Infrastructure | `NodeEnvironmentResolver.FindExecutablePath` | Unused wrapper; `…AtPlatform` remains |
| Presentation | `SkillsTargetSelectionResolver.GetInstallState` | Zero callers |
| Presentation | `ViewDataBinder.Bind*` / `UpdateIntegerField` / `SetEnabled` / `AddModifierClass` | Zero callers; `SetVisible` / `ToggleClass` / `UpdateToggle|Enum|Foldout` remain |
| Presentation | `UnityCliLoopSettingsModel.SaveToSettings` | Empty unused stub |
| Presentation | `UnityCliLoopSettingsModel.DisablePostCompileMode` | Zero callers (`EnablePostCompileMode` remains) |
| Presentation | `UnityCliLoopSettingsModel.UpdateMainScrollPosition` / `UpdateShowUnityCliLoopSecuritySetting` | Zero callers |

## Boy-scout / cascade deletions

| Leftover | Why removed |
|---|---|
| `UnityCliLoopServerController.Add/RemoveServerStartedHandler` | Only called from deleted Application wrappers |
| `IUnityCliLoopEditorSettingsPort.SetShowUnityCliLoopSecuritySetting` + repository setter | Only called from deleted `UpdateShowUnityCliLoopSecuritySetting` |

## Counts

| Metric | Before | After |
|---|---|---|
| PublicCandidate total | 86 | 47 |
| Core (D/A/I/P) PublicCandidate | 44 | 5 (all `ErrorData.type`) |
| High-confidence findings | 0 | 0 |

## Test plan

- [x] `scripts/check-dead-code.sh` → no high-confidence candidates
- [x] `uloop compile` → Success, 0 errors / 0 warnings
- [x] Focused EditMode regex (`SkillsTargetSelectionResolverTests|UnityCliLoopSettings|CliSetup|JsonRpcError|ServerBusy|SkillInstall`) → 160 passed / 0 failed
- [ ] Advisor final review


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

