### PR TITLE
chore: Remove unreferenced FirstPartyTools and Runtime PublicCandidates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ Comments in the code, commit messages, PR titles, and PR descriptions must all b
 
 Every test method must have a short comment that states what behavior the test verifies.
 
+Do not reformat unrelated code. Surgical edits must keep existing wrapping and layout; only
+change lines required by the task. Do not run C# formatters, IDE format-on-save, or rewrite
+scripts that collapse multi-line argument lists or object initializers into one-liners.
+
 ## CLI / Unity Package Compatibility
 
 Runtime compatibility between the Unity package and the native CLI is gated on an integer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,10 +35,6 @@ Comments in the code, commit messages, PR titles, and PR descriptions must all b
 
 Every test method must have a short comment that states what behavior the test verifies.
 
-Do not reformat unrelated code. Surgical edits must keep existing wrapping and layout; only
-change lines required by the task. Do not run C# formatters, IDE format-on-save, or rewrite
-scripts that collapse multi-line argument lists or object initializers into one-liners.
-
 ## CLI / Unity Package Compatibility
 
 Runtime compatibility between the Unity package and the native CLI is gated on an integer

--- a/Assets/Tests/Editor/MouseUiMainThreadCleanupSchedulerTests.cs
+++ b/Assets/Tests/Editor/MouseUiMainThreadCleanupSchedulerTests.cs
@@ -43,7 +43,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 MouseAction.Click,
                 new Vector2(10f, 20f),
                 null,
-                "Target",
                 new Vector2(100f, 200f));
             MouseUiMainThreadCleanupScheduler scheduler = new();
             scheduler.CaptureMainThreadContext();

--- a/Packages/src/Editor/FirstPartyTools/ClearConsole/ClearConsoleResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ClearConsole/ClearConsoleResponse.cs
@@ -41,28 +41,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Message = message ?? string.Empty;
             ErrorMessage = string.Empty;
         }
-
-        /// <summary>
-        /// Create a new ClearConsoleResponse for failed operation
-        /// </summary>
-        public ClearConsoleResponse(string errorMessage)
-        {
-            Success = false;
-            ClearedLogCount = 0;
-            ClearedCounts = new ClearedLogCounts();
-            Message = string.Empty;
-            ErrorMessage = errorMessage ?? string.Empty;
-        }
-
-        /// <summary>
-        /// Parameterless constructor for JSON deserialization
-        /// </summary>
-        public ClearConsoleResponse()
-        {
-            ClearedCounts = new ClearedLogCounts();
-            Message = string.Empty;
-            ErrorMessage = string.Empty;
-        }
     }
 
     /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecorder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecorder.cs
@@ -234,11 +234,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ServiceValue.NotifyRecordingStopped();
         }
 
-        public static void ForceStop()
-        {
-            ServiceValue.ForceStop();
-        }
-
         internal static string FormatVector2(Vector2 v)
         {
             return InputRecordingVectorFormat.FormatVector2(v);

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayUiController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayUiController.cs
@@ -80,11 +80,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _pressTime = Time.realtimeSinceStartup;
                 OnUiPointerDown(replayFrame.ScreenPosition, replayFrame.EventSystem);
                 SimulateMouseUiOverlayState.Update(
-                    MouseAction.Click,
-                    replayFrame.InputPosition,
-                    null,
-                    _currentPressTarget?.name,
-                    replayFrame.GameViewSize);
+                    MouseAction.Click, replayFrame.InputPosition, null, replayFrame.GameViewSize);
                 SimulateMouseUiOverlayState.RequestExpandAnimation();
                 return;
             }
@@ -101,11 +97,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // from being cancelled by the next idle frame at the same position.
                 _suppressIdleUiOverlay = false;
                 SimulateMouseUiOverlayState.Update(
-                    MouseAction.Click,
-                    replayFrame.InputPosition,
-                    null,
-                    null,
-                    replayFrame.GameViewSize);
+                    MouseAction.Click, replayFrame.InputPosition, null, replayFrame.GameViewSize);
             }
         }
 
@@ -116,14 +108,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (_isDragging)
             {
                 Vector2 pressInputPos = new(
-                    _pressScreenPosition.x,
-                    replayFrame.GameViewSize.y - _pressScreenPosition.y);
+                    _pressScreenPosition.x, replayFrame.GameViewSize.y - _pressScreenPosition.y);
                 SimulateMouseUiOverlayState.Update(
-                    MouseAction.Drag,
-                    replayFrame.InputPosition,
-                    pressInputPos,
-                    null,
-                    replayFrame.GameViewSize);
+                    MouseAction.Drag, replayFrame.InputPosition, pressInputPos, replayFrame.GameViewSize);
                 return;
             }
 
@@ -134,11 +121,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             SimulateMouseUiOverlayState.Update(
-                MouseAction.LongPress,
-                replayFrame.InputPosition,
-                null,
-                _currentPressTarget?.name,
-                replayFrame.GameViewSize);
+                MouseAction.LongPress, replayFrame.InputPosition, null, replayFrame.GameViewSize);
             SimulateMouseUiOverlayState.UpdateLongPressElapsed(elapsed);
         }
 
@@ -183,14 +166,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Vector2 inputPos = new(screenPos.x, gameViewSize.y - screenPos.y);
 
             return new UiReplayFrame(
-                eventSystem,
-                screenPos,
-                inputPos,
-                gameViewSize,
-                leftHeld,
-                justPressed,
-                justReleased,
-                mouseMoved);
+                eventSystem, screenPos, inputPos, gameViewSize, leftHeld, justPressed, justReleased, mouseMoved);
         }
 
         private void OnUiPointerDown(Vector2 screenPos, EventSystem eventSystem)
@@ -199,9 +175,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             _pointerData = new PointerEventData(eventSystem)
             {
-                position = screenPos,
-                pressPosition = screenPos,
-                button = PointerEventData.InputButton.Left
+                position = screenPos, pressPosition = screenPos, button = PointerEventData.InputButton.Left
             };
             _pressScreenPosition = screenPos;
             _isDragging = false;
@@ -348,14 +322,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly struct UiReplayFrame
         {
             public UiReplayFrame(
-                EventSystem eventSystem,
-                Vector2 screenPosition,
-                Vector2 inputPosition,
-                Vector2 gameViewSize,
-                bool leftHeld,
-                bool justPressed,
-                bool justReleased,
-                bool mouseMoved)
+                EventSystem eventSystem, Vector2 screenPosition, Vector2 inputPosition, Vector2 gameViewSize, bool leftHeld, bool justPressed, bool justReleased, bool mouseMoved)
             {
                 EventSystem = eventSystem;
                 ScreenPosition = screenPosition;

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayUiController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayUiController.cs
@@ -80,7 +80,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _pressTime = Time.realtimeSinceStartup;
                 OnUiPointerDown(replayFrame.ScreenPosition, replayFrame.EventSystem);
                 SimulateMouseUiOverlayState.Update(
-                    MouseAction.Click, replayFrame.InputPosition, null, replayFrame.GameViewSize);
+                    MouseAction.Click,
+                    replayFrame.InputPosition,
+                    null,
+                    replayFrame.GameViewSize);
                 SimulateMouseUiOverlayState.RequestExpandAnimation();
                 return;
             }
@@ -97,7 +100,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // from being cancelled by the next idle frame at the same position.
                 _suppressIdleUiOverlay = false;
                 SimulateMouseUiOverlayState.Update(
-                    MouseAction.Click, replayFrame.InputPosition, null, replayFrame.GameViewSize);
+                    MouseAction.Click,
+                    replayFrame.InputPosition,
+                    null,
+                    replayFrame.GameViewSize);
             }
         }
 
@@ -108,9 +114,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (_isDragging)
             {
                 Vector2 pressInputPos = new(
-                    _pressScreenPosition.x, replayFrame.GameViewSize.y - _pressScreenPosition.y);
+                    _pressScreenPosition.x,
+                    replayFrame.GameViewSize.y - _pressScreenPosition.y);
                 SimulateMouseUiOverlayState.Update(
-                    MouseAction.Drag, replayFrame.InputPosition, pressInputPos, replayFrame.GameViewSize);
+                    MouseAction.Drag,
+                    replayFrame.InputPosition,
+                    pressInputPos,
+                    replayFrame.GameViewSize);
                 return;
             }
 
@@ -121,7 +131,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             SimulateMouseUiOverlayState.Update(
-                MouseAction.LongPress, replayFrame.InputPosition, null, replayFrame.GameViewSize);
+                MouseAction.LongPress,
+                replayFrame.InputPosition,
+                null,
+                replayFrame.GameViewSize);
             SimulateMouseUiOverlayState.UpdateLongPressElapsed(elapsed);
         }
 
@@ -166,7 +179,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Vector2 inputPos = new(screenPos.x, gameViewSize.y - screenPos.y);
 
             return new UiReplayFrame(
-                eventSystem, screenPos, inputPos, gameViewSize, leftHeld, justPressed, justReleased, mouseMoved);
+                eventSystem,
+                screenPos,
+                inputPos,
+                gameViewSize,
+                leftHeld,
+                justPressed,
+                justReleased,
+                mouseMoved);
         }
 
         private void OnUiPointerDown(Vector2 screenPos, EventSystem eventSystem)
@@ -175,7 +195,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             _pointerData = new PointerEventData(eventSystem)
             {
-                position = screenPos, pressPosition = screenPos, button = PointerEventData.InputButton.Left
+                position = screenPos,
+                pressPosition = screenPos,
+                button = PointerEventData.InputButton.Left
             };
             _pressScreenPosition = screenPos;
             _isDragging = false;
@@ -322,7 +344,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly struct UiReplayFrame
         {
             public UiReplayFrame(
-                EventSystem eventSystem, Vector2 screenPosition, Vector2 inputPosition, Vector2 gameViewSize, bool leftHeld, bool justPressed, bool justReleased, bool mouseMoved)
+                EventSystem eventSystem,
+                Vector2 screenPosition,
+                Vector2 inputPosition,
+                Vector2 gameViewSize,
+                bool leftHeld,
+                bool justPressed,
+                bool justReleased,
+                bool mouseMoved)
             {
                 EventSystem = eventSystem;
                 ScreenPosition = screenPosition;

--- a/Packages/src/Editor/FirstPartyTools/Common/MouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/MouseUi/UiRaycastHelper.cs
@@ -18,14 +18,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return context.Raycast(screenPosition);
         }
 
-        // Bypass EventSystem's Screen-bounds clipping by directly testing Graphic rects in Canvas space.
-        // Only supports ScreenSpaceOverlay canvases where world positions equal Canvas-space positions.
-        public static RaycastResult? RaycastCanvasSpace(Vector2 canvasPosition)
-        {
-            List<CanvasRaycastSource> canvasRaycastSources = CollectCanvasRaycastSources();
-            return RaycastCanvasSpaceFromSources(canvasPosition, canvasRaycastSources);
-        }
-
         private static List<CanvasRaycastSource> CollectCanvasRaycastSources()
         {
 #if UNITY_6000_4_OR_NEWER

--- a/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionDuplicationValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionDuplicationValidationService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEditorInternal;
-using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -17,88 +16,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private static readonly Regex AsmdefNameRegex =
             new("\"name\"\\s*:\\s*\"(?<name>[^\"]+)\"", RegexOptions.Compiled);
-
-        private static readonly Regex DuplicateAsmdefConsoleRegex = new(
-            "^Assembly with name '(?<name>[^']+)' already exists \\((?<path>[^)]+)\\)$",
-            RegexOptions.Compiled
-        );
-
-        public ValidationResult ValidateNoDuplicateAsmdefNamesFromConsoleErrors()
-        {
-            LogRetrievalService retrievalService = new();
-            LogDisplayDto logData = retrievalService.GetLogsWithSearch(
-                UnityCliLoopLogType.Error,
-                "Assembly with name '",
-                useRegex: false,
-                searchInStackTrace: false
-            );
-
-            Dictionary<string, List<string>> pathsByAsmName = new(StringComparer.Ordinal);
-
-            foreach (LogEntryDto entry in logData.LogEntries)
-            {
-                if (string.IsNullOrEmpty(entry.Message))
-                {
-                    continue;
-                }
-
-                Match match = DuplicateAsmdefConsoleRegex.Match(entry.Message.Trim());
-                if (!match.Success)
-                {
-                    continue;
-                }
-
-                string asmName = match.Groups["name"].Value;
-                string assetPath = match.Groups["path"].Value;
-                if (string.IsNullOrEmpty(asmName) || string.IsNullOrEmpty(assetPath))
-                {
-                    continue;
-                }
-
-                // Prevent false positives from stale console logs by verifying the asset still exists.
-                UnityEngine.Object obj = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath);
-                if (obj == null)
-                {
-                    continue;
-                }
-
-                if (!pathsByAsmName.TryGetValue(asmName, out List<string> paths))
-                {
-                    paths = new List<string>();
-                    pathsByAsmName.Add(asmName, paths);
-                }
-
-                if (!paths.Contains(assetPath))
-                {
-                    paths.Add(assetPath);
-                }
-            }
-
-            if (pathsByAsmName.Count == 0)
-            {
-                return ValidationResult.Success();
-            }
-
-            string details = string.Join(
-                "\n",
-                pathsByAsmName
-                    .OrderBy(kvp => kvp.Key, StringComparer.Ordinal)
-                    .Take(5)
-                    .Select(d =>
-                    {
-                        string paths = string.Join("\n  ", d.Value.Take(8));
-                        return $"- {d.Key}\n  {paths}";
-                    })
-            );
-
-            string message =
-                $"{UnityCliLoopConstants.ERROR_MESSAGE_DUPLICATE_ASMDEF}\n" +
-                "Detected from Console errors:\n" +
-                $"{details}\n" +
-                "Fix: ensure each .asmdef has a unique \"name\".";
-
-            return ValidationResult.Failure(message);
-        }
 
         public ValidationResult ValidateNoDuplicateAsmdefNames()
         {

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectDetails.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectDetails.cs
@@ -8,7 +8,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class GameObjectDetails
     {
         public bool Found { get; set; }
-        public string ErrorMessage { get; set; }
         public GameObject GameObject { get; set; }
         public string Name { get; set; }
         public string Path { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/GetLogs/GetLogsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/GetLogs/GetLogsResponse.cs
@@ -19,13 +19,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Message = message;
             StackTrace = stackTrace;
         }
-
-        /// <summary>
-        /// Parameterless constructor for JSON deserialization
-        /// </summary>
-        public LogEntry()
-        {
-        }
     }
 
     /// <summary>
@@ -82,16 +75,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SearchText = searchText;
             IncludeStackTrace = includeStackTrace;
             Logs = logs ?? Array.Empty<LogEntry>();
-        }
-
-        /// <summary>
-        /// Parameterless constructor for JSON deserialization
-        /// </summary>
-        public GetLogsResponse()
-        {
-            LogType = string.Empty;
-            SearchText = string.Empty;
-            Logs = Array.Empty<LogEntry>();
         }
     }
 } 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -115,18 +115,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             NoTestsFoundExplanation = noTestsFoundExplanation;
         }
 
-        /// <summary>
-        /// Parameterless constructor for JSON deserialization
-        /// </summary>
-        public RunTestsResponse()
-        {
-            Message = string.Empty;
-            Status = string.Empty;
-            NoTestsFoundExplanation = string.Empty;
-            CompletedAt = string.Empty;
-            XmlPath = string.Empty;
-        }
-
         public static RunTestsResponse CreateTestFrameworkUnavailable()
         {
             return new RunTestsResponse(

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Application/KeyboardKeyState.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Application/KeyboardKeyState.cs
@@ -74,12 +74,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _transientKeys.Remove(key);
         }
 
-        public void Clear()
-        {
-            _heldKeys.Clear();
-            _transientKeys.Clear();
-        }
-
         // Keyboard keys are stored as a bitfield, so StateEvent.From captures
         // the entire keyboard state. To support simultaneous key holds, we write
         // ALL currently held keys into every event — not just the target key.
@@ -178,11 +172,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static void UnregisterTransientKey(Key key)
         {
             ServiceValue.UnregisterTransientKey(key);
-        }
-
-        public static void Clear()
-        {
-            ServiceValue.Clear();
         }
 
         public static IReadOnlyList<Key> ClearTrackedKeys()

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Application/MouseInputState.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Application/MouseInputState.cs
@@ -25,8 +25,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private Action? _pendingDeltaReset;
         private Action? _pendingScrollReset;
 
-        public bool IsButtonHeld(RuntimeMouseButton button) => _heldButtons.Contains(button);
-
         public void RegisterPlayModeCallbacks()
         {
             EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
@@ -236,8 +234,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             ServiceValue.RegisterPlayModeCallbacks();
         }
-
-        public static bool IsButtonHeld(RuntimeMouseButton button) => ServiceValue.IsButtonHeld(button);
 
         public static void SetButtonDown(RuntimeMouseButton button)
         {

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiIncrementalDragExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiIncrementalDragExecutor.cs
@@ -16,13 +16,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class MouseUiIncrementalDragExecutor
     {
         internal static async Task<SimulateMouseUiResponse> ExecuteDragStart(
-            MouseUiSimulationCommand parameters, EventSystem eventSystem, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
+            MouseUiSimulationCommand parameters,
+            EventSystem eventSystem,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
         {
             if (MouseDragState.IsDragging)
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false, Message = "A drag is already in progress. Call DragEnd first.", Action = MouseAction.DragStart.ToString(), PositionX = parameters.X, PositionY = parameters.Y
+                    Success = false,
+                    Message = "A drag is already in progress. Call DragEnd first.",
+                    Action = MouseAction.DragStart.ToString(),
+                    PositionX = parameters.X,
+                    PositionY = parameters.Y
                 };
             }
 
@@ -30,7 +37,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
             (RaycastResult startRaycast, GameObject? target, SimulateMouseUiResponse? targetFailureResponse) =
                 MouseUiDragTargetResolver.Resolve(
-                    parameters, eventSystem, MouseAction.DragStart, inputPos, screenPos);
+                    parameters,
+                    eventSystem,
+                    MouseAction.DragStart,
+                    inputPos,
+                    screenPos);
             if (targetFailureResponse != null)
             {
                 return targetFailureResponse;
@@ -50,7 +61,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     cleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.DragStart, inputPos, null, "DragStart stopped because Unity paused during Pause Point inspection. No draggable target was found at the position, so no drag was initiated.");
+                        MouseAction.DragStart, inputPos, null,
+                        "DragStart stopped because Unity paused during Pause Point inspection. No draggable target was found at the position, so no drag was initiated.");
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -64,15 +76,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     cleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.DragStart, inputPos, null, "DragStart stopped because Unity paused during Pause Point inspection. No draggable target was found at the position, so no drag was initiated.");
+                        MouseAction.DragStart, inputPos, null,
+                        "DragStart stopped because Unity paused during Pause Point inspection. No draggable target was found at the position, so no drag was initiated.");
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
                 return new SimulateMouseUiResponse
                 {
-                    Success = false, Message = parameters.BypassRaycast
+                    Success = false,
+                    Message = parameters.BypassRaycast
                         ? $"TargetPath '{parameters.TargetPath}' has no drag handler."
-                        : $"No draggable UI element at ({inputPos.x:F1}, {inputPos.y:F1}). Use find-game-objects or screenshot to verify positions.", Action = MouseAction.DragStart.ToString(), PositionX = inputPos.x, PositionY = inputPos.y
+                        : $"No draggable UI element at ({inputPos.x:F1}, {inputPos.y:F1}). Use find-game-objects or screenshot to verify positions.",
+                    Action = MouseAction.DragStart.ToString(),
+                    PositionX = inputPos.x,
+                    PositionY = inputPos.y
                 };
             }
 
@@ -100,7 +117,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     cleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.DragStart, inputPos, targetName, "DragStart was finalized early (pointerUp/drop/endDrag dispatched via cleanup) because Unity paused during Pause Point inspection before the start animation finished. No drag session is active; call DragStart again to retry.");
+                        MouseAction.DragStart, inputPos, targetName,
+                        "DragStart was finalized early (pointerUp/drop/endDrag dispatched via cleanup) because Unity paused during Pause Point inspection before the start animation finished. No drag session is active; call DragStart again to retry.");
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
                 animationCompleted = true;
@@ -120,18 +138,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             return new SimulateMouseUiResponse
             {
-                Success = true, Message = $"Drag started on '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1})", Action = MouseAction.DragStart.ToString(), HitGameObjectName = targetName, PositionX = inputPos.x, PositionY = inputPos.y
+                Success = true,
+                Message = $"Drag started on '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1})",
+                Action = MouseAction.DragStart.ToString(),
+                HitGameObjectName = targetName,
+                PositionX = inputPos.x,
+                PositionY = inputPos.y
             };
         }
 
         internal static async Task<SimulateMouseUiResponse> ExecuteDragMove(
-            MouseUiSimulationCommand parameters, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
+            MouseUiSimulationCommand parameters,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
         {
             if (!MouseDragState.IsDragging)
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false, Message = "No drag in progress. Call DragStart first.", Action = MouseAction.DragMove.ToString(), PositionX = parameters.X, PositionY = parameters.Y
+                    Success = false,
+                    Message = "No drag in progress. Call DragStart first.",
+                    Action = MouseAction.DragMove.ToString(),
+                    PositionX = parameters.X,
+                    PositionY = parameters.Y
                 };
             }
 
@@ -151,11 +180,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string targetName = target.name;
 
             SimulateMouseUiOverlayState.Update(
-                MouseAction.DragMove, MouseUiCoordinateConverter.ScreenToInput(pointerData.position), SimulateMouseUiOverlayState.DragStartPosition, Handles.GetMainGameViewSize());
+                MouseAction.DragMove,
+                MouseUiCoordinateConverter.ScreenToInput(pointerData.position),
+                SimulateMouseUiOverlayState.DragStartPosition,
+                Handles.GetMainGameViewSize());
 
             // Cancellation leaves drag state intact so the user can continue with DragMove/DragEnd
             MouseUiFrameWaitOutcome dragOutcome = await MouseUiDragEventExecutor.InterpolateDragPosition(
-                pointerData, target, screenEnd, parameters.DragSpeed, ct).ConfigureAwait(false);
+                pointerData, target, screenEnd,
+                parameters.DragSpeed, ct).ConfigureAwait(false);
             if (dragOutcome == MouseUiFrameWaitOutcome.TimedOut)
             {
                 cleanupScheduler.QueueOverlayClear();
@@ -165,7 +198,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.DragMove, inputEnd, targetName, "DragMove was interrupted because Unity paused during Pause Point inspection while interpolating. The drag session is still active (not finalized); the pointer may not have reached the requested position. Call DragMove or DragEnd to continue.");
+                    MouseAction.DragMove, inputEnd, targetName,
+                    "DragMove was interrupted because Unity paused during Pause Point inspection while interpolating. The drag session is still active (not finalized); the pointer may not have reached the requested position. Call DragMove or DragEnd to continue.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -173,18 +207,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             return new SimulateMouseUiResponse
             {
-                Success = true, Message = $"Drag moved on '{targetName}' to ({inputEnd.x:F1}, {inputEnd.y:F1}) at {parameters.DragSpeed:F0} px/s", Action = MouseAction.DragMove.ToString(), HitGameObjectName = targetName, PositionX = inputEnd.x, PositionY = inputEnd.y
+                Success = true,
+                Message = $"Drag moved on '{targetName}' to ({inputEnd.x:F1}, {inputEnd.y:F1}) at {parameters.DragSpeed:F0} px/s",
+                Action = MouseAction.DragMove.ToString(),
+                HitGameObjectName = targetName,
+                PositionX = inputEnd.x,
+                PositionY = inputEnd.y
             };
         }
 
         internal static async Task<SimulateMouseUiResponse> ExecuteDragEnd(
-            MouseUiSimulationCommand parameters, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
+            MouseUiSimulationCommand parameters,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
         {
             if (!MouseDragState.IsDragging)
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false, Message = "No drag in progress. Call DragStart first.", Action = MouseAction.DragEnd.ToString(), PositionX = parameters.X, PositionY = parameters.Y
+                    Success = false,
+                    Message = "No drag in progress. Call DragStart first.",
+                    Action = MouseAction.DragEnd.ToString(),
+                    PositionX = parameters.X,
+                    PositionY = parameters.Y
                 };
             }
 
@@ -204,14 +249,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string targetName = target.name;
             (GameObject? explicitDropTarget, SimulateMouseUiResponse? dropFailureResponse) =
                 MouseUiPointerTargetResolver.ResolveDropTargetPath(
-                    parameters, MouseAction.DragEnd, inputEnd);
+                    parameters,
+                    MouseAction.DragEnd,
+                    inputEnd);
             if (dropFailureResponse != null)
             {
                 return dropFailureResponse;
             }
 
             SimulateMouseUiOverlayState.Update(
-                MouseAction.DragEnd, MouseUiCoordinateConverter.ScreenToInput(pointerData.position), SimulateMouseUiOverlayState.DragStartPosition, Handles.GetMainGameViewSize());
+                MouseAction.DragEnd,
+                MouseUiCoordinateConverter.ScreenToInput(pointerData.position),
+                SimulateMouseUiOverlayState.DragStartPosition,
+                Handles.GetMainGameViewSize());
 
             // Any Paused exit inside this try still runs FinalizeDrag + MouseDragState.Clear()
             // in the finally below, so every in-try branch reports the drag as finalized early.
@@ -221,7 +271,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             try
             {
                 MouseUiFrameWaitOutcome dragOutcome = await MouseUiDragEventExecutor.InterpolateDragPosition(
-                    pointerData, target, screenEnd, parameters.DragSpeed, ct).ConfigureAwait(false);
+                    pointerData, target, screenEnd,
+                    parameters.DragSpeed, ct).ConfigureAwait(false);
                 if (dragOutcome == MouseUiFrameWaitOutcome.TimedOut)
                 {
                     cleanupScheduler.QueueOverlayClear();
@@ -271,7 +322,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.DragEnd, inputEnd, targetName, "DragEnd was already completed (target position reached, pointerUp/drop/endDrag dispatched, drag state cleared). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
+                    MouseAction.DragEnd, inputEnd, targetName,
+                    "DragEnd was already completed (target position reached, pointerUp/drop/endDrag dispatched, drag state cleared). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -288,7 +340,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 SimulateMouseUiOverlayState.Clear();
                 return new SimulateMouseUiResponse
                 {
-                    Success = false, Message = "Drag target was destroyed or deactivated during drag.", Action = action.ToString()
+                    Success = false,
+                    Message = "Drag target was destroyed or deactivated during drag.",
+                    Action = action.ToString()
                 };
             }
 
@@ -299,7 +353,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 SimulateMouseUiOverlayState.Clear();
                 return new SimulateMouseUiResponse
                 {
-                    Success = false, Message = "Drag was interrupted by user input or system event.", Action = action.ToString()
+                    Success = false,
+                    Message = "Drag was interrupted by user input or system event.",
+                    Action = action.ToString()
                 };
             }
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiIncrementalDragExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiIncrementalDragExecutor.cs
@@ -16,20 +16,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class MouseUiIncrementalDragExecutor
     {
         internal static async Task<SimulateMouseUiResponse> ExecuteDragStart(
-            MouseUiSimulationCommand parameters,
-            EventSystem eventSystem,
-            MouseUiMainThreadCleanupScheduler cleanupScheduler,
-            CancellationToken ct)
+            MouseUiSimulationCommand parameters, EventSystem eventSystem, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
         {
             if (MouseDragState.IsDragging)
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false,
-                    Message = "A drag is already in progress. Call DragEnd first.",
-                    Action = MouseAction.DragStart.ToString(),
-                    PositionX = parameters.X,
-                    PositionY = parameters.Y
+                    Success = false, Message = "A drag is already in progress. Call DragEnd first.", Action = MouseAction.DragStart.ToString(), PositionX = parameters.X, PositionY = parameters.Y
                 };
             }
 
@@ -37,11 +30,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
             (RaycastResult startRaycast, GameObject? target, SimulateMouseUiResponse? targetFailureResponse) =
                 MouseUiDragTargetResolver.Resolve(
-                    parameters,
-                    eventSystem,
-                    MouseAction.DragStart,
-                    inputPos,
-                    screenPos);
+                    parameters, eventSystem, MouseAction.DragStart, inputPos, screenPos);
             if (targetFailureResponse != null)
             {
                 return targetFailureResponse;
@@ -50,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (target == null)
             {
                 SimulateMouseUiOverlayState.Update(
-                    MouseAction.DragStart, inputPos, null, null, Handles.GetMainGameViewSize());
+                    MouseAction.DragStart, inputPos, null, Handles.GetMainGameViewSize());
                 MouseUiFrameWaitOutcome noTargetExpandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
                 if (noTargetExpandOutcome == MouseUiFrameWaitOutcome.TimedOut)
                 {
@@ -61,8 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     cleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.DragStart, inputPos, null,
-                        "DragStart stopped because Unity paused during Pause Point inspection. No draggable target was found at the position, so no drag was initiated.");
+                        MouseAction.DragStart, inputPos, null, "DragStart stopped because Unity paused during Pause Point inspection. No draggable target was found at the position, so no drag was initiated.");
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -76,20 +64,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     cleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.DragStart, inputPos, null,
-                        "DragStart stopped because Unity paused during Pause Point inspection. No draggable target was found at the position, so no drag was initiated.");
+                        MouseAction.DragStart, inputPos, null, "DragStart stopped because Unity paused during Pause Point inspection. No draggable target was found at the position, so no drag was initiated.");
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
                 return new SimulateMouseUiResponse
                 {
-                    Success = false,
-                    Message = parameters.BypassRaycast
+                    Success = false, Message = parameters.BypassRaycast
                         ? $"TargetPath '{parameters.TargetPath}' has no drag handler."
-                        : $"No draggable UI element at ({inputPos.x:F1}, {inputPos.y:F1}). Use find-game-objects or screenshot to verify positions.",
-                    Action = MouseAction.DragStart.ToString(),
-                    PositionX = inputPos.x,
-                    PositionY = inputPos.y
+                        : $"No draggable UI element at ({inputPos.x:F1}, {inputPos.y:F1}). Use find-game-objects or screenshot to verify positions.", Action = MouseAction.DragStart.ToString(), PositionX = inputPos.x, PositionY = inputPos.y
                 };
             }
 
@@ -102,7 +85,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             string targetName = target.name;
             SimulateMouseUiOverlayState.Update(
-                MouseAction.DragStart, inputPos, inputPos, targetName, Handles.GetMainGameViewSize());
+                MouseAction.DragStart, inputPos, inputPos, Handles.GetMainGameViewSize());
 
             bool animationCompleted = false;
             try
@@ -117,8 +100,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     cleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.DragStart, inputPos, targetName,
-                        "DragStart was finalized early (pointerUp/drop/endDrag dispatched via cleanup) because Unity paused during Pause Point inspection before the start animation finished. No drag session is active; call DragStart again to retry.");
+                        MouseAction.DragStart, inputPos, targetName, "DragStart was finalized early (pointerUp/drop/endDrag dispatched via cleanup) because Unity paused during Pause Point inspection before the start animation finished. No drag session is active; call DragStart again to retry.");
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
                 animationCompleted = true;
@@ -138,29 +120,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             return new SimulateMouseUiResponse
             {
-                Success = true,
-                Message = $"Drag started on '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1})",
-                Action = MouseAction.DragStart.ToString(),
-                HitGameObjectName = targetName,
-                PositionX = inputPos.x,
-                PositionY = inputPos.y
+                Success = true, Message = $"Drag started on '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1})", Action = MouseAction.DragStart.ToString(), HitGameObjectName = targetName, PositionX = inputPos.x, PositionY = inputPos.y
             };
         }
 
         internal static async Task<SimulateMouseUiResponse> ExecuteDragMove(
-            MouseUiSimulationCommand parameters,
-            MouseUiMainThreadCleanupScheduler cleanupScheduler,
-            CancellationToken ct)
+            MouseUiSimulationCommand parameters, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
         {
             if (!MouseDragState.IsDragging)
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false,
-                    Message = "No drag in progress. Call DragStart first.",
-                    Action = MouseAction.DragMove.ToString(),
-                    PositionX = parameters.X,
-                    PositionY = parameters.Y
+                    Success = false, Message = "No drag in progress. Call DragStart first.", Action = MouseAction.DragMove.ToString(), PositionX = parameters.X, PositionY = parameters.Y
                 };
             }
 
@@ -180,15 +151,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string targetName = target.name;
 
             SimulateMouseUiOverlayState.Update(
-                MouseAction.DragMove,
-                MouseUiCoordinateConverter.ScreenToInput(pointerData.position),
-                SimulateMouseUiOverlayState.DragStartPosition,
-                targetName, Handles.GetMainGameViewSize());
+                MouseAction.DragMove, MouseUiCoordinateConverter.ScreenToInput(pointerData.position), SimulateMouseUiOverlayState.DragStartPosition, Handles.GetMainGameViewSize());
 
             // Cancellation leaves drag state intact so the user can continue with DragMove/DragEnd
             MouseUiFrameWaitOutcome dragOutcome = await MouseUiDragEventExecutor.InterpolateDragPosition(
-                pointerData, target, screenEnd,
-                parameters.DragSpeed, ct).ConfigureAwait(false);
+                pointerData, target, screenEnd, parameters.DragSpeed, ct).ConfigureAwait(false);
             if (dragOutcome == MouseUiFrameWaitOutcome.TimedOut)
             {
                 cleanupScheduler.QueueOverlayClear();
@@ -198,8 +165,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.DragMove, inputEnd, targetName,
-                    "DragMove was interrupted because Unity paused during Pause Point inspection while interpolating. The drag session is still active (not finalized); the pointer may not have reached the requested position. Call DragMove or DragEnd to continue.");
+                    MouseAction.DragMove, inputEnd, targetName, "DragMove was interrupted because Unity paused during Pause Point inspection while interpolating. The drag session is still active (not finalized); the pointer may not have reached the requested position. Call DragMove or DragEnd to continue.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -207,29 +173,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             return new SimulateMouseUiResponse
             {
-                Success = true,
-                Message = $"Drag moved on '{targetName}' to ({inputEnd.x:F1}, {inputEnd.y:F1}) at {parameters.DragSpeed:F0} px/s",
-                Action = MouseAction.DragMove.ToString(),
-                HitGameObjectName = targetName,
-                PositionX = inputEnd.x,
-                PositionY = inputEnd.y
+                Success = true, Message = $"Drag moved on '{targetName}' to ({inputEnd.x:F1}, {inputEnd.y:F1}) at {parameters.DragSpeed:F0} px/s", Action = MouseAction.DragMove.ToString(), HitGameObjectName = targetName, PositionX = inputEnd.x, PositionY = inputEnd.y
             };
         }
 
         internal static async Task<SimulateMouseUiResponse> ExecuteDragEnd(
-            MouseUiSimulationCommand parameters,
-            MouseUiMainThreadCleanupScheduler cleanupScheduler,
-            CancellationToken ct)
+            MouseUiSimulationCommand parameters, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
         {
             if (!MouseDragState.IsDragging)
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false,
-                    Message = "No drag in progress. Call DragStart first.",
-                    Action = MouseAction.DragEnd.ToString(),
-                    PositionX = parameters.X,
-                    PositionY = parameters.Y
+                    Success = false, Message = "No drag in progress. Call DragStart first.", Action = MouseAction.DragEnd.ToString(), PositionX = parameters.X, PositionY = parameters.Y
                 };
             }
 
@@ -249,19 +204,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string targetName = target.name;
             (GameObject? explicitDropTarget, SimulateMouseUiResponse? dropFailureResponse) =
                 MouseUiPointerTargetResolver.ResolveDropTargetPath(
-                    parameters,
-                    MouseAction.DragEnd,
-                    inputEnd);
+                    parameters, MouseAction.DragEnd, inputEnd);
             if (dropFailureResponse != null)
             {
                 return dropFailureResponse;
             }
 
             SimulateMouseUiOverlayState.Update(
-                MouseAction.DragEnd,
-                MouseUiCoordinateConverter.ScreenToInput(pointerData.position),
-                SimulateMouseUiOverlayState.DragStartPosition,
-                targetName, Handles.GetMainGameViewSize());
+                MouseAction.DragEnd, MouseUiCoordinateConverter.ScreenToInput(pointerData.position), SimulateMouseUiOverlayState.DragStartPosition, Handles.GetMainGameViewSize());
 
             // Any Paused exit inside this try still runs FinalizeDrag + MouseDragState.Clear()
             // in the finally below, so every in-try branch reports the drag as finalized early.
@@ -271,8 +221,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             try
             {
                 MouseUiFrameWaitOutcome dragOutcome = await MouseUiDragEventExecutor.InterpolateDragPosition(
-                    pointerData, target, screenEnd,
-                    parameters.DragSpeed, ct).ConfigureAwait(false);
+                    pointerData, target, screenEnd, parameters.DragSpeed, ct).ConfigureAwait(false);
                 if (dragOutcome == MouseUiFrameWaitOutcome.TimedOut)
                 {
                     cleanupScheduler.QueueOverlayClear();
@@ -310,7 +259,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             SimulateMouseUiOverlayState.Update(
-                MouseAction.DragEnd, inputEnd, null, targetName, Handles.GetMainGameViewSize());
+                MouseAction.DragEnd, inputEnd, null, Handles.GetMainGameViewSize());
 
             MouseUiFrameWaitOutcome dissipateOutcome = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
             if (dissipateOutcome == MouseUiFrameWaitOutcome.TimedOut)
@@ -322,8 +271,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.DragEnd, inputEnd, targetName,
-                    "DragEnd was already completed (target position reached, pointerUp/drop/endDrag dispatched, drag state cleared). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
+                    MouseAction.DragEnd, inputEnd, targetName, "DragEnd was already completed (target position reached, pointerUp/drop/endDrag dispatched, drag state cleared). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -340,9 +288,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 SimulateMouseUiOverlayState.Clear();
                 return new SimulateMouseUiResponse
                 {
-                    Success = false,
-                    Message = "Drag target was destroyed or deactivated during drag.",
-                    Action = action.ToString()
+                    Success = false, Message = "Drag target was destroyed or deactivated during drag.", Action = action.ToString()
                 };
             }
 
@@ -353,9 +299,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 SimulateMouseUiOverlayState.Clear();
                 return new SimulateMouseUiResponse
                 {
-                    Success = false,
-                    Message = "Drag was interrupted by user input or system event.",
-                    Action = action.ToString()
+                    Success = false, Message = "Drag was interrupted by user input or system event.", Action = action.ToString()
                 };
             }
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
@@ -16,10 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class MouseUiOneShotDragExecutor
     {
         internal static async Task<SimulateMouseUiResponse> ExecuteDragOneShot(
-            MouseUiSimulationCommand parameters,
-            EventSystem eventSystem,
-            MouseUiMainThreadCleanupScheduler cleanupScheduler,
-            CancellationToken ct)
+            MouseUiSimulationCommand parameters, EventSystem eventSystem, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
         {
             Vector2 inputStart = new(parameters.FromX, parameters.FromY);
             Vector2 inputEnd = new(parameters.X, parameters.Y);
@@ -27,11 +24,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Vector2 screenEnd = MouseUiCoordinateConverter.InputToScreen(inputEnd);
             (RaycastResult startRaycast, GameObject? target, SimulateMouseUiResponse? targetFailureResponse) =
                 MouseUiDragTargetResolver.Resolve(
-                    parameters,
-                    eventSystem,
-                    MouseAction.Drag,
-                    inputStart,
-                    screenStart);
+                    parameters, eventSystem, MouseAction.Drag, inputStart, screenStart);
             if (targetFailureResponse != null)
             {
                 return targetFailureResponse;
@@ -39,9 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             (GameObject? explicitDropTarget, SimulateMouseUiResponse? dropFailureResponse) =
                 MouseUiPointerTargetResolver.ResolveDropTargetPath(
-                    parameters,
-                    MouseAction.Drag,
-                    inputEnd);
+                    parameters, MouseAction.Drag, inputEnd);
             if (dropFailureResponse != null)
             {
                 return dropFailureResponse;
@@ -50,7 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (target == null)
             {
                 SimulateMouseUiOverlayState.Update(
-                    MouseAction.Drag, inputStart, null, null, Handles.GetMainGameViewSize());
+                    MouseAction.Drag, inputStart, null, Handles.GetMainGameViewSize());
                 MouseUiFrameWaitOutcome noTargetExpandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
                 if (noTargetExpandOutcome == MouseUiFrameWaitOutcome.TimedOut)
                 {
@@ -61,8 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     cleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.Drag, inputStart, null,
-                        "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.");
+                        MouseAction.Drag, inputStart, null, "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.");
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -76,22 +66,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     cleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.Drag, inputStart, null,
-                        "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.");
+                        MouseAction.Drag, inputStart, null, "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.");
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
                 return new SimulateMouseUiResponse
                 {
-                    Success = false,
-                    Message = parameters.BypassRaycast
+                    Success = false, Message = parameters.BypassRaycast
                         ? $"TargetPath '{parameters.TargetPath}' has no drag handler."
-                        : $"No draggable UI element at ({inputStart.x:F1}, {inputStart.y:F1}). Use find-game-objects or screenshot to verify positions.",
-                    Action = MouseAction.Drag.ToString(),
-                    PositionX = inputStart.x,
-                    PositionY = inputStart.y,
-                    EndPositionX = inputEnd.x,
-                    EndPositionY = inputEnd.y
+                        : $"No draggable UI element at ({inputStart.x:F1}, {inputStart.y:F1}). Use find-game-objects or screenshot to verify positions.", Action = MouseAction.Drag.ToString(), PositionX = inputStart.x, PositionY = inputStart.y, EndPositionX = inputEnd.x, EndPositionY = inputEnd.y
                 };
             }
 
@@ -102,7 +85,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             string targetName = target.name;
             SimulateMouseUiOverlayState.Update(
-                MouseAction.Drag, inputStart, inputStart, targetName, Handles.GetMainGameViewSize());
+                MouseAction.Drag, inputStart, inputStart, Handles.GetMainGameViewSize());
 
             // Any Paused exit inside this try still runs FinalizeDrag in the finally below
             // (pointerUp/drop/endDrag), so every branch reports the drag as finalized early
@@ -161,7 +144,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             SimulateMouseUiOverlayState.Update(
-                MouseAction.Drag, inputEnd, inputStart, targetName, Handles.GetMainGameViewSize());
+                MouseAction.Drag, inputEnd, inputStart, Handles.GetMainGameViewSize());
 
             MouseUiFrameWaitOutcome dissipateOutcome = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
             if (dissipateOutcome == MouseUiFrameWaitOutcome.TimedOut)
@@ -173,8 +156,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.Drag, inputStart, targetName,
-                    "Drag was already completed (target position reached, pointerUp/drop/endDrag dispatched). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
+                    MouseAction.Drag, inputStart, targetName, "Drag was already completed (target position reached, pointerUp/drop/endDrag dispatched). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
@@ -16,7 +16,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class MouseUiOneShotDragExecutor
     {
         internal static async Task<SimulateMouseUiResponse> ExecuteDragOneShot(
-            MouseUiSimulationCommand parameters, EventSystem eventSystem, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
+            MouseUiSimulationCommand parameters,
+            EventSystem eventSystem,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
         {
             Vector2 inputStart = new(parameters.FromX, parameters.FromY);
             Vector2 inputEnd = new(parameters.X, parameters.Y);
@@ -24,7 +27,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Vector2 screenEnd = MouseUiCoordinateConverter.InputToScreen(inputEnd);
             (RaycastResult startRaycast, GameObject? target, SimulateMouseUiResponse? targetFailureResponse) =
                 MouseUiDragTargetResolver.Resolve(
-                    parameters, eventSystem, MouseAction.Drag, inputStart, screenStart);
+                    parameters,
+                    eventSystem,
+                    MouseAction.Drag,
+                    inputStart,
+                    screenStart);
             if (targetFailureResponse != null)
             {
                 return targetFailureResponse;
@@ -32,7 +39,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             (GameObject? explicitDropTarget, SimulateMouseUiResponse? dropFailureResponse) =
                 MouseUiPointerTargetResolver.ResolveDropTargetPath(
-                    parameters, MouseAction.Drag, inputEnd);
+                    parameters,
+                    MouseAction.Drag,
+                    inputEnd);
             if (dropFailureResponse != null)
             {
                 return dropFailureResponse;
@@ -52,7 +61,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     cleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.Drag, inputStart, null, "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.");
+                        MouseAction.Drag, inputStart, null,
+                        "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.");
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -66,15 +76,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     cleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.Drag, inputStart, null, "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.");
+                        MouseAction.Drag, inputStart, null,
+                        "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.");
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
                 return new SimulateMouseUiResponse
                 {
-                    Success = false, Message = parameters.BypassRaycast
+                    Success = false,
+                    Message = parameters.BypassRaycast
                         ? $"TargetPath '{parameters.TargetPath}' has no drag handler."
-                        : $"No draggable UI element at ({inputStart.x:F1}, {inputStart.y:F1}). Use find-game-objects or screenshot to verify positions.", Action = MouseAction.Drag.ToString(), PositionX = inputStart.x, PositionY = inputStart.y, EndPositionX = inputEnd.x, EndPositionY = inputEnd.y
+                        : $"No draggable UI element at ({inputStart.x:F1}, {inputStart.y:F1}). Use find-game-objects or screenshot to verify positions.",
+                    Action = MouseAction.Drag.ToString(),
+                    PositionX = inputStart.x,
+                    PositionY = inputStart.y,
+                    EndPositionX = inputEnd.x,
+                    EndPositionY = inputEnd.y
                 };
             }
 
@@ -156,7 +173,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.Drag, inputStart, targetName, "Drag was already completed (target position reached, pointerUp/drop/endDrag dispatched). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
+                    MouseAction.Drag, inputStart, targetName,
+                    "Drag was already completed (target position reached, pointerUp/drop/endDrag dispatched). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
@@ -16,10 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class MouseUiPressActionExecutor
     {
         internal static async Task<SimulateMouseUiResponse> ExecuteClick(
-            MouseUiSimulationCommand parameters,
-            EventSystem eventSystem,
-            MouseUiMainThreadCleanupScheduler cleanupScheduler,
-            CancellationToken ct)
+            MouseUiSimulationCommand parameters, EventSystem eventSystem, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
         {
             Vector2 inputPos = new(parameters.X, parameters.Y);
             Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
@@ -36,19 +33,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false,
-                    Message = $"TargetPath '{parameters.TargetPath}' has no pointer click or pointer down handler.",
-                    Action = MouseAction.Click.ToString(),
-                    PositionX = inputPos.x,
-                    PositionY = inputPos.y
+                    Success = false, Message = $"TargetPath '{parameters.TargetPath}' has no pointer click or pointer down handler.", Action = MouseAction.Click.ToString(), PositionX = inputPos.x, PositionY = inputPos.y
                 };
             }
 
             string? targetName = resolvedTargets.Target?.name;
             bool hitTarget = resolvedTargets.Target != null;
             SimulateMouseUiOverlayState.Update(
-                MouseAction.Click, inputPos, null,
-                targetName, Handles.GetMainGameViewSize());
+                MouseAction.Click, inputPos, null, Handles.GetMainGameViewSize());
 
             MouseUiFrameWaitOutcome expandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
             if (expandOutcome == MouseUiFrameWaitOutcome.TimedOut)
@@ -60,8 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.Click, inputPos, targetName,
-                    "Click stopped because Unity paused during Pause Point inspection before the click was dispatched. No pointer event was fired.");
+                    MouseAction.Click, inputPos, targetName, "Click stopped because Unity paused during Pause Point inspection before the click was dispatched. No pointer event was fired.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -78,8 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.Click, inputPos, targetName,
-                    "Click was already dispatched. Unity paused during Pause Point inspection while the click overlay animation was still playing; only the animation was interrupted.");
+                    MouseAction.Click, inputPos, targetName, "Click was already dispatched. Unity paused during Pause Point inspection while the click overlay animation was still playing; only the animation was interrupted.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -87,18 +77,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         internal static async Task<SimulateMouseUiResponse> ExecuteLongPress(
-            MouseUiSimulationCommand parameters,
-            EventSystem eventSystem,
-            MouseUiMainThreadCleanupScheduler cleanupScheduler,
-            CancellationToken ct)
+            MouseUiSimulationCommand parameters, EventSystem eventSystem, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
         {
             if (parameters.Duration <= 0f || float.IsNaN(parameters.Duration) || float.IsInfinity(parameters.Duration))
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false,
-                    Message = $"Duration must be positive, got: {parameters.Duration}",
-                    Action = MouseAction.LongPress.ToString()
+                    Success = false, Message = $"Duration must be positive, got: {parameters.Duration}", Action = MouseAction.LongPress.ToString()
                 };
             }
 
@@ -117,11 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false,
-                    Message = $"TargetPath '{parameters.TargetPath}' has no pointer down or pointer click handler.",
-                    Action = MouseAction.LongPress.ToString(),
-                    PositionX = inputPos.x,
-                    PositionY = inputPos.y
+                    Success = false, Message = $"TargetPath '{parameters.TargetPath}' has no pointer down or pointer click handler.", Action = MouseAction.LongPress.ToString(), PositionX = inputPos.x, PositionY = inputPos.y
                 };
             }
 
@@ -129,8 +110,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool hitTarget = resolvedTargets.Target != null;
             bool shouldReleasePointer = resolvedTargets.RawTarget != null && resolvedTargets.Target != null;
             SimulateMouseUiOverlayState.Update(
-                MouseAction.LongPress, inputPos, null,
-                targetName, Handles.GetMainGameViewSize());
+                MouseAction.LongPress, inputPos, null, Handles.GetMainGameViewSize());
 
             MouseUiFrameWaitOutcome expandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
             if (expandOutcome == MouseUiFrameWaitOutcome.TimedOut)
@@ -142,8 +122,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.LongPress, inputPos, targetName,
-                    "Long-press stopped because Unity paused during Pause Point inspection before pointerDown was dispatched. No pointer event was fired.");
+                    MouseAction.LongPress, inputPos, targetName, "Long-press stopped because Unity paused during Pause Point inspection before pointerDown was dispatched. No pointer event was fired.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -168,8 +147,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         // Returning here still runs the finally below, which releases pointerUp early.
                         cleanupScheduler.QueueOverlayClear();
                         return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                            MouseAction.LongPress, inputPos, targetName,
-                            "Long-press pointerDown was already dispatched. Unity paused during Pause Point inspection while holding; pointerUp was released early and the press duration was cut short.");
+                            MouseAction.LongPress, inputPos, targetName, "Long-press pointerDown was already dispatched. Unity paused during Pause Point inspection while holding; pointerUp was released early and the press duration was cut short.");
                     }
                     await MainThreadSwitcher.SwitchToMainThread(ct);
                     elapsed = Time.realtimeSinceStartup - startTime;
@@ -196,8 +174,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.LongPress, inputPos, targetName,
-                    "Long-press was already completed (pointerDown and pointerUp both dispatched). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
+                    MouseAction.LongPress, inputPos, targetName, "Long-press was already completed (pointerDown and pointerUp both dispatched). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -205,8 +182,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         private static void ExecutePointerClickEvents(
-            ResolvedPointerTargets resolvedTargets,
-            PointerEventData pointerData)
+            ResolvedPointerTargets resolvedTargets, PointerEventData pointerData)
         {
             if (resolvedTargets.RawTarget == null)
             {
@@ -216,31 +192,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (resolvedTargets.PressTarget != null)
             {
                 ExecuteEvents.ExecuteHierarchy(
-                    resolvedTargets.RawTarget,
-                    pointerData,
-                    ExecuteEvents.pointerDownHandler);
+                    resolvedTargets.RawTarget, pointerData, ExecuteEvents.pointerDownHandler);
             }
 
             if (resolvedTargets.Target != null)
             {
                 ExecuteEvents.Execute(
-                    resolvedTargets.Target,
-                    pointerData,
-                    ExecuteEvents.pointerUpHandler);
+                    resolvedTargets.Target, pointerData, ExecuteEvents.pointerUpHandler);
             }
 
             if (resolvedTargets.ClickTarget != null)
             {
                 ExecuteEvents.Execute(
-                    resolvedTargets.ClickTarget,
-                    pointerData,
-                    ExecuteEvents.pointerClickHandler);
+                    resolvedTargets.ClickTarget, pointerData, ExecuteEvents.pointerClickHandler);
             }
         }
 
         private static void ExecuteLongPressPointerDown(
-            ResolvedPointerTargets resolvedTargets,
-            PointerEventData pointerData)
+            ResolvedPointerTargets resolvedTargets, PointerEventData pointerData)
         {
             if (resolvedTargets.RawTarget == null || resolvedTargets.Target == null)
             {
@@ -248,9 +217,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             ExecuteEvents.ExecuteHierarchy(
-                resolvedTargets.RawTarget,
-                pointerData,
-                ExecuteEvents.pointerDownHandler);
+                resolvedTargets.RawTarget, pointerData, ExecuteEvents.pointerDownHandler);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
@@ -16,7 +16,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class MouseUiPressActionExecutor
     {
         internal static async Task<SimulateMouseUiResponse> ExecuteClick(
-            MouseUiSimulationCommand parameters, EventSystem eventSystem, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
+            MouseUiSimulationCommand parameters,
+            EventSystem eventSystem,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
         {
             Vector2 inputPos = new(parameters.X, parameters.Y);
             Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
@@ -33,14 +36,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false, Message = $"TargetPath '{parameters.TargetPath}' has no pointer click or pointer down handler.", Action = MouseAction.Click.ToString(), PositionX = inputPos.x, PositionY = inputPos.y
+                    Success = false,
+                    Message = $"TargetPath '{parameters.TargetPath}' has no pointer click or pointer down handler.",
+                    Action = MouseAction.Click.ToString(),
+                    PositionX = inputPos.x,
+                    PositionY = inputPos.y
                 };
             }
 
             string? targetName = resolvedTargets.Target?.name;
             bool hitTarget = resolvedTargets.Target != null;
             SimulateMouseUiOverlayState.Update(
-                MouseAction.Click, inputPos, null, Handles.GetMainGameViewSize());
+                MouseAction.Click, inputPos, null,
+                Handles.GetMainGameViewSize());
 
             MouseUiFrameWaitOutcome expandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
             if (expandOutcome == MouseUiFrameWaitOutcome.TimedOut)
@@ -52,7 +60,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.Click, inputPos, targetName, "Click stopped because Unity paused during Pause Point inspection before the click was dispatched. No pointer event was fired.");
+                    MouseAction.Click, inputPos, targetName,
+                    "Click stopped because Unity paused during Pause Point inspection before the click was dispatched. No pointer event was fired.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -69,7 +78,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.Click, inputPos, targetName, "Click was already dispatched. Unity paused during Pause Point inspection while the click overlay animation was still playing; only the animation was interrupted.");
+                    MouseAction.Click, inputPos, targetName,
+                    "Click was already dispatched. Unity paused during Pause Point inspection while the click overlay animation was still playing; only the animation was interrupted.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -77,13 +87,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         internal static async Task<SimulateMouseUiResponse> ExecuteLongPress(
-            MouseUiSimulationCommand parameters, EventSystem eventSystem, MouseUiMainThreadCleanupScheduler cleanupScheduler, CancellationToken ct)
+            MouseUiSimulationCommand parameters,
+            EventSystem eventSystem,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
         {
             if (parameters.Duration <= 0f || float.IsNaN(parameters.Duration) || float.IsInfinity(parameters.Duration))
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false, Message = $"Duration must be positive, got: {parameters.Duration}", Action = MouseAction.LongPress.ToString()
+                    Success = false,
+                    Message = $"Duration must be positive, got: {parameters.Duration}",
+                    Action = MouseAction.LongPress.ToString()
                 };
             }
 
@@ -102,7 +117,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return new SimulateMouseUiResponse
                 {
-                    Success = false, Message = $"TargetPath '{parameters.TargetPath}' has no pointer down or pointer click handler.", Action = MouseAction.LongPress.ToString(), PositionX = inputPos.x, PositionY = inputPos.y
+                    Success = false,
+                    Message = $"TargetPath '{parameters.TargetPath}' has no pointer down or pointer click handler.",
+                    Action = MouseAction.LongPress.ToString(),
+                    PositionX = inputPos.x,
+                    PositionY = inputPos.y
                 };
             }
 
@@ -110,7 +129,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool hitTarget = resolvedTargets.Target != null;
             bool shouldReleasePointer = resolvedTargets.RawTarget != null && resolvedTargets.Target != null;
             SimulateMouseUiOverlayState.Update(
-                MouseAction.LongPress, inputPos, null, Handles.GetMainGameViewSize());
+                MouseAction.LongPress, inputPos, null,
+                Handles.GetMainGameViewSize());
 
             MouseUiFrameWaitOutcome expandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
             if (expandOutcome == MouseUiFrameWaitOutcome.TimedOut)
@@ -122,7 +142,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.LongPress, inputPos, targetName, "Long-press stopped because Unity paused during Pause Point inspection before pointerDown was dispatched. No pointer event was fired.");
+                    MouseAction.LongPress, inputPos, targetName,
+                    "Long-press stopped because Unity paused during Pause Point inspection before pointerDown was dispatched. No pointer event was fired.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -147,7 +168,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         // Returning here still runs the finally below, which releases pointerUp early.
                         cleanupScheduler.QueueOverlayClear();
                         return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                            MouseAction.LongPress, inputPos, targetName, "Long-press pointerDown was already dispatched. Unity paused during Pause Point inspection while holding; pointerUp was released early and the press duration was cut short.");
+                            MouseAction.LongPress, inputPos, targetName,
+                            "Long-press pointerDown was already dispatched. Unity paused during Pause Point inspection while holding; pointerUp was released early and the press duration was cut short.");
                     }
                     await MainThreadSwitcher.SwitchToMainThread(ct);
                     elapsed = Time.realtimeSinceStartup - startTime;
@@ -174,7 +196,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                    MouseAction.LongPress, inputPos, targetName, "Long-press was already completed (pointerDown and pointerUp both dispatched). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
+                    MouseAction.LongPress, inputPos, targetName,
+                    "Long-press was already completed (pointerDown and pointerUp both dispatched). Unity paused during Pause Point inspection while the overlay animation was still playing; only the animation was interrupted.");
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -182,7 +205,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         private static void ExecutePointerClickEvents(
-            ResolvedPointerTargets resolvedTargets, PointerEventData pointerData)
+            ResolvedPointerTargets resolvedTargets,
+            PointerEventData pointerData)
         {
             if (resolvedTargets.RawTarget == null)
             {
@@ -192,24 +216,31 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (resolvedTargets.PressTarget != null)
             {
                 ExecuteEvents.ExecuteHierarchy(
-                    resolvedTargets.RawTarget, pointerData, ExecuteEvents.pointerDownHandler);
+                    resolvedTargets.RawTarget,
+                    pointerData,
+                    ExecuteEvents.pointerDownHandler);
             }
 
             if (resolvedTargets.Target != null)
             {
                 ExecuteEvents.Execute(
-                    resolvedTargets.Target, pointerData, ExecuteEvents.pointerUpHandler);
+                    resolvedTargets.Target,
+                    pointerData,
+                    ExecuteEvents.pointerUpHandler);
             }
 
             if (resolvedTargets.ClickTarget != null)
             {
                 ExecuteEvents.Execute(
-                    resolvedTargets.ClickTarget, pointerData, ExecuteEvents.pointerClickHandler);
+                    resolvedTargets.ClickTarget,
+                    pointerData,
+                    ExecuteEvents.pointerClickHandler);
             }
         }
 
         private static void ExecuteLongPressPointerDown(
-            ResolvedPointerTargets resolvedTargets, PointerEventData pointerData)
+            ResolvedPointerTargets resolvedTargets,
+            PointerEventData pointerData)
         {
             if (resolvedTargets.RawTarget == null || resolvedTargets.Target == null)
             {
@@ -217,7 +248,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             ExecuteEvents.ExecuteHierarchy(
-                resolvedTargets.RawTarget, pointerData, ExecuteEvents.pointerDownHandler);
+                resolvedTargets.RawTarget,
+                pointerData,
+                ExecuteEvents.pointerDownHandler);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionStepMonitor.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionStepMonitor.cs
@@ -26,17 +26,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _isStarted = true;
         }
 
-        public void Stop()
-        {
-            if (!_isStarted)
-            {
-                return;
-            }
-
-            EditorApplication.update -= OnEditorUpdate;
-            _isStarted = false;
-        }
-
         private void OnEditorUpdate()
         {
             _registry.EvaluateIfFrameChanged();

--- a/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlayState.cs
+++ b/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlayState.cs
@@ -87,11 +87,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             LastActivityTime = Time.realtimeSinceStartup;
         }
 
-        public void ClearScroll()
-        {
-            _scrollActiveUntil = 0f;
-        }
-
         public void SetMoveDelta(Vector2 delta)
         {
             _moveAccumulator += delta;
@@ -157,11 +152,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public static void SetScrollDirection(int direction)
         {
             ServiceValue.SetScrollDirection(direction);
-        }
-
-        public static void ClearScroll()
-        {
-            ServiceValue.ClearScroll();
         }
 
         public static void SetMoveDelta(Vector2 delta)

--- a/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlayState.cs
+++ b/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlayState.cs
@@ -14,7 +14,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public MouseAction Action { get; private set; }
         public Vector2 CurrentPosition { get; private set; }
         public Vector2? DragStartPosition { get; private set; }
-        public string? HitGameObjectName { get; private set; }
 
         // Screen.width/height at the time positions were recorded (Editor context may differ from Game context)
         public Vector2 SourceScreenSize { get; private set; }
@@ -36,7 +35,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             MouseAction action,
             Vector2 currentPosition,
             Vector2? dragStartPosition,
-            string? hitGameObjectName,
             Vector2 sourceScreenSize)
         {
             // PlayDissipateAnimation calls Clear() on normal completion, but a cancelled or stuck drag
@@ -50,7 +48,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             Action = action;
             CurrentPosition = currentPosition;
             DragStartPosition = dragStartPosition;
-            HitGameObjectName = hitGameObjectName;
             SourceScreenSize = sourceScreenSize;
         }
 
@@ -113,7 +110,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             Action = default;
             CurrentPosition = Vector2.zero;
             DragStartPosition = null;
-            HitGameObjectName = null;
             SourceScreenSize = Vector2.zero;
             LongPressElapsed = 0f;
             _dragWaypoints.Clear();
@@ -132,7 +128,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public static MouseAction Action => ServiceValue.Action;
         public static Vector2 CurrentPosition => ServiceValue.CurrentPosition;
         public static Vector2? DragStartPosition => ServiceValue.DragStartPosition;
-        public static string? HitGameObjectName => ServiceValue.HitGameObjectName;
         public static Vector2 SourceScreenSize => ServiceValue.SourceScreenSize;
         public static float LongPressElapsed => ServiceValue.LongPressElapsed;
         public static IReadOnlyList<Vector2> DragWaypoints => ServiceValue.DragWaypoints;
@@ -141,10 +136,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             MouseAction action,
             Vector2 currentPosition,
             Vector2? dragStartPosition,
-            string? hitGameObjectName,
             Vector2 sourceScreenSize)
         {
-            ServiceValue.Update(action, currentPosition, dragStartPosition, hitGameObjectName, sourceScreenSize);
+            ServiceValue.Update(action, currentPosition, dragStartPosition, sourceScreenSize);
         }
 
         public static void UpdateLongPressElapsed(float elapsed)


### PR DESCRIPTION
## Summary

- Remove unreferenced FirstPartyTools / Runtime `PublicCandidate` members after Skill / CLI / reflection keep-checks (issue #1997 PR-5).
- Shrink production PC from **47 → 33**; FirstPartyTools+Runtime keepers left: **9**. HC remains **0**.
- Runtime deletions are limited to overlay-only dead API (`ClearScroll`, `HitGameObjectName` + `Update` arity); no extension-facing keepers removed.

## Decision table

### DELETE

| Symbol | Why |
|---|---|
| `ClearConsoleResponse(string)` / parameterless ctor | Outbound response; no production construction / JSON round-trip need |
| `LogEntry()` / `GetLogsResponse()` parameterless ctors | Same |
| `RunTestsResponse()` parameterless ctor | Same |
| `GameObjectDetails.ErrorMessage` | Never read or assigned in production |
| `InputRecorder.ForceStop()` (static facade) | Only instance path used; static unused |
| `UiRaycastHelper.RaycastCanvasSpace` | No callers; private `RaycastCanvasSpaceFromSources` still used |
| `ValidateNoDuplicateAsmdefNamesFromConsoleErrors` (+ console regex) | Dead alternate path; asset-scan validator remains |
| `KeyboardKeyState.Clear` (instance + static) | Unused; `ClearTrackedKeys` remains |
| `MouseInputState.IsButtonHeld` (instance + static) | Unused |
| `WatchExpressionStepMonitor.Stop` | Never called; monitor lifetime ends with domain |
| Runtime `SimulateMouseInputOverlayState.ClearScroll` (instance + static) | No callers; scroll still cleared via existing `Clear` / setter paths |
| Runtime `SimulateMouseUiOverlayState.HitGameObjectName` + `Update(..., hitName, ...)` | Write-only overlay field; response still carries `HitGameObjectName` via tool DTO |

Boy-scout after delete: removed unused `using UnityEngine` from asmdef validator; confirmed `_scrollActiveUntil` / `_isStarted` still have live readers; no sole-writer DI seams left behind.

### KEEP

| Symbol | Why |
|---|---|
| `FindGameObjectsSchema.IncludeInheritedProperties` | Skill + `default-tools.json` tool parameter |
| `UnifiedTestCallback.{Run,Test}{Started,Finished}` | Unity Test Runner `ICallbacks` (reflection) |
| `NUnitXmlResultExporter.Utf8StringWriter.Encoding` | Required `TextWriter` override |
| `ReferenceEqualityComparer.Equals` / `GetHashCode` | `HashSet` comparer contract |
| `GenericConsoleWindowUtility.GetConsoleLogCounts` | Used under `#else` (pre–Unity 6) |

## Verification

- [x] `scripts/check-dead-code.sh` → HC 0
- [x] `uloop compile` → 0 errors / 0 warnings
- [x] Focused EditMode (196) → Passed
- [x] Full EditMode → 2362 passed; **2 known failures** only (`NativeCliInstallerTests` / `ToolSkillSynchronizerTests`, #2001) — out of scope for PR-5

## Test plan

- [ ] CI dead-code + Unity compile jobs green
- [ ] Spot-check Simulate Mouse UI overlay still draws after `Update` arity change
- [ ] Confirm advisor LGTM on Runtime keep/delete split before merge to `chore/public-candidate-triage`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

