### PR TITLE
chore: Document that agents must not reformat unrelated C# code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ Comments in the code, commit messages, PR titles, and PR descriptions must all b
 
 Every test method must have a short comment that states what behavior the test verifies.
 
+Do not reformat unrelated code. Surgical edits must keep existing wrapping and layout; only
+change lines required by the task. Do not run C# formatters, IDE format-on-save, or rewrite
+scripts that collapse multi-line argument lists or object initializers into one-liners.
+
 ## CLI / Unity Package Compatibility
 
 Runtime compatibility between the Unity package and the native CLI is gated on an integer


### PR DESCRIPTION
## Summary

- Add a short AGENTS.md rule forbidding unrelated C# reformatting and collapse-only rewrite scripts.
- Split out of #2007 so PublicCandidate triage stays scoped and the agent-rule change has a clear history.

## Context

During PR-5 triage, an agent rewrite collapsed multi-line call sites into one-liners and made the real deletion unreviewable. The durable fix is an explicit agent instruction (`CLAUDE.md` is a symlink to `AGENTS.md`).

## Test plan

- [ ] Confirm the PR touches only `AGENTS.md` (+4 lines)
- [ ] Confirm wording matches the intended no-reformat / no-collapse-rewrite policy


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

