### PR TITLE
chore: Keep ShouldSerialize methods and gate PublicCandidate count

### DIFF
--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -45,3 +45,4 @@ jobs:
           --include-kept false
           --format table
           --fail-on high-confidence
+          --max-public-candidates 22

--- a/docs/dead-code-scanner.md
+++ b/docs/dead-code-scanner.md
@@ -23,17 +23,28 @@ dotnet run --project tools/UnityCliLoop.DeadCodeScanner -- --scope public --incl
 target `main` or `v3-beta` and touch `Packages/src/**/*.cs`, the scanner
 itself, its tests, `scripts/check-dead-code.sh`, or the workflow file.
 
-The gate uses `--fail-on high-confidence`, so CI fails only for
-`Unused`, `UnusedPrivateMember`, and `UnusedLocal`.
+The workflow combines two independent failure conditions (either one exits 1):
 
-`PublicCandidate` and `TestOnly` do not fail CI. Those findings need
-manual review of non-C# references and cannot be decided mechanically.
+- `--fail-on high-confidence` fails immediately on `Unused`,
+  `UnusedPrivateMember`, and `UnusedLocal`. These are delete-ready findings.
+- `--max-public-candidates <n>` fails when the `PublicCandidate` count exceeds
+  `n`. This is a ceiling monitor for symbols that still need human review; it
+  does not auto-delete them. `TestOnly` findings are outside this limit.
+
+Set `<n>` to the measured `PublicCandidate` count after triage, with no slack.
+PRs that raise the count should be rejected unless they also raise the gate
+value for a documented reason. When triage lowers the count, lower `<n>` in
+the same change.
+
+Negative `--max-public-candidates` values, or omitting the option, disable the
+ceiling check.
 
 ## Interpreting the output
 
 Interpret scanner output conservatively:
 
 - `KeptByUnityOrReflection` usually means the symbol is intentionally reachable through Unity callbacks, attributes, serialization, or reflection-style discovery. Do not add explanatory comments for every such symbol when the attribute/base type already makes the reason obvious.
+- Framework conventions that the compiler or serializer resolve by name are classified as `KeptByUnityOrReflection` by the scanner (`await` pattern members, the `IsExternalInit` polyfill, and Newtonsoft `ShouldSerialize{Property}` methods). Do not treat those as `PublicCandidate` triage items.
 - `PublicCandidate` means Roslyn found no direct references. Check non-C# references such as `release-please-config.json`, checked-in JSON contracts, Unity assets, generated files, and documented public APIs before removing or commenting the symbol.
 - If a symbol is referenced only by non-C# tooling, verify that the tool reads it for runtime or release behavior. If the tool only rewrites the symbol and no code reads it, remove the marker instead of documenting it.
 

--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/CommandLineOptionsTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/CommandLineOptionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using UnityCliLoop.DeadCodeScanner;
 
@@ -23,6 +24,40 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
 
             Assert.That(highConfidenceOptions.FailOnHighConfidence, Is.True);
             Assert.That(noneOptions.FailOnHighConfidence, Is.False);
+        }
+
+        // Verifies that --max-public-candidates parses integers and defaults to unlimited (-1).
+        [Test]
+        public void Parse_WhenMaxPublicCandidatesIsProvidedOrOmitted_ShouldSetLimitOrLeaveUnlimited()
+        {
+            ScanOptions limitedOptions = CommandLineOptions.Parse(new[]
+            {
+                "--max-public-candidates",
+                "22"
+            });
+            ScanOptions defaultOptions = CommandLineOptions.Parse(Array.Empty<string>());
+            ScanOptions negativeOptions = CommandLineOptions.Parse(new[]
+            {
+                "--max-public-candidates",
+                "-1"
+            });
+
+            Assert.That(limitedOptions.MaxPublicCandidates, Is.EqualTo(22));
+            Assert.That(defaultOptions.MaxPublicCandidates, Is.EqualTo(-1));
+            Assert.That(negativeOptions.MaxPublicCandidates, Is.EqualTo(-1));
+        }
+
+        // Verifies that a non-integer --max-public-candidates value is rejected.
+        [Test]
+        public void Parse_WhenMaxPublicCandidatesIsNotInteger_ShouldThrow()
+        {
+            Assert.That(
+                () => CommandLineOptions.Parse(new[]
+                {
+                    "--max-public-candidates",
+                    "abc"
+                }),
+                Throws.ArgumentException);
         }
     }
 }

--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
@@ -69,7 +69,8 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 includeTestOnly: true,
                 includeKept: false,
                 ReportFormat.Table,
-                failOnHighConfidence: false);
+                failOnHighConfidence: false,
+                maxPublicCandidates: -1);
 
             System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
                 await scanner.ScanAsync(options, CancellationToken.None);
@@ -97,7 +98,8 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 includeTestOnly: true,
                 includeKept: false,
                 ReportFormat.Table,
-                failOnHighConfidence: false);
+                failOnHighConfidence: false,
+                maxPublicCandidates: -1);
 
             System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
                 await scanner.ScanAsync(options, CancellationToken.None);
@@ -134,7 +136,8 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 includeTestOnly: true,
                 includeKept: true,
                 ReportFormat.Table,
-                failOnHighConfidence: false);
+                failOnHighConfidence: false,
+                maxPublicCandidates: -1);
 
             System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
                 await scanner.ScanAsync(options, CancellationToken.None);
@@ -269,6 +272,27 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 && issue.FullName.Contains("IsExternalInit", StringComparison.Ordinal)), Is.False);
         }
 
+        /// <summary>
+        /// Verifies that Newtonsoft ShouldSerialize{Property} methods are kept as
+        /// KeptByUnityOrReflection and are not reported as PublicCandidate.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenShouldSerializeMethodHasNoDirectReferences_ShouldReportKeptAndNotPublicCandidate()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: true);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("ShouldSerializeOptionalNote", StringComparison.Ordinal)), Is.True);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("ShouldSerializeOptionalNote", StringComparison.Ordinal)), Is.False);
+        }
+
         private static ScanOptions CreatePublicScopeOptions(string rootPath, bool includeKept)
         {
             return new ScanOptions(
@@ -280,7 +304,8 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 includeTestOnly: true,
                 includeKept,
                 ReportFormat.Table,
-                failOnHighConfidence: false);
+                failOnHighConfidence: false,
+                maxPublicCandidates: -1);
         }
 
         private static void CreateSampleRepository(string rootPath)
@@ -362,6 +387,16 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
 
                     public sealed class UnreferencedPublicApi
                     {
+                    }
+
+                    public sealed class JsonOptionalPayload
+                    {
+                        public string OptionalNote { get; set; } = string.Empty;
+
+                        public bool ShouldSerializeOptionalNote()
+                        {
+                            return !string.IsNullOrEmpty(OptionalNote);
+                        }
                     }
 
                     public sealed class TestOnlyFactory

--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
@@ -293,6 +293,26 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 && issue.FullName.Contains("ShouldSerializeOptionalNote", StringComparison.Ordinal)), Is.False);
         }
 
+        /// <summary>
+        /// Verifies that a ShouldSerialize* method without a matching property/field is not kept.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenShouldSerializeMethodHasNoMatchingMember_ShouldNotReportKept()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: true);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("ShouldSerializeMissingMember", StringComparison.Ordinal)), Is.False);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("ShouldSerializeMissingMember", StringComparison.Ordinal)), Is.True);
+        }
+
         private static ScanOptions CreatePublicScopeOptions(string rootPath, bool includeKept)
         {
             return new ScanOptions(
@@ -396,6 +416,11 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                         public bool ShouldSerializeOptionalNote()
                         {
                             return !string.IsNullOrEmpty(OptionalNote);
+                        }
+
+                        public bool ShouldSerializeMissingMember()
+                        {
+                            return false;
                         }
                     }
 

--- a/tools/UnityCliLoop.DeadCodeScanner/CommandLineOptions.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/CommandLineOptions.cs
@@ -20,6 +20,7 @@ namespace UnityCliLoop.DeadCodeScanner
             bool includeKept = defaults.IncludeKept;
             ReportFormat format = defaults.Format;
             bool failOnHighConfidence = defaults.FailOnHighConfidence;
+            int maxPublicCandidates = defaults.MaxPublicCandidates;
 
             for (int index = 0; index < args.Length; index++)
             {
@@ -78,6 +79,14 @@ namespace UnityCliLoop.DeadCodeScanner
                     continue;
                 }
 
+                if (argument == "--max-public-candidates")
+                {
+                    maxPublicCandidates = ParseMaxPublicCandidates(
+                        ReadValue(args, ref index, argument),
+                        argument);
+                    continue;
+                }
+
                 if (argument == "--help" || argument == "-h")
                 {
                     throw new ArgumentException(CreateHelpText());
@@ -95,7 +104,8 @@ namespace UnityCliLoop.DeadCodeScanner
                 includeTestOnly,
                 includeKept,
                 format,
-                failOnHighConfidence);
+                failOnHighConfidence,
+                maxPublicCandidates);
         }
 
         public static string CreateHelpText()
@@ -113,7 +123,9 @@ namespace UnityCliLoop.DeadCodeScanner
                 "  --include-test-only true|false   Include test-only findings. Defaults to true.",
                 "  --include-kept true|false        Include Unity/reflection-kept findings. Defaults to false.",
                 "  --format table|json              Output format. Defaults to table.",
-                "  --fail-on none|high-confidence   Exit 1 for high confidence findings.");
+                "  --fail-on none|high-confidence   Exit 1 for high confidence findings.",
+                "  --max-public-candidates <n>      Exit 1 when PublicCandidate count exceeds n.",
+                "                                   Negative or omitted disables the limit.");
         }
 
         private static string ReadValue(string[] args, ref int index, string optionName)
@@ -179,6 +191,16 @@ namespace UnityCliLoop.DeadCodeScanner
             }
 
             throw new ArgumentException($"Unsupported fail-on value '{value}'.");
+        }
+
+        private static int ParseMaxPublicCandidates(string value, string optionName)
+        {
+            if (!int.TryParse(value.Trim(), out int parsed))
+            {
+                throw new ArgumentException($"{optionName} expects an integer.");
+            }
+
+            return parsed;
         }
 
         private static bool ParseBoolean(string value, string optionName)

--- a/tools/UnityCliLoop.DeadCodeScanner/DeadCodeModels.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/DeadCodeModels.cs
@@ -50,6 +50,11 @@ namespace UnityCliLoop.DeadCodeScanner
         public ReportFormat Format { get; }
         public bool FailOnHighConfidence { get; }
 
+        /// <summary>
+        /// Maximum allowed PublicCandidate count. Negative means no limit.
+        /// </summary>
+        public int MaxPublicCandidates { get; }
+
         public ScanOptions(
             string rootPath,
             ScanScope scope,
@@ -59,7 +64,8 @@ namespace UnityCliLoop.DeadCodeScanner
             bool includeTestOnly,
             bool includeKept,
             ReportFormat format,
-            bool failOnHighConfidence)
+            bool failOnHighConfidence,
+            int maxPublicCandidates)
         {
             RootPath = rootPath;
             Scope = scope;
@@ -70,6 +76,7 @@ namespace UnityCliLoop.DeadCodeScanner
             IncludeKept = includeKept;
             Format = format;
             FailOnHighConfidence = failOnHighConfidence;
+            MaxPublicCandidates = maxPublicCandidates;
         }
 
         public static ScanOptions Default(string rootPath)
@@ -83,7 +90,8 @@ namespace UnityCliLoop.DeadCodeScanner
                 includeTestOnly: true,
                 includeKept: false,
                 ReportFormat.Table,
-                failOnHighConfidence: false);
+                failOnHighConfidence: false,
+                maxPublicCandidates: -1);
         }
     }
 

--- a/tools/UnityCliLoop.DeadCodeScanner/Program.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/Program.cs
@@ -29,7 +29,13 @@ namespace UnityCliLoop.DeadCodeScanner
             IReadOnlyList<DeadCodeIssue> issues = await scanner.ScanAsync(options, ct);
             DeadCodeReporter.Write(issues, options);
 
-            if (options.FailOnHighConfidence && issues.Any(issue => issue.IsHighConfidenceDeletionCandidate()))
+            bool failedOnHighConfidence = options.FailOnHighConfidence
+                && issues.Any(issue => issue.IsHighConfidenceDeletionCandidate());
+            bool failedOnPublicCandidateLimit = options.MaxPublicCandidates >= 0
+                && issues.Count(issue => issue.Category == DeadCodeCategory.PublicCandidate)
+                    > options.MaxPublicCandidates;
+
+            if (failedOnHighConfidence || failedOnPublicCandidateLimit)
             {
                 return 1;
             }

--- a/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
@@ -191,11 +191,6 @@ namespace UnityCliLoop.DeadCodeScanner
 
             // Why: Newtonsoft only invokes ShouldSerialize{PropertyName} when that member exists.
             // Keeping every ShouldSerialize* name would let dead methods silence the scanner.
-            if (methodSymbol.ContainingType == null)
-            {
-                return false;
-            }
-
             string propertyName = methodSymbol.Name.Substring(Prefix.Length);
             return methodSymbol.ContainingType.GetMembers(propertyName)
                 .Any(member => member is IPropertySymbol || member is IFieldSymbol);

--- a/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
@@ -183,8 +183,22 @@ namespace UnityCliLoop.DeadCodeScanner
             }
 
             const string Prefix = "ShouldSerialize";
-            return methodSymbol.Name.StartsWith(Prefix, StringComparison.Ordinal)
-                && methodSymbol.Name.Length > Prefix.Length;
+            if (!methodSymbol.Name.StartsWith(Prefix, StringComparison.Ordinal)
+                || methodSymbol.Name.Length <= Prefix.Length)
+            {
+                return false;
+            }
+
+            // Why: Newtonsoft only invokes ShouldSerialize{PropertyName} when that member exists.
+            // Keeping every ShouldSerialize* name would let dead methods silence the scanner.
+            if (methodSymbol.ContainingType == null)
+            {
+                return false;
+            }
+
+            string propertyName = methodSymbol.Name.Substring(Prefix.Length);
+            return methodSymbol.ContainingType.GetMembers(propertyName)
+                .Any(member => member is IPropertySymbol || member is IFieldSymbol);
         }
 
         private static bool IsAwaiterType(ITypeSymbol typeSymbol)

--- a/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
@@ -91,6 +91,14 @@ namespace UnityCliLoop.DeadCodeScanner
                     "Member is part of the compiler-bound awaiter pattern.");
             }
 
+            // Why: Newtonsoft.Json discovers ShouldSerialize{Property} by name convention and
+            // invokes it via reflection, so reference search never sees call sites.
+            if (IsNewtonsoftShouldSerializeMethod(symbol))
+            {
+                return KeeperDecision.Keep(
+                    "Method matches the Newtonsoft.Json ShouldSerialize{Property} naming convention.");
+            }
+
             if (symbol is INamedTypeSymbol namedType && HasKeptBaseType(namedType))
             {
                 return KeeperDecision.Keep("Type derives from a Unity entry-point base class.");
@@ -155,6 +163,28 @@ namespace UnityCliLoop.DeadCodeScanner
             }
 
             return IsAwaiterType(symbol.ContainingType);
+        }
+
+        private static bool IsNewtonsoftShouldSerializeMethod(ISymbol symbol)
+        {
+            if (symbol is not IMethodSymbol methodSymbol)
+            {
+                return false;
+            }
+
+            if (methodSymbol.IsStatic || methodSymbol.Parameters.Length != 0)
+            {
+                return false;
+            }
+
+            if (methodSymbol.ReturnType.SpecialType != SpecialType.System_Boolean)
+            {
+                return false;
+            }
+
+            const string Prefix = "ShouldSerialize";
+            return methodSymbol.Name.StartsWith(Prefix, StringComparison.Ordinal)
+                && methodSymbol.Name.Length > Prefix.Length;
         }
 
         private static bool IsAwaiterType(ITypeSymbol typeSymbol)


### PR DESCRIPTION
## Summary

- Classify Newtonsoft `ShouldSerialize{Property}` methods as `KeptByUnityOrReflection` (name-convention reflection).
- Add `--max-public-candidates <n>` and pin CI to the measured post-PR-6/PR-7 count of **22**.
- Document HC vs PC gate roles and framework keep conventions in `docs/dead-code-scanner.md`.

## Verification

- [x] Pre-change baseline after PR-6 merge: PC **28** (6× `ShouldSerialize*`)
- [x] Post-change: PC **22**, `ShouldSerialize*` no longer PublicCandidate
- [x] `dotnet test tests/UnityCliLoop.DeadCodeScanner.Tests/...` → 14 passed (includes `includeKept: true` assert for `ShouldSerializeOptionalNote`)
- [x] `--max-public-candidates 22` → exit 0
- [x] `--max-public-candidates 21` → exit 1

## Test plan

- [ ] CI Dead Code job green (scanner tests + scan with limit 22)
- [ ] Confirm docs explain HC fail-fast vs PC ceiling, and list await / IsExternalInit / ShouldSerialize keeps


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

