### PR TITLE
chore: Finish PublicCandidate triage and gate residual count

### DIFF
--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -45,3 +45,4 @@ jobs:
           --include-kept false
           --format table
           --fail-on high-confidence
+          --max-public-candidates 22

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionFacadeTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionFacadeTests.cs
@@ -183,11 +183,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 };
             }
 
-            public ExecutionStatistics GetStatistics()
-            {
-                return new ExecutionStatistics();
-            }
-
             public void Dispose()
             {
                 DisposeCallCount++;

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutorPoolTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutorPoolTests.cs
@@ -130,11 +130,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 });
             }
 
-            public ExecutionStatistics GetStatistics()
-            {
-                return new ExecutionStatistics();
-            }
-
             public void Dispose()
             {
                 DisposeCallCount++;

--- a/Assets/Tests/Editor/MouseUiMainThreadCleanupSchedulerTests.cs
+++ b/Assets/Tests/Editor/MouseUiMainThreadCleanupSchedulerTests.cs
@@ -43,7 +43,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 MouseAction.Click,
                 new Vector2(10f, 20f),
                 null,
-                "Target",
                 new Vector2(100f, 200f));
             MouseUiMainThreadCleanupScheduler scheduler = new();
             scheduler.CaptureMainThreadContext();

--- a/Packages/src/Editor/Application/CliSetupApplicationService.cs
+++ b/Packages/src/Editor/Application/CliSetupApplicationService.cs
@@ -155,11 +155,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
             return _cliInstallationDetector.IsCliVisibleFromShellAsync(platform, ct);
         }
 
-        public void InvalidateCliCache()
-        {
-            _cliInstallationDetector.InvalidateCache();
-        }
-
         public string GetMinimumRequiredCliVersion()
         {
             // Why: v3 setup installs the global dispatcher and reads the minimum from the package pin JSON
@@ -177,26 +172,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
         public bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform)
         {
             return _nativeCliInstaller.HasPackageOwnedCurrentUserInstall(platform);
-        }
-
-        public bool IsCliVersionLessThan(string leftVersion, string rightVersion)
-        {
-            return CliVersionComparer.IsVersionLessThan(leftVersion, rightVersion);
-        }
-
-        public bool IsCliVersionGreaterThan(string leftVersion, string rightVersion)
-        {
-            return CliVersionComparer.IsVersionGreaterThan(leftVersion, rightVersion);
-        }
-
-        public bool IsCliVersionGreaterThanOrEqual(string leftVersion, string rightVersion)
-        {
-            return CliVersionComparer.IsVersionGreaterThanOrEqual(leftVersion, rightVersion);
-        }
-
-        public bool IsCliVersionEqual(string leftVersion, string rightVersion)
-        {
-            return CliVersionComparer.IsVersionEqual(leftVersion, rightVersion);
         }
 
         public async Task<CliInstallResult> InstallGlobalCliAsync(

--- a/Packages/src/Editor/Application/UnityCliLoopServerApplicationService.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopServerApplicationService.cs
@@ -61,10 +61,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
         void AddServerStateChangedHandler(Action handler);
 
         void RemoveServerStateChangedHandler(Action handler);
-
-        void AddServerStartedHandler(Action handler);
-
-        void RemoveServerStartedHandler(Action handler);
     }
 
     /// <summary>
@@ -234,16 +230,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
         public void RemoveServerStateChangedHandler(Action handler)
         {
             _controller.RemoveServerStateChangedHandler(handler);
-        }
-
-        public void AddServerStartedHandler(Action handler)
-        {
-            _controller.AddServerStartedHandler(handler);
-        }
-
-        public void RemoveServerStartedHandler(Action handler)
-        {
-            _controller.RemoveServerStartedHandler(handler);
         }
     }
 }

--- a/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
@@ -142,16 +142,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
             ServiceValue = service ?? throw new ArgumentNullException(nameof(service));
         }
 
-        internal static void AddToolsChangedHandler(Action handler)
-        {
-            Service.OnToolsChanged += handler;
-        }
-
-        internal static void RemoveToolsChangedHandler(Action handler)
-        {
-            Service.OnToolsChanged -= handler;
-        }
-
         public static UnityCliLoopToolRegistrarService Service
         {
             get

--- a/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
@@ -174,20 +174,5 @@ namespace io.github.hatayama.UnityCliLoop.Application
         {
             return Service.IsCustomToolRegistered(toolName);
         }
-
-        public static UnityCliLoopToolRegistry TryGetRegistry()
-        {
-            return Service.TryGetRegistry();
-        }
-
-        public static string GetDebugInfo()
-        {
-            return Service.GetDebugInfo();
-        }
-
-        public static void NotifyToolChanges()
-        {
-            Service.NotifyToolChanges();
-        }
     }
 }

--- a/Packages/src/Editor/Application/UnityCliLoopUIConstants.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopUIConstants.cs
@@ -8,7 +8,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
     {
         // Tool Settings
         public const string TOOL_SETTINGS_MENU_PATH = "Window > Unity CLI Loop > Settings";
-        public const string CLI_COMMAND_REFERENCE_URL = "https://github.com/hatayama/unity-cli-loop#direct-cli-usage-advanced";
         public const string PROJECT_REPOSITORY_URL = "https://github.com/hatayama/unity-cli-loop";
     }
 }

--- a/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
@@ -22,13 +22,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
             _migrationPort = migrationPort ?? throw new ArgumentNullException(nameof(migrationPort));
         }
 
-        public ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            return _migrationPort.PreviewMigration(projectRoot);
-        }
-
         public Task<ThirdPartyToolMigrationPreview> PreviewMigrationAsync(
             string projectRoot,
             IProgress<ThirdPartyToolMigrationProgress> progress,
@@ -53,13 +46,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
             return _migrationPort.HasMigrationTargetsAsync(projectRoot, ct);
-        }
-
-        public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            return _migrationPort.ApplyMigration(projectRoot);
         }
 
         public Task<ThirdPartyToolMigrationResult> ApplyMigrationAsync(

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -32,14 +32,11 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string POSIX_PATH_SEPARATOR = ":";
         public const string WINDOWS_PATH_SEPARATOR = ";";
         public const string DISPATCHER_RELEASE_TAG_PREFIX = "dispatcher-v";
-        public const string BETA_VERSION_MARKER = "-beta.";
         public const string SKILL_DIR_PREFIX = "uloop-";
         public const string TEMPORARY_SKILLS_DIR_NAME = "TemporarySkills~";
         public const string V3_CLI_INVOCATION_MIGRATION_SKILL_NAME = "v3-cli-invocation-migration";
         public const string UNITY_PACKAGES_DIR_NAME = "Packages";
         public const string PACKAGE_SOURCE_DIR_NAME = "src";
-        public const string CLI_LAYOUT_CONTRACT_FILE_NAME = "layout-contract.json";
-        public const string CLI_CONTRACT_FILE_NAME = "contract.json";
         public const string GLOBAL_UNIX_COMMAND_NAME = EXECUTABLE_NAME;
         public const string GLOBAL_WINDOWS_COMMAND_NAME = EXECUTABLE_NAME + ".exe";
     }

--- a/Packages/src/Editor/Domain/IUnityCliLoopEditorSettingsPort.cs
+++ b/Packages/src/Editor/Domain/IUnityCliLoopEditorSettingsPort.cs
@@ -12,10 +12,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         void SaveSettings(UnityCliLoopEditorSettingsData settings);
         void UpdateSettings(Func<UnityCliLoopEditorSettingsData, UnityCliLoopEditorSettingsData> transform);
         string GetLastSeenSetupWizardVersion();
-        void SetLastSeenSetupWizardVersion(string version);
         bool GetSuppressSetupWizardAutoShow();
         void SetSuppressSetupWizardAutoShow(bool suppressAutoShow);
-        void SetShowUnityCliLoopSecuritySetting(bool showUnityCliLoopSecuritySetting);
         void SetShowToolSettings(bool showToolSettings);
         void SetInstallSkillsFlat(bool installSkillsFlat);
     }

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationApiDetectionRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationApiDetectionRules.cs
@@ -188,32 +188,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             return RegexMatchesCode(source, CurrentToolContractsNamespaceRegex);
         }
 
-        public static bool ContainsLegacyDomainMetadataApi(string source)
-        {
-            Debug.Assert(source != null, "source must not be null");
-
-            return RegexMatchesCode(source, LegacyDomainMetadataRegex) ||
-                ContainsLegacyDomainHelperApiForAssembly(
-                    source,
-                    hasLegacyAssemblySource: ContainsLegacyToolMigrationMarker(source),
-                    legacyAssemblyAliases: Array.Empty<string>());
-        }
-
-        public static bool ContainsLegacyDomainHelperApiForAssembly(
-            string source,
-            bool hasLegacyAssemblySource,
-            string[] legacyAssemblyAliases)
-        {
-            Debug.Assert(source != null, "source must not be null");
-            Debug.Assert(legacyAssemblyAliases != null, "legacyAssemblyAliases must not be null");
-
-            string[] legacyNamespaceAliases = GetCombinedLegacyNamespaceAliases(source, legacyAssemblyAliases);
-            return ContainsLegacyDomainHelperReference(
-                source,
-                hasLegacyAssemblySource,
-                legacyNamespaceAliases);
-        }
-
         public static bool ContainsCurrentDomainMetadataApi(string source)
         {
             Debug.Assert(source != null, "source must not be null");
@@ -324,19 +298,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 canMigrateBareLegacyEditorWindowCaptureUtility,
                 assemblyDeclaredTypeNames,
                 requiresTimeoutArgumentMigration: true);
-        }
-
-        public static bool ContainsCurrentFirstPartyScreenshotApi(string source)
-        {
-            Debug.Assert(source != null, "source must not be null");
-
-            bool hasCurrentFirstPartyToolsNamespaceUsage =
-                RegexMatchesCode(source, CurrentFirstPartyToolsNamespaceRegex);
-            return ContainsCurrentFirstPartyScreenshotApiForAssembly(
-                source,
-                hasCurrentFirstPartyToolsNamespaceUsage,
-                Array.Empty<string>(),
-                Array.Empty<string>());
         }
 
         public static bool ContainsCurrentFirstPartyScreenshotApiForAssembly(

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationDomainDetectionRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationDomainDetectionRules.cs
@@ -158,14 +158,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             return false;
         }
 
-        public static bool ContainsCurrentDomainHelperApi(string source)
-        {
-            Debug.Assert(source != null, "source must not be null");
-
-            bool hasCurrentDomainNamespaceUsage = RegexMatchesCode(source, CurrentDomainNamespaceRegex);
-            return ContainsCurrentDomainHelperApiForAssembly(source, hasCurrentDomainNamespaceUsage);
-        }
-
         public static bool ContainsCurrentDomainHelperApiForAssembly(
             string source,
             bool canUseBareCurrentDomainType)

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationDomainDetectionRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationDomainDetectionRules.cs
@@ -158,43 +158,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             return false;
         }
 
-        public static bool ContainsLegacyDomainHelperReference(
-            string source,
-            bool canMigrateBareLegacyDomainHelper,
-            string[] aliases)
-        {
-            Debug.Assert(source != null, "source must not be null");
-            Debug.Assert(aliases != null, "aliases must not be null");
-
-            CodeTextMask codeTextMask = CodeTextMask.Create(source);
-            foreach (TypeReplacementRule rule in DomainTypeReplacementRules)
-            {
-                Regex fullyQualifiedRegex = new(
-                    $@"(?:(?:global::)?{Regex.Escape(LegacyNamespace)}\.){Regex.Escape(rule.LegacyName)}\b",
-                    RegexOptions.Compiled);
-                if (RegexMatchesCode(source, fullyQualifiedRegex))
-                {
-                    return true;
-                }
-
-                foreach (string alias in aliases)
-                {
-                    if (ContainsAliasQualifiedName(source, alias, rule.LegacyName))
-                    {
-                        return true;
-                    }
-                }
-
-                if (canMigrateBareLegacyDomainHelper &&
-                    ContainsLegacyAssemblyScopedTypeName(source, codeTextMask, rule.LegacyName))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         public static bool ContainsCurrentDomainHelperApi(string source)
         {
             Debug.Assert(source != null, "source must not be null");

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleCatalog.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleCatalog.cs
@@ -33,7 +33,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string DescriptionAttributeArgumentName = "Description";
         public const string DisplayDevelopmentOnlyAttributeArgumentName = "DisplayDevelopmentOnly";
         public const string RequiredSecuritySettingAttributeArgumentName = "RequiredSecuritySetting";
-        public const string LegacySecuritySettingsTypeName = "SecuritySettings";
         public const string CurrentSecuritySettingTypeName = "UnityCliLoopSecuritySetting";
         public const string LegacyEditorDelayTypeName = "EditorDelay";
         public const string LegacyEditorDelayMethodName = "DelayFrame";

--- a/Packages/src/Editor/FirstPartyTools/ClearConsole/ClearConsoleResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ClearConsole/ClearConsoleResponse.cs
@@ -41,28 +41,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Message = message ?? string.Empty;
             ErrorMessage = string.Empty;
         }
-
-        /// <summary>
-        /// Create a new ClearConsoleResponse for failed operation
-        /// </summary>
-        public ClearConsoleResponse(string errorMessage)
-        {
-            Success = false;
-            ClearedLogCount = 0;
-            ClearedCounts = new ClearedLogCounts();
-            Message = string.Empty;
-            ErrorMessage = errorMessage ?? string.Empty;
-        }
-
-        /// <summary>
-        /// Parameterless constructor for JSON deserialization
-        /// </summary>
-        public ClearConsoleResponse()
-        {
-            ClearedCounts = new ClearedLogCounts();
-            Message = string.Empty;
-            ErrorMessage = string.Empty;
-        }
     }
 
     /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecorder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecorder.cs
@@ -234,11 +234,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ServiceValue.NotifyRecordingStopped();
         }
 
-        public static void ForceStop()
-        {
-            ServiceValue.ForceStop();
-        }
-
         internal static string FormatVector2(Vector2 v)
         {
             return InputRecordingVectorFormat.FormatVector2(v);

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayUiController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayUiController.cs
@@ -83,7 +83,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     MouseAction.Click,
                     replayFrame.InputPosition,
                     null,
-                    _currentPressTarget?.name,
                     replayFrame.GameViewSize);
                 SimulateMouseUiOverlayState.RequestExpandAnimation();
                 return;
@@ -104,7 +103,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     MouseAction.Click,
                     replayFrame.InputPosition,
                     null,
-                    null,
                     replayFrame.GameViewSize);
             }
         }
@@ -122,7 +120,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     MouseAction.Drag,
                     replayFrame.InputPosition,
                     pressInputPos,
-                    null,
                     replayFrame.GameViewSize);
                 return;
             }
@@ -137,7 +134,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 MouseAction.LongPress,
                 replayFrame.InputPosition,
                 null,
-                _currentPressTarget?.name,
                 replayFrame.GameViewSize);
             SimulateMouseUiOverlayState.UpdateLongPressElapsed(elapsed);
         }

--- a/Packages/src/Editor/FirstPartyTools/Common/MouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/MouseUi/UiRaycastHelper.cs
@@ -18,14 +18,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return context.Raycast(screenPosition);
         }
 
-        // Bypass EventSystem's Screen-bounds clipping by directly testing Graphic rects in Canvas space.
-        // Only supports ScreenSpaceOverlay canvases where world positions equal Canvas-space positions.
-        public static RaycastResult? RaycastCanvasSpace(Vector2 canvasPosition)
-        {
-            List<CanvasRaycastSource> canvasRaycastSources = CollectCanvasRaycastSources();
-            return RaycastCanvasSpaceFromSources(canvasPosition, canvasRaycastSources);
-        }
-
         private static List<CanvasRaycastSource> CollectCanvasRaycastSources()
         {
 #if UNITY_6000_4_OR_NEWER

--- a/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionDuplicationValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionDuplicationValidationService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEditorInternal;
-using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -17,88 +16,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private static readonly Regex AsmdefNameRegex =
             new("\"name\"\\s*:\\s*\"(?<name>[^\"]+)\"", RegexOptions.Compiled);
-
-        private static readonly Regex DuplicateAsmdefConsoleRegex = new(
-            "^Assembly with name '(?<name>[^']+)' already exists \\((?<path>[^)]+)\\)$",
-            RegexOptions.Compiled
-        );
-
-        public ValidationResult ValidateNoDuplicateAsmdefNamesFromConsoleErrors()
-        {
-            LogRetrievalService retrievalService = new();
-            LogDisplayDto logData = retrievalService.GetLogsWithSearch(
-                UnityCliLoopLogType.Error,
-                "Assembly with name '",
-                useRegex: false,
-                searchInStackTrace: false
-            );
-
-            Dictionary<string, List<string>> pathsByAsmName = new(StringComparer.Ordinal);
-
-            foreach (LogEntryDto entry in logData.LogEntries)
-            {
-                if (string.IsNullOrEmpty(entry.Message))
-                {
-                    continue;
-                }
-
-                Match match = DuplicateAsmdefConsoleRegex.Match(entry.Message.Trim());
-                if (!match.Success)
-                {
-                    continue;
-                }
-
-                string asmName = match.Groups["name"].Value;
-                string assetPath = match.Groups["path"].Value;
-                if (string.IsNullOrEmpty(asmName) || string.IsNullOrEmpty(assetPath))
-                {
-                    continue;
-                }
-
-                // Prevent false positives from stale console logs by verifying the asset still exists.
-                UnityEngine.Object obj = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath);
-                if (obj == null)
-                {
-                    continue;
-                }
-
-                if (!pathsByAsmName.TryGetValue(asmName, out List<string> paths))
-                {
-                    paths = new List<string>();
-                    pathsByAsmName.Add(asmName, paths);
-                }
-
-                if (!paths.Contains(assetPath))
-                {
-                    paths.Add(assetPath);
-                }
-            }
-
-            if (pathsByAsmName.Count == 0)
-            {
-                return ValidationResult.Success();
-            }
-
-            string details = string.Join(
-                "\n",
-                pathsByAsmName
-                    .OrderBy(kvp => kvp.Key, StringComparer.Ordinal)
-                    .Take(5)
-                    .Select(d =>
-                    {
-                        string paths = string.Join("\n  ", d.Value.Take(8));
-                        return $"- {d.Key}\n  {paths}";
-                    })
-            );
-
-            string message =
-                $"{UnityCliLoopConstants.ERROR_MESSAGE_DUPLICATE_ASMDEF}\n" +
-                "Detected from Console errors:\n" +
-                $"{details}\n" +
-                "Fix: ensure each .asmdef has a unique \"name\".";
-
-            return ValidationResult.Failure(message);
-        }
 
         public ValidationResult ValidateNoDuplicateAsmdefNames()
         {

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/CompilationRequest.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/CompilationRequest.cs
@@ -38,9 +38,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public enum AssemblyLoadingMode
     {
-        /// <summary>Reference only selected assemblies</summary>
-        SelectiveReference,
-        
         /// <summary>Add all assemblies</summary>
         AllAssemblies
     }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/CompilationResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/CompilationResult.cs
@@ -63,12 +63,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         None,
 
         /// <summary>Compilation Error</summary>
-        CompilationError,
-
-        /// <summary>Dynamic Assembly Addition Failed</summary>
-        DynamicAssemblyFailed,
-
-        /// <summary>Using Statement Addition Failed</summary>
-        UsingStatementFailed
+        CompilationError
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/DynamicCompilationHealthMonitor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/DynamicCompilationHealthMonitor.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Threading;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -13,7 +12,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private static readonly object ReportedIssueLock = new();
         private static readonly HashSet<string> ReportedIssues = new(System.StringComparer.Ordinal);
-        private static readonly AsyncLocal<string> ConsoleDiagnosticSource = new();
 
         public static void ReportFastPathUnavailable(
             string editorPath,
@@ -91,11 +89,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string humanNote,
             string aiTodo)
         {
-            string effectiveIssueKey = CreateEffectiveIssueKey(issueKey);
-
             lock (ReportedIssueLock)
             {
-                if (!ReportedIssues.Add(effectiveIssueKey))
+                if (!ReportedIssues.Add(issueKey))
                 {
                     return;
                 }
@@ -116,11 +112,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string message,
             object context)
         {
-            string effectiveIssueKey = CreateEffectiveIssueKey(issueKey);
-
             lock (ReportedIssueLock)
             {
-                if (!ReportedIssues.Add(effectiveIssueKey))
+                if (!ReportedIssues.Add(issueKey))
                 {
                     return;
                 }
@@ -129,75 +123,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             VibeLogger.LogInfo(operation, message, context);
         }
 
-        private static string CreateEffectiveIssueKey(string issueKey)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(issueKey), "issueKey must not be empty");
-
-            if (string.IsNullOrEmpty(ConsoleDiagnosticSource.Value))
-            {
-                return issueKey;
-            }
-
-            return $"{issueKey}::source::{ConsoleDiagnosticSource.Value}";
-        }
-
-        internal static System.IDisposable UseConsoleDiagnosticSource(string source)
-        {
-            if (string.IsNullOrEmpty(source))
-            {
-                return EmptyDisposable.Instance;
-            }
-
-            string previousSource = ConsoleDiagnosticSource.Value;
-            ConsoleDiagnosticSource.Value = source;
-            return new ConsoleDiagnosticSourceScope(previousSource);
-        }
-
         private static string FormatConsoleErrorMessage(string operation, string message, object context)
         {
             Debug.Assert(!string.IsNullOrEmpty(operation), "operation must not be empty");
             Debug.Assert(!string.IsNullOrEmpty(message), "message must not be empty");
 
-            string diagnosticSourceLine = string.IsNullOrEmpty(ConsoleDiagnosticSource.Value)
-                ? string.Empty
-                : $"\ndiagnostic_source: {ConsoleDiagnosticSource.Value}";
-
             if (context == null)
             {
-                return $"[{UnityCliLoopConstants.PROJECT_NAME}] {message}\noperation: {operation}{diagnosticSourceLine}";
+                return $"[{UnityCliLoopConstants.PROJECT_NAME}] {message}\noperation: {operation}";
             }
 
-            return $"[{UnityCliLoopConstants.PROJECT_NAME}] {message}\noperation: {operation}{diagnosticSourceLine}\ncontext: {context}";
-        }
-
-        /// <summary>
-        /// Provides Console Diagnostic Source Scope behavior for Unity CLI Loop.
-        /// </summary>
-        private sealed class ConsoleDiagnosticSourceScope : System.IDisposable
-        {
-            private readonly string _previousSource;
-
-            public ConsoleDiagnosticSourceScope(string previousSource)
-            {
-                _previousSource = previousSource;
-            }
-
-            public void Dispose()
-            {
-                ConsoleDiagnosticSource.Value = _previousSource;
-            }
-        }
-
-        /// <summary>
-        /// Provides Empty Disposable behavior for Unity CLI Loop.
-        /// </summary>
-        private sealed class EmptyDisposable : System.IDisposable
-        {
-            public static readonly EmptyDisposable Instance = new EmptyDisposable();
-
-            public void Dispose()
-            {
-            }
+            return $"[{UnityCliLoopConstants.PROJECT_NAME}] {message}\noperation: {operation}\ncontext: {context}";
         }
 
         internal static void ResetForTests()
@@ -206,8 +142,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 ReportedIssues.Clear();
             }
-
-            ConsoleDiagnosticSource.Value = null;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
@@ -214,11 +214,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             get { return GetRegistry().CommandEntryPointResolver; }
         }
 
-        internal static RegistryDynamicCodeExecutorFactory ExecutorFactory
-        {
-            get { return GetRegistry().ExecutorFactory; }
-        }
-
         internal static IExecuteDynamicCodeUseCase GetExecuteDynamicCodeUseCase()
         {
             return GetRegistry().GetExecuteDynamicCodeUseCase();

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
@@ -204,11 +204,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return RegistryValue;
         }
 
-        internal static IDynamicCodeSourcePreparationService SourcePreparationService
-        {
-            get { return GetRegistry().SourcePreparationService; }
-        }
-
         internal static CompiledCommandEntryPointResolver CommandEntryPointResolver
         {
             get { return GetRegistry().CommandEntryPointResolver; }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCompilationTimingFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCompilationTimingFormatter.cs
@@ -7,8 +7,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class DynamicCompilationTimingFormatter
     {
-        private const string CacheHitTimingEntry = "[Perf] CacheHit: true";
-
         public static List<string> CreateCompilationTimings(
             double referenceResolutionMilliseconds,
             double buildMilliseconds,
@@ -27,14 +25,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 timings.Add(backendTimingEntry);
             }
 
-            return timings;
-        }
-
-        public static List<string> CreateCachedCompilationTimings(
-            DynamicCompilationBackendKind backendKind = DynamicCompilationBackendKind.Unknown)
-        {
-            List<string> timings = CreateCompilationTimings(0, 0, 0, backendKind);
-            timings.Add(CacheHitTimingEntry);
             return timings;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
@@ -265,21 +265,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Shutdown();
         }
 
-        internal static Action<Process, string> SwapCompileRequestSenderForTests(Action<Process, string> sender)
-        {
-            return ServiceValue.SwapCompileRequestSenderForTests(sender);
-        }
-
         internal static Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]>
             SwapWorkerAssemblyCompilerForTests(
                 Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]> compiler)
         {
             return ServiceValue.SwapWorkerAssemblyCompilerForTests(compiler);
-        }
-
-        internal static void SetResponseTimeoutMillisecondsForTests(int timeoutMilliseconds)
-        {
-            ServiceValue.SetResponseTimeoutMillisecondsForTests(timeoutMilliseconds);
         }
 
         private static void Shutdown()

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
@@ -20,7 +20,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private readonly SharedRoslynCompilerWorkerSessionCoordination _coordination = new();
         private Func<ProcessStartInfo, Process> _startProcess = ProcessStartHelper.TryStart;
-        private Action<Process, string> _sendCompileRequest = SendCompileRequestCore;
         private Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]>
             _compileWorkerAssemblyForTests;
         private Process _workerProcess;
@@ -70,16 +69,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        internal void SetResponseTimeoutMillisecondsForTests(int timeoutMilliseconds)
-        {
-            Debug.Assert(timeoutMilliseconds > 0, "timeoutMilliseconds must be positive");
-
-            _coordination.ExecuteWithStateLock(() =>
-            {
-                _responseTimeoutMilliseconds = timeoutMilliseconds;
-            });
-        }
-
         internal bool HasLiveProcessLocked()
         {
             AssertStateLockHeld();
@@ -114,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal void SendCompileRequestLocked(string requestFilePath)
         {
             AssertStateLockHeld();
-            _sendCompileRequest(_workerProcess, requestFilePath);
+            SendCompileRequestCore(_workerProcess, requestFilePath);
         }
 
         internal StreamReader GetOutputReaderLocked()
@@ -329,15 +318,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             Func<ProcessStartInfo, Process> previous = _startProcess;
             _startProcess = starter;
-            return previous;
-        }
-
-        internal Action<Process, string> SwapCompileRequestSenderForTests(Action<Process, string> sender)
-        {
-            Debug.Assert(sender != null, "sender must not be null");
-
-            Action<Process, string> previous = _sendCompileRequest;
-            _sendCompileRequest = sender;
             return previous;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
@@ -23,14 +23,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         
         /// <summary>Error message (on failure)</summary>
         public string ErrorMessage { get; set; }
-        
-        /// <summary>Error message (alias for ErrorMessage)</summary>
-        public string Error 
-        { 
-            get => ErrorMessage; 
-            set => ErrorMessage = value; 
+
+        /// <summary>
+        /// Error message alias for ErrorMessage.
+        /// Why keep: documented tool-response JSON field (Skill/SKILL.md); agents and CLI read it.
+        /// </summary>
+        public string Error
+        {
+            get => ErrorMessage;
+            set => ErrorMessage = value;
         }
-        
+
         /// <summary>
         /// Code formatted for compilation
         /// (After extracting/moving using statements and applying class/method wrapping)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -58,11 +58,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             );
         }
 
-        public void Cancel()
-        {
-            _executionSlot.Cancel();
-        }
-
         public async Task<ExecutionResult> ExecuteAsync(ExecutionContext context)
         {
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunnerExecutionSlot.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunnerExecutionSlot.cs
@@ -39,11 +39,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return true;
         }
 
-        public void Cancel()
-        {
-            _cancellationTokenSource?.Cancel();
-        }
-
         /// <summary>
         /// Ends the execution slot even when undo collapse throws.
         /// Why nested finally: collapse can throw on a torn-down editor; the running flag must clear.

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutor.cs
@@ -16,15 +16,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly IDynamicCompilationService _compiler;
         private readonly ICompiledCommandInvoker _invoker;
         private readonly IDynamicCodeSourcePreparationService _sourcePreparationService;
-        private readonly ExecutionStatistics _statistics;
-        private readonly object _statsLock = new();
-
-        public DynamicCodeExecutor(
-            IDynamicCompilationService compiler,
-            ICompiledCommandInvoker invoker)
-            : this(compiler, invoker, DynamicCodeServices.SourcePreparationService)
-        {
-        }
 
         internal DynamicCodeExecutor(
             IDynamicCompilationService compiler,
@@ -34,7 +25,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _compiler = compiler ?? throw new ArgumentNullException(nameof(compiler));
             _invoker = invoker ?? throw new ArgumentNullException(nameof(invoker));
             _sourcePreparationService = sourcePreparationService ?? throw new ArgumentNullException(nameof(sourcePreparationService));
-            _statistics = new ExecutionStatistics();
         }
 
         public async Task<ExecutionResult> ExecuteCodeAsync(
@@ -103,36 +93,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     compileTotalStopwatch.Elapsed.TotalMilliseconds);
                 AppendCompilationAdvisories(executionResult.Logs, compilationResult.AdvisoryLogs);
 
-                UpdateStatistics(executionResult, totalStopwatch.Elapsed);
                 return executionResult;
             }
             catch (OperationCanceledException)
             {
-                ExecutionResult cancelledResult = CreateCancelledResult(totalStopwatch.Elapsed);
-                UpdateStatistics(cancelledResult, totalStopwatch.Elapsed);
-                return cancelledResult;
+                return CreateCancelledResult(totalStopwatch.Elapsed);
             }
             catch (Exception ex)
             {
                 ExecutionResult failureResult = CreateUnexpectedErrorResult(ex, totalStopwatch.Elapsed);
-                UpdateStatistics(failureResult, totalStopwatch.Elapsed);
                 LogUnexpectedExecutionException(ex, correlationId, totalStopwatch.ElapsedMilliseconds);
                 return failureResult;
-            }
-        }
-
-        public ExecutionStatistics GetStatistics()
-        {
-            lock (_statsLock)
-            {
-                return new ExecutionStatistics
-                {
-                    TotalExecutions = _statistics.TotalExecutions,
-                    SuccessfulExecutions = _statistics.SuccessfulExecutions,
-                    FailedExecutions = _statistics.FailedExecutions,
-                    AverageExecutionTime = _statistics.AverageExecutionTime,
-                    CompilationErrors = _statistics.CompilationErrors
-                };
             }
         }
 
@@ -155,16 +126,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Namespace = DynamicCodeConstants.DEFAULT_NAMESPACE
             };
 
-            CompilationResult result = await _compiler.CompileAsync(request, ct).ConfigureAwait(false);
-            if (!result.Success)
-            {
-                lock (_statsLock)
-                {
-                    _statistics.CompilationErrors++;
-                }
-            }
-
-            return result;
+            return await _compiler.CompileAsync(request, ct).ConfigureAwait(false);
         }
 
         private ExecutionResult TryCreateCompilationFailureResult(
@@ -264,28 +226,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             destination.AddRange(advisoryLogs);
-        }
-
-        private void UpdateStatistics(ExecutionResult result, TimeSpan executionTime)
-        {
-            lock (_statsLock)
-            {
-                _statistics.TotalExecutions++;
-                if (result.Success)
-                {
-                    _statistics.SuccessfulExecutions++;
-                }
-                else
-                {
-                    _statistics.FailedExecutions++;
-                }
-
-                double totalMilliseconds =
-                    _statistics.AverageExecutionTime.TotalMilliseconds * (_statistics.TotalExecutions - 1);
-                totalMilliseconds += executionTime.TotalMilliseconds;
-                _statistics.AverageExecutionTime =
-                    TimeSpan.FromMilliseconds(totalMilliseconds / _statistics.TotalExecutions);
-            }
         }
 
         private static Dictionary<string, object> BuildExecutionParameters(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutorStub.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutorStub.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,13 +10,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class DynamicCodeExecutorStub : IDynamicCodeExecutor
     {
-        private readonly ExecutionStatistics _statistics;
-
-        public DynamicCodeExecutorStub()
-        {
-            _statistics = new ExecutionStatistics();
-        }
-
         /// <summary>Execute code asynchronously (always returns a Roslyn required error)</summary>
         public Task<ExecutionResult> ExecuteCodeAsync(
             string code,
@@ -27,19 +19,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool compileOnly = false)
         {
             return Task.FromResult(CreateCompilationProviderUnavailableResult());
-        }
-
-        /// <summary>Retrieve execution statistics</summary>
-        public ExecutionStatistics GetStatistics()
-        {
-            return new ExecutionStatistics
-            {
-                TotalExecutions = _statistics.TotalExecutions,
-                SuccessfulExecutions = _statistics.SuccessfulExecutions,
-                FailedExecutions = _statistics.FailedExecutions,
-                AverageExecutionTime = _statistics.AverageExecutionTime,
-                CompilationErrors = _statistics.CompilationErrors
-            };
         }
 
         public void Dispose()
@@ -52,8 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 Success = false,
                 ErrorMessage = "COMPILATION_PROVIDER_UNAVAILABLE: No compilation provider is registered. Check initialization.",
-                ExecutionTime = TimeSpan.Zero,
-                Statistics = _statistics
+                ExecutionTime = TimeSpan.Zero
             };
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/IDynamicCodeExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/IDynamicCodeExecutor.cs
@@ -17,28 +17,5 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CancellationToken cancellationToken = default,
             bool compileOnly = false
         );
-
-
-
-        ExecutionStatistics GetStatistics();
-    }
-
-    /// <summary>Execution statistics</summary>
-    public class ExecutionStatistics
-    {
-        /// <summary>Total execution count</summary>
-        public int TotalExecutions { get; set; }
-
-        /// <summary>Successful execution count</summary>
-        public int SuccessfulExecutions { get; set; }
-
-        /// <summary>Failed execution count</summary>
-        public int FailedExecutions { get; set; }
-
-        /// <summary>Average execution time</summary>
-        public TimeSpan AverageExecutionTime { get; set; }
-
-        /// <summary>Compilation error count</summary>
-        public int CompilationErrors { get; set; }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Models/ExecutionResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Models/ExecutionResult.cs
@@ -28,9 +28,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>Logs</summary>
         public List<string> Logs { get; set; } = new();
 
-        /// <summary>Execution Statistics</summary>
-        public ExecutionStatistics Statistics { get; set; }
-
         /// <summary>
         /// Structured compilation errors when compilation failed.
         /// Preserved to enable rich diagnostics formatting at the tool layer.

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectDetails.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectDetails.cs
@@ -8,7 +8,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class GameObjectDetails
     {
         public bool Found { get; set; }
-        public string ErrorMessage { get; set; }
         public GameObject GameObject { get; set; }
         public string Name { get; set; }
         public string Path { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/GetLogs/GetLogsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/GetLogs/GetLogsResponse.cs
@@ -19,13 +19,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Message = message;
             StackTrace = stackTrace;
         }
-
-        /// <summary>
-        /// Parameterless constructor for JSON deserialization
-        /// </summary>
-        public LogEntry()
-        {
-        }
     }
 
     /// <summary>
@@ -82,16 +75,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SearchText = searchText;
             IncludeStackTrace = includeStackTrace;
             Logs = logs ?? Array.Empty<LogEntry>();
-        }
-
-        /// <summary>
-        /// Parameterless constructor for JSON deserialization
-        /// </summary>
-        public GetLogsResponse()
-        {
-            LogType = string.Empty;
-            SearchText = string.Empty;
-            Logs = Array.Empty<LogEntry>();
         }
     }
 } 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -115,18 +115,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             NoTestsFoundExplanation = noTestsFoundExplanation;
         }
 
-        /// <summary>
-        /// Parameterless constructor for JSON deserialization
-        /// </summary>
-        public RunTestsResponse()
-        {
-            Message = string.Empty;
-            Status = string.Empty;
-            NoTestsFoundExplanation = string.Empty;
-            CompletedAt = string.Empty;
-            XmlPath = string.Empty;
-        }
-
         public static RunTestsResponse CreateTestFrameworkUnavailable()
         {
             return new RunTestsResponse(

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs
@@ -17,21 +17,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static volatile bool _resolved;
         private static MethodInfo _cancelTestRunMethod;
         private static MethodInfo _isRunActiveMethod;
-        private static string _resolveLog;
-
-        /// <summary>
-        /// Resets cached lookup state for unit tests.
-        /// </summary>
-        internal static void ResetResolvedStateForTests()
-        {
-            lock (ResolveLock)
-            {
-                _resolved = false;
-                _cancelTestRunMethod = null;
-                _isRunActiveMethod = null;
-                _resolveLog = null;
-            }
-        }
 
         /// <summary>
         /// True when CancelTestRun(string) was resolved.
@@ -54,15 +39,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 EnsureResolved();
                 return _isRunActiveMethod != null;
-            }
-        }
-
-        internal static string ResolveLogForTests
-        {
-            get
-            {
-                EnsureResolved();
-                return _resolveLog;
             }
         }
 
@@ -117,7 +93,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     TestRunnerApiCancelMethodLookup.Resolve(typeof(TestRunnerApi));
                 _cancelTestRunMethod = cancel;
                 _isRunActiveMethod = isRunActive;
-                _resolveLog = log;
                 _resolved = true;
 
                 if (!string.IsNullOrEmpty(log))

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Application/KeyboardKeyState.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Application/KeyboardKeyState.cs
@@ -74,12 +74,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _transientKeys.Remove(key);
         }
 
-        public void Clear()
-        {
-            _heldKeys.Clear();
-            _transientKeys.Clear();
-        }
-
         // Keyboard keys are stored as a bitfield, so StateEvent.From captures
         // the entire keyboard state. To support simultaneous key holds, we write
         // ALL currently held keys into every event — not just the target key.
@@ -178,11 +172,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static void UnregisterTransientKey(Key key)
         {
             ServiceValue.UnregisterTransientKey(key);
-        }
-
-        public static void Clear()
-        {
-            ServiceValue.Clear();
         }
 
         public static IReadOnlyList<Key> ClearTrackedKeys()

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Application/MouseInputState.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Application/MouseInputState.cs
@@ -25,8 +25,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private Action? _pendingDeltaReset;
         private Action? _pendingScrollReset;
 
-        public bool IsButtonHeld(RuntimeMouseButton button) => _heldButtons.Contains(button);
-
         public void RegisterPlayModeCallbacks()
         {
             EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
@@ -236,8 +234,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             ServiceValue.RegisterPlayModeCallbacks();
         }
-
-        public static bool IsButtonHeld(RuntimeMouseButton button) => ServiceValue.IsButtonHeld(button);
 
         public static void SetButtonDown(RuntimeMouseButton button)
         {

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Application/MouseInputState.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Application/MouseInputState.cs
@@ -278,11 +278,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             ServiceValue.ReleaseAllButtons();
         }
-
-        internal static ButtonControl GetButtonControl(Mouse mouse, RuntimeMouseButton button)
-        {
-            return ServiceValue.GetButtonControl(mouse, button);
-        }
     }
 }
 #endif

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiIncrementalDragExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiIncrementalDragExecutor.cs
@@ -50,7 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (target == null)
             {
                 SimulateMouseUiOverlayState.Update(
-                    MouseAction.DragStart, inputPos, null, null, Handles.GetMainGameViewSize());
+                    MouseAction.DragStart, inputPos, null, Handles.GetMainGameViewSize());
                 MouseUiFrameWaitOutcome noTargetExpandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
                 if (noTargetExpandOutcome == MouseUiFrameWaitOutcome.TimedOut)
                 {
@@ -102,7 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             string targetName = target.name;
             SimulateMouseUiOverlayState.Update(
-                MouseAction.DragStart, inputPos, inputPos, targetName, Handles.GetMainGameViewSize());
+                MouseAction.DragStart, inputPos, inputPos, Handles.GetMainGameViewSize());
 
             bool animationCompleted = false;
             try
@@ -183,7 +183,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 MouseAction.DragMove,
                 MouseUiCoordinateConverter.ScreenToInput(pointerData.position),
                 SimulateMouseUiOverlayState.DragStartPosition,
-                targetName, Handles.GetMainGameViewSize());
+                Handles.GetMainGameViewSize());
 
             // Cancellation leaves drag state intact so the user can continue with DragMove/DragEnd
             MouseUiFrameWaitOutcome dragOutcome = await MouseUiDragEventExecutor.InterpolateDragPosition(
@@ -261,7 +261,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 MouseAction.DragEnd,
                 MouseUiCoordinateConverter.ScreenToInput(pointerData.position),
                 SimulateMouseUiOverlayState.DragStartPosition,
-                targetName, Handles.GetMainGameViewSize());
+                Handles.GetMainGameViewSize());
 
             // Any Paused exit inside this try still runs FinalizeDrag + MouseDragState.Clear()
             // in the finally below, so every in-try branch reports the drag as finalized early.
@@ -310,7 +310,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             SimulateMouseUiOverlayState.Update(
-                MouseAction.DragEnd, inputEnd, null, targetName, Handles.GetMainGameViewSize());
+                MouseAction.DragEnd, inputEnd, null, Handles.GetMainGameViewSize());
 
             MouseUiFrameWaitOutcome dissipateOutcome = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
             if (dissipateOutcome == MouseUiFrameWaitOutcome.TimedOut)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
@@ -50,7 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (target == null)
             {
                 SimulateMouseUiOverlayState.Update(
-                    MouseAction.Drag, inputStart, null, null, Handles.GetMainGameViewSize());
+                    MouseAction.Drag, inputStart, null, Handles.GetMainGameViewSize());
                 MouseUiFrameWaitOutcome noTargetExpandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
                 if (noTargetExpandOutcome == MouseUiFrameWaitOutcome.TimedOut)
                 {
@@ -102,7 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             string targetName = target.name;
             SimulateMouseUiOverlayState.Update(
-                MouseAction.Drag, inputStart, inputStart, targetName, Handles.GetMainGameViewSize());
+                MouseAction.Drag, inputStart, inputStart, Handles.GetMainGameViewSize());
 
             // Any Paused exit inside this try still runs FinalizeDrag in the finally below
             // (pointerUp/drop/endDrag), so every branch reports the drag as finalized early
@@ -161,7 +161,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             SimulateMouseUiOverlayState.Update(
-                MouseAction.Drag, inputEnd, inputStart, targetName, Handles.GetMainGameViewSize());
+                MouseAction.Drag, inputEnd, inputStart, Handles.GetMainGameViewSize());
 
             MouseUiFrameWaitOutcome dissipateOutcome = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
             if (dissipateOutcome == MouseUiFrameWaitOutcome.TimedOut)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
@@ -48,7 +48,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool hitTarget = resolvedTargets.Target != null;
             SimulateMouseUiOverlayState.Update(
                 MouseAction.Click, inputPos, null,
-                targetName, Handles.GetMainGameViewSize());
+                Handles.GetMainGameViewSize());
 
             MouseUiFrameWaitOutcome expandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
             if (expandOutcome == MouseUiFrameWaitOutcome.TimedOut)
@@ -130,7 +130,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool shouldReleasePointer = resolvedTargets.RawTarget != null && resolvedTargets.Target != null;
             SimulateMouseUiOverlayState.Update(
                 MouseAction.LongPress, inputPos, null,
-                targetName, Handles.GetMainGameViewSize());
+                Handles.GetMainGameViewSize());
 
             MouseUiFrameWaitOutcome expandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
             if (expandOutcome == MouseUiFrameWaitOutcome.TimedOut)

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionStepMonitor.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionStepMonitor.cs
@@ -26,17 +26,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _isStarted = true;
         }
 
-        public void Stop()
-        {
-            if (!_isStarted)
-            {
-                return;
-            }
-
-            EditorApplication.update -= OnEditorUpdate;
-            _isStarted = false;
-        }
-
         private void OnEditorUpdate()
         {
             _registry.EvaluateIfFrameChanged();

--- a/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
@@ -140,11 +140,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return Task.Run(() => DetectCliInstallationBlocking(platform, ct), ct);
         }
 
-        internal static string DetectCliVersionBlocking(RuntimePlatform platform, CancellationToken ct)
-        {
-            return DetectCliInstallationBlocking(platform, ct).Version;
-        }
-
         internal static CliInstallationDetection DetectCliInstallationBlocking(RuntimePlatform platform, CancellationToken ct)
         {
             CliInstallationDetection packageOwnedDetection = DetectPackageOwnedCliInstallationBlocking(platform, ct);

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
@@ -395,16 +395,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             _serverLifecycleRegistry.ServerStateChanged -= handler;
         }
-
-        public void AddServerStartedHandler(Action handler)
-        {
-            _serverLifecycleRegistry.ServerStarted += handler;
-        }
-
-        public void RemoveServerStartedHandler(Action handler)
-        {
-            _serverLifecycleRegistry.ServerStarted -= handler;
-        }
     }
 
 }

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsRepository.cs
@@ -121,14 +121,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return GetSettings().lastSeenSetupWizardVersion ?? string.Empty;
         }
 
-        public void SetLastSeenSetupWizardVersion(string version)
-        {
-            string normalizedVersion = version ?? string.Empty;
-            UnityCliLoopEditorSettingsData settings = GetSettings();
-            UnityCliLoopEditorSettingsData updatedSettings = settings with { lastSeenSetupWizardVersion = normalizedVersion };
-            SaveSettings(updatedSettings);
-        }
-
         public bool GetSuppressSetupWizardAutoShow()
         {
             return GetSettings().suppressSetupWizardAutoShow;
@@ -139,13 +131,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             UnityCliLoopEditorSettingsData settings = GetSettings();
             UnityCliLoopEditorSettingsData updatedSettings = settings with { suppressSetupWizardAutoShow = suppressAutoShow };
             SaveSettings(updatedSettings);
-        }
-
-        public void SetShowUnityCliLoopSecuritySetting(bool showUnityCliLoopSecuritySetting)
-        {
-            UnityCliLoopEditorSettingsData settings = GetSettings();
-            UnityCliLoopEditorSettingsData newSettings = settings with { showUnityCliLoopSecuritySetting = showUnityCliLoopSecuritySetting };
-            SaveSettings(newSettings);
         }
 
         public void SetShowToolSettings(bool showToolSettings)

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallationDetector.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallationDetector.cs
@@ -11,22 +11,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public sealed class SkillInstallationDetector
     {
-        public bool AreSkillsInstalled(string targetDir)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
-
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return AreSkillsInstalledInAnyLayout(projectRoot, targetDir);
-        }
-
-        public bool AreSkillsInstalled(string targetDir, bool groupSkillsUnderUnityCliLoop)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
-
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return AreSkillsInstalledForLayout(projectRoot, targetDir, groupSkillsUnderUnityCliLoop);
-        }
-
         internal bool AreSkillsInstalledInAnyLayout(string projectRoot, string targetDir)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -79,22 +79,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return false;
         }
 
-        public static List<SkillTargetInfo> DetectTargetsForLayout(bool groupSkillsUnderUnityCliLoop)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            return DetectTargetsForLayoutAtProjectRoot(projectRoot, groupSkillsUnderUnityCliLoop);
-        }
-
-        public static List<SkillTargetInfo> DetectTargetsForLayoutFast(bool groupSkillsUnderUnityCliLoop)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            return DetectTargetsForLayoutFastAtProjectRoot(projectRoot, groupSkillsUnderUnityCliLoop);
-        }
-
         internal static List<SkillTargetInfo> DetectTargetsForLayoutAtProjectRoot(
             string projectRoot,
             bool groupSkillsUnderUnityCliLoop)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -138,19 +138,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return ThirdPartyToolMigrationApiDetectionRules.ContainsCurrentToolContractsApi(source);
         }
 
-        internal static bool ContainsLegacyDomainMetadataApi(string source)
-        {
-            return ThirdPartyToolMigrationApiDetectionRules.ContainsLegacyDomainMetadataApi(source);
-        }
-
-        internal static bool ContainsLegacyDomainHelperApiForAssembly(
-            string source,
-            bool hasLegacyAssemblySource,
-            string[] legacyAssemblyAliases)
-        {
-            return ThirdPartyToolMigrationApiDetectionRules.ContainsLegacyDomainHelperApiForAssembly(source, hasLegacyAssemblySource, legacyAssemblyAliases);
-        }
-
         internal static bool ContainsCurrentDomainMetadataApi(string source)
         {
             return ThirdPartyToolMigrationApiDetectionRules.ContainsCurrentDomainMetadataApi(source);
@@ -203,11 +190,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string[] assemblyDeclaredTypeNames)
         {
             return ThirdPartyToolMigrationApiDetectionRules.ContainsLegacyEditorWindowCaptureUtilityTimeoutMigrationForAssembly(source, hasLegacyAssemblySource, hasAssemblyScopedCurrentToolContractsUsing, hasAssemblyScopedCurrentFirstPartyToolsUsing, legacyAssemblyAliases, currentFirstPartyToolsAssemblyAliases, assemblyDeclaredTypeNames);
-        }
-
-        internal static bool ContainsCurrentFirstPartyScreenshotApi(string source)
-        {
-            return ThirdPartyToolMigrationApiDetectionRules.ContainsCurrentFirstPartyScreenshotApi(source);
         }
 
         internal static bool ContainsCurrentFirstPartyScreenshotApiForAssembly(

--- a/Packages/src/Editor/Infrastructure/Utils/NodeEnvironmentResolver.cs
+++ b/Packages/src/Editor/Infrastructure/Utils/NodeEnvironmentResolver.cs
@@ -177,8 +177,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return null;
         }
 
-        private const string PATH_START_MARKER = "__PATH_START__";
-        private const string PATH_END_MARKER = "__PATH_END__";
         private const string WHICH_START_MARKER = "__WHICH_START__";
         private const string WHICH_END_MARKER = "__WHICH_END__";
         private const string POSIX_FALLBACK_SHELL_PATH = "/bin/sh";
@@ -186,28 +184,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string DIRECTORY_SERVICE_USERS_PATH_PREFIX = "/Users/";
         private const string DIRECTORY_SERVICE_USER_SHELL_ATTRIBUTE = "UserShell";
         private const string DIRECTORY_SERVICE_USER_SHELL_PREFIX = DIRECTORY_SERVICE_USER_SHELL_ATTRIBUTE + ":";
-
-        // Uses markers to extract PATH value, ignoring any banner/echo output from shell startup files
-        internal static string GetLoginShellPathAtPlatform(RuntimePlatform platform)
-        {
-            if (IsWindowsEditor(platform))
-            {
-                return null;
-            }
-
-            string shell = GetUserShell();
-            ProcessStartInfo startInfo = new()            {
-                FileName = shell,
-                Arguments = "-l -i -c \"echo " + PATH_START_MARKER + "; printenv PATH; echo " + PATH_END_MARKER + "\"",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true
-            };
-
-            string output = ExecuteAndGetOutput(startInfo);
-            return ExtractBetweenMarkers(output, PATH_START_MARKER, PATH_END_MARKER);
-        }
 
         internal static string ExtractBetweenMarkers(string output, string startMarker, string endMarker)
         {

--- a/Packages/src/Editor/Infrastructure/Utils/NodeEnvironmentResolver.cs
+++ b/Packages/src/Editor/Infrastructure/Utils/NodeEnvironmentResolver.cs
@@ -13,16 +13,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     {
         private const int PROCESS_TIMEOUT_MS = 5000;
 
-        /// <summary>
-        /// Finds an executable path using platform-appropriate resolution.
-        /// On Windows, resolves .cmd shims via 'where' command.
-        /// On Unix, resolves via login shell 'which' command.
-        /// </summary>
-        public static string FindExecutablePath(string executableName)
-        {
-            return FindExecutablePathAtPlatform(executableName, UnityEngine.Application.platform);
-        }
-
         internal static string FindExecutablePathAtPlatform(string executableName, RuntimePlatform platform)
         {
             if (IsWindowsEditor(platform))

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -176,11 +176,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 || installState == SkillInstallState.Outdated;
         }
 
-        internal static bool HasFiniteSize(Vector2 size)
-        {
-            return ThirdPartyToolMigrationWizardWindowResizer.HasFiniteSize(size);
-        }
-
         internal static bool ShouldReportMigrationProgress(
             long lastReportTimestamp,
             long currentTimestamp,

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
@@ -21,7 +21,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private readonly Foldout _installSpecificTargetFoldout;
         private readonly VisualElement _groupSkillsRow;
         private readonly Toggle _groupSkillsToggle;
-        private readonly Label _groupSkillsLabel;
         private readonly EnumField _skillsTargetField;
         private readonly Button _refreshSkillsStateButton;
         private readonly Button _installSelectedSkillsButton;
@@ -34,10 +33,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal event System.Action OnRefreshClicked;
         internal event System.Action<SkillsTarget> OnTargetChanged;
         internal event System.Action<bool> OnGroupSkillsChanged;
-
-        internal Toggle GroupSkillsToggle => _groupSkillsToggle;
-        internal Label GroupSkillsLabel => _groupSkillsLabel;
-        internal VisualElement GroupSkillsRow => _groupSkillsRow;
 
         internal SkillsSetupPanelView(VisualElement panelRoot, Button refreshSkillsStateButton)
         {
@@ -55,7 +50,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _installSpecificTargetFoldout = root.Q<Foldout>("install-specific-target-foldout");
             _groupSkillsRow = root.Q<VisualElement>("group-skills-row");
             _groupSkillsToggle = root.Q<Toggle>("group-skills-toggle");
-            _groupSkillsLabel = root.Q<Label>("group-skills-label");
             _skillsTargetField = root.Q<EnumField>("skills-target-field");
             _installSelectedSkillsButton = root.Q<Button>("install-selected-skills-button");
 
@@ -67,7 +61,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             Debug.Assert(_installSpecificTargetFoldout != null, "install-specific-target-foldout must not be null");
             Debug.Assert(_groupSkillsRow != null, "group-skills-row must not be null");
             Debug.Assert(_groupSkillsToggle != null, "group-skills-toggle must not be null");
-            Debug.Assert(_groupSkillsLabel != null, "group-skills-label must not be null");
             Debug.Assert(_skillsTargetField != null, "skills-target-field must not be null");
             Debug.Assert(_installSelectedSkillsButton != null, "install-selected-skills-button must not be null");
 
@@ -80,7 +73,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 ?? throw new System.ArgumentNullException(nameof(_installSpecificTargetFoldout));
             _ = _groupSkillsRow ?? throw new System.ArgumentNullException(nameof(_groupSkillsRow));
             _ = _groupSkillsToggle ?? throw new System.ArgumentNullException(nameof(_groupSkillsToggle));
-            _ = _groupSkillsLabel ?? throw new System.ArgumentNullException(nameof(_groupSkillsLabel));
             _ = _skillsTargetField ?? throw new System.ArgumentNullException(nameof(_skillsTargetField));
             _ = _installSelectedSkillsButton
                 ?? throw new System.ArgumentNullException(nameof(_installSelectedSkillsButton));

--- a/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
+++ b/Packages/src/Editor/Presentation/SkillsTargetSelectionResolver.cs
@@ -1,5 +1,4 @@
 using io.github.hatayama.UnityCliLoop.Application;
-using io.github.hatayama.UnityCliLoop.Domain;
 
 namespace io.github.hatayama.UnityCliLoop.Presentation
 {
@@ -54,11 +53,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 SkillsTarget.Agents => data.IsAgentsSkillsInstalled,
                 _ => false
             };
-        }
-
-        public static SkillInstallState GetInstallState(CliSetupData data, SkillsTarget target)
-        {
-            return data.SelectedTarget == target ? data.SelectedTargetInstallState : SkillInstallState.Missing;
         }
     }
 }

--- a/Packages/src/Editor/Presentation/UIToolkit/Bindings/ViewDataBinder.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Bindings/ViewDataBinder.cs
@@ -10,54 +10,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     /// </summary>
     public static class ViewDataBinder
     {
-        public static void BindToggle(Toggle toggle, Func<bool> getter, Action<bool> onChanged)
-        {
-            toggle.SetValueWithoutNotify(getter());
-            toggle.RegisterValueChangedCallback(evt => onChanged(evt.newValue));
-        }
-
-        public static void BindIntegerField(IntegerField field, Func<int> getter, Action<int> onChanged)
-        {
-            field.SetValueWithoutNotify(getter());
-            field.RegisterValueChangedCallback(evt => onChanged(evt.newValue));
-        }
-
-        public static void BindEnumField<T>(EnumField field, Func<T> getter, Action<T> onChanged) where T : Enum
-        {
-            field.Init(getter());
-            field.RegisterValueChangedCallback(evt =>
-            {
-                if (evt.newValue is T newValue)
-                {
-                    onChanged(newValue);
-                }
-            });
-        }
-
-        public static void BindFoldout(Foldout foldout, Func<bool> getter, Action<bool> onChanged)
-        {
-            foldout.SetValueWithoutNotify(getter());
-            foldout.RegisterValueChangedCallback(evt => onChanged(evt.newValue));
-        }
-
-        public static void BindButton(Button button, Action onClick)
-        {
-            button.clicked += onClick;
-        }
-
-        public static void BindLabel(Label label, Action<Label> onClick)
-        {
-            label.RegisterCallback<ClickEvent>(evt => onClick(label));
-        }
-
         public static void UpdateToggle(Toggle toggle, bool value)
         {
             toggle.SetValueWithoutNotify(value);
-        }
-
-        public static void UpdateIntegerField(IntegerField field, int value)
-        {
-            field.SetValueWithoutNotify(value);
         }
 
         public static void UpdateEnumField<T>(EnumField field, T value) where T : Enum
@@ -73,24 +28,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         public static void SetVisible(VisualElement element, bool visible)
         {
             element.style.display = visible ? DisplayStyle.Flex : DisplayStyle.None;
-        }
-
-        public static void SetEnabled(VisualElement element, bool enabled)
-        {
-            element.SetEnabled(enabled);
-        }
-
-        public static void AddModifierClass(VisualElement element, string baseClass, string modifier, bool condition)
-        {
-            string modifierClass = $"{baseClass}--{modifier}";
-            if (condition)
-            {
-                element.AddToClassList(modifierClass);
-            }
-            else
-            {
-                element.RemoveFromClassList(modifierClass);
-            }
         }
 
         public static void ToggleClass(VisualElement element, string className, bool condition)

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsModel.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsModel.cs
@@ -71,13 +71,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         }
 
         /// <summary>
-        /// Save current UI state to persistent settings
-        /// </summary>
-        public void SaveToSettings()
-        {
-        }
-
-        /// <summary>
         /// Load state from persistent settings (formerly from SessionState)
         /// </summary>
         public void LoadFromSessionState()
@@ -108,17 +101,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         }
 
         /// <summary>
-        /// Exit post-compile mode
-        /// </summary>
-        public void DisablePostCompileMode()
-        {
-            UpdateRuntimeState(runtime => new RuntimeState(
-                isPostCompileMode: false,
-                needsRepaint: runtime.NeedsRepaint,
-                lastServerRunning: runtime.LastServerRunning));
-        }
-
-        /// <summary>
         /// Mark that UI repaint is needed
         /// </summary>
         public void RequestRepaint()
@@ -141,31 +123,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         }
 
         // UIState-specific update methods with persistence
-
-        /// <summary>
-        /// Update MainScrollPosition setting
-        /// </summary>
-        public void UpdateMainScrollPosition(Vector2 position)
-        {
-            UpdateUIState(ui => new UIState(
-                mainScrollPosition: position,
-                showUnityCliLoopSecuritySetting: ui.ShowUnityCliLoopSecuritySetting,
-                showToolSettings: ui.ShowToolSettings,
-                showConfiguration: ui.ShowConfiguration));
-        }
-
-        /// <summary>
-        /// Update ShowUnityCliLoopSecuritySetting setting with persistence
-        /// </summary>
-        public void UpdateShowUnityCliLoopSecuritySetting(bool show)
-        {
-            UpdateUIState(ui => new UIState(
-                mainScrollPosition: ui.MainScrollPosition,
-                showUnityCliLoopSecuritySetting: show,
-                showToolSettings: ui.ShowToolSettings,
-                showConfiguration: ui.ShowConfiguration));
-            _editorSettingsPort.SetShowUnityCliLoopSecuritySetting(show);
-        }
 
         public void UpdateShowToolSettings(bool show)
         {

--- a/Packages/src/Editor/ToolContracts/EditorFrameWaiter.cs
+++ b/Packages/src/Editor/ToolContracts/EditorFrameWaiter.cs
@@ -16,17 +16,6 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         private readonly List<EditorFrameWaitRequest> _requests = new List<EditorFrameWaitRequest>();
         private int _currentFrameCount;
 
-        public int CurrentFrameCount
-        {
-            get
-            {
-                lock (_lockObject)
-                {
-                    return _currentFrameCount;
-                }
-            }
-        }
-
         public int PendingWaitCount
         {
             get
@@ -117,14 +106,6 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
             for (int i = 0; i < requestsToCancel.Count; i++)
             {
                 requestsToCancel[i].CancelFromTest();
-            }
-        }
-
-        public void ResetFrameCountForTests()
-        {
-            lock (_lockObject)
-            {
-                _currentFrameCount = 0;
             }
         }
 
@@ -260,7 +241,6 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
     {
         private static readonly EditorFrameWaiterService ServiceValue = new EditorFrameWaiterService();
 
-        public static int CurrentFrameCount => ServiceValue.CurrentFrameCount;
         public static int PendingWaitCount => ServiceValue.PendingWaitCount;
 
         public static void InitializeForEditorStartup()
@@ -279,11 +259,6 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public static void ClearAllForTests()
         {
             ServiceValue.ClearAllForTests();
-        }
-
-        public static void ResetFrameCountForTests()
-        {
-            ServiceValue.ResetFrameCountForTests();
         }
     }
 }

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -47,12 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string ENV_KEY_ULOOP_DEBUG = "ULOOP_DEBUG";
         // Reconnection settings
         public const int RECONNECTION_TIMEOUT_SECONDS = 10;
-        
-        // Package path constants
-        public const string TEMP_DIR = "Temp";
-        public const string UNITYCLILOOP_DIR = "UnityCliLoop";
-        public const string JSON_FILE_EXTENSION = ".json";
-        
+
         // .uloop directory
         public const string ULOOP_DIR = ".uloop";
         public const string ULOOP_TOOL_SETTINGS_FILE_NAME = "settings.tools.json";

--- a/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlayState.cs
+++ b/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlayState.cs
@@ -87,11 +87,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             LastActivityTime = Time.realtimeSinceStartup;
         }
 
-        public void ClearScroll()
-        {
-            _scrollActiveUntil = 0f;
-        }
-
         public void SetMoveDelta(Vector2 delta)
         {
             _moveAccumulator += delta;
@@ -157,11 +152,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public static void SetScrollDirection(int direction)
         {
             ServiceValue.SetScrollDirection(direction);
-        }
-
-        public static void ClearScroll()
-        {
-            ServiceValue.ClearScroll();
         }
 
         public static void SetMoveDelta(Vector2 delta)

--- a/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlayState.cs
+++ b/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlayState.cs
@@ -14,7 +14,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public MouseAction Action { get; private set; }
         public Vector2 CurrentPosition { get; private set; }
         public Vector2? DragStartPosition { get; private set; }
-        public string? HitGameObjectName { get; private set; }
 
         // Screen.width/height at the time positions were recorded (Editor context may differ from Game context)
         public Vector2 SourceScreenSize { get; private set; }
@@ -36,7 +35,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             MouseAction action,
             Vector2 currentPosition,
             Vector2? dragStartPosition,
-            string? hitGameObjectName,
             Vector2 sourceScreenSize)
         {
             // PlayDissipateAnimation calls Clear() on normal completion, but a cancelled or stuck drag
@@ -50,7 +48,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             Action = action;
             CurrentPosition = currentPosition;
             DragStartPosition = dragStartPosition;
-            HitGameObjectName = hitGameObjectName;
             SourceScreenSize = sourceScreenSize;
         }
 
@@ -113,7 +110,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             Action = default;
             CurrentPosition = Vector2.zero;
             DragStartPosition = null;
-            HitGameObjectName = null;
             SourceScreenSize = Vector2.zero;
             LongPressElapsed = 0f;
             _dragWaypoints.Clear();
@@ -132,7 +128,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public static MouseAction Action => ServiceValue.Action;
         public static Vector2 CurrentPosition => ServiceValue.CurrentPosition;
         public static Vector2? DragStartPosition => ServiceValue.DragStartPosition;
-        public static string? HitGameObjectName => ServiceValue.HitGameObjectName;
         public static Vector2 SourceScreenSize => ServiceValue.SourceScreenSize;
         public static float LongPressElapsed => ServiceValue.LongPressElapsed;
         public static IReadOnlyList<Vector2> DragWaypoints => ServiceValue.DragWaypoints;
@@ -141,10 +136,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             MouseAction action,
             Vector2 currentPosition,
             Vector2? dragStartPosition,
-            string? hitGameObjectName,
             Vector2 sourceScreenSize)
         {
-            ServiceValue.Update(action, currentPosition, dragStartPosition, hitGameObjectName, sourceScreenSize);
+            ServiceValue.Update(action, currentPosition, dragStartPosition, sourceScreenSize);
         }
 
         public static void UpdateLongPressElapsed(float elapsed)

--- a/docs/dead-code-scanner.md
+++ b/docs/dead-code-scanner.md
@@ -36,3 +36,19 @@ Interpret scanner output conservatively:
 - `KeptByUnityOrReflection` usually means the symbol is intentionally reachable through Unity callbacks, attributes, serialization, or reflection-style discovery. Do not add explanatory comments for every such symbol when the attribute/base type already makes the reason obvious.
 - `PublicCandidate` means Roslyn found no direct references. Check non-C# references such as `release-please-config.json`, checked-in JSON contracts, Unity assets, generated files, and documented public APIs before removing or commenting the symbol.
 - If a symbol is referenced only by non-C# tooling, verify that the tool reads it for runtime or release behavior. If the tool only rewrites the symbol and no code reads it, remove the marker instead of documenting it.
+
+## Intentionally retained PublicCandidates
+
+These symbols stay `PublicCandidate` on purpose. Do not delete them during routine triage,
+and do not add scanner-silencing machinery that changes the public API surface.
+
+| Symbol | Why it stays |
+|---|---|
+| `UnityCliLoopToolRegistrar.RegisterCustomTool` | Public extension API for external packages that register custom tools. Missing in-repo callers is expected. |
+| `UnityCliLoopToolRegistrar.UnregisterCustomTool` | Same public extension API. |
+| `UnityCliLoopToolRegistrar.GetRegisteredCustomTools` | Same public extension API. |
+| `UnityCliLoopToolRegistrar.IsCustomToolRegistered` | Same public extension API. |
+| `UnityCliLoopToolRegistrar.GetDebugInfo` | Same public extension API. |
+| `UnityCliLoopToolRegistrar.NotifyToolChanges` | Same public extension API. |
+| `ToolContracts.EditorWindowCaptureUtility.CaptureGameRenderingAsync` | Migration target: `ThirdPartyToolMigrationRuleCatalog` rewrites third-party tool code to call this façade, so user code outside this repository is the caller. |
+| `ExecuteDynamicCodeResponse.Error` | Documented tool response field (`ExecuteDynamicCode` Skill). Outbound JSON shape, not an in-repo read. |

--- a/docs/dead-code-scanner.md
+++ b/docs/dead-code-scanner.md
@@ -23,17 +23,28 @@ dotnet run --project tools/UnityCliLoop.DeadCodeScanner -- --scope public --incl
 target `main` or `v3-beta` and touch `Packages/src/**/*.cs`, the scanner
 itself, its tests, `scripts/check-dead-code.sh`, or the workflow file.
 
-The gate uses `--fail-on high-confidence`, so CI fails only for
-`Unused`, `UnusedPrivateMember`, and `UnusedLocal`.
+The workflow combines two independent failure conditions (either one exits 1):
 
-`PublicCandidate` and `TestOnly` do not fail CI. Those findings need
-manual review of non-C# references and cannot be decided mechanically.
+- `--fail-on high-confidence` fails immediately on `Unused`,
+  `UnusedPrivateMember`, and `UnusedLocal`. These are delete-ready findings.
+- `--max-public-candidates <n>` fails when the `PublicCandidate` count exceeds
+  `n`. This is a ceiling monitor for symbols that still need human review; it
+  does not auto-delete them. `TestOnly` findings are outside this limit.
+
+Set `<n>` to the measured `PublicCandidate` count after triage, with no slack.
+PRs that raise the count should be rejected unless they also raise the gate
+value for a documented reason. When triage lowers the count, lower `<n>` in
+the same change.
+
+Negative `--max-public-candidates` values, or omitting the option, disable the
+ceiling check.
 
 ## Interpreting the output
 
 Interpret scanner output conservatively:
 
 - `KeptByUnityOrReflection` usually means the symbol is intentionally reachable through Unity callbacks, attributes, serialization, or reflection-style discovery. Do not add explanatory comments for every such symbol when the attribute/base type already makes the reason obvious.
+- Framework conventions that the compiler or serializer resolve by name are classified as `KeptByUnityOrReflection` by the scanner (`await` pattern members, the `IsExternalInit` polyfill, and Newtonsoft `ShouldSerialize{Property}` methods). Do not treat those as `PublicCandidate` triage items.
 - `PublicCandidate` means Roslyn found no direct references. Check non-C# references such as `release-please-config.json`, checked-in JSON contracts, Unity assets, generated files, and documented public APIs before removing or commenting the symbol.
 - If a symbol is referenced only by non-C# tooling, verify that the tool reads it for runtime or release behavior. If the tool only rewrites the symbol and no code reads it, remove the marker instead of documenting it.
 

--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/CommandLineOptionsTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/CommandLineOptionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using UnityCliLoop.DeadCodeScanner;
 
@@ -23,6 +24,40 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
 
             Assert.That(highConfidenceOptions.FailOnHighConfidence, Is.True);
             Assert.That(noneOptions.FailOnHighConfidence, Is.False);
+        }
+
+        // Verifies that --max-public-candidates parses integers and defaults to unlimited (-1).
+        [Test]
+        public void Parse_WhenMaxPublicCandidatesIsProvidedOrOmitted_ShouldSetLimitOrLeaveUnlimited()
+        {
+            ScanOptions limitedOptions = CommandLineOptions.Parse(new[]
+            {
+                "--max-public-candidates",
+                "22"
+            });
+            ScanOptions defaultOptions = CommandLineOptions.Parse(Array.Empty<string>());
+            ScanOptions negativeOptions = CommandLineOptions.Parse(new[]
+            {
+                "--max-public-candidates",
+                "-1"
+            });
+
+            Assert.That(limitedOptions.MaxPublicCandidates, Is.EqualTo(22));
+            Assert.That(defaultOptions.MaxPublicCandidates, Is.EqualTo(-1));
+            Assert.That(negativeOptions.MaxPublicCandidates, Is.EqualTo(-1));
+        }
+
+        // Verifies that a non-integer --max-public-candidates value is rejected.
+        [Test]
+        public void Parse_WhenMaxPublicCandidatesIsNotInteger_ShouldThrow()
+        {
+            Assert.That(
+                () => CommandLineOptions.Parse(new[]
+                {
+                    "--max-public-candidates",
+                    "abc"
+                }),
+                Throws.ArgumentException);
         }
     }
 }

--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
@@ -69,7 +69,8 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 includeTestOnly: true,
                 includeKept: false,
                 ReportFormat.Table,
-                failOnHighConfidence: false);
+                failOnHighConfidence: false,
+                maxPublicCandidates: -1);
 
             System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
                 await scanner.ScanAsync(options, CancellationToken.None);
@@ -97,7 +98,8 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 includeTestOnly: true,
                 includeKept: false,
                 ReportFormat.Table,
-                failOnHighConfidence: false);
+                failOnHighConfidence: false,
+                maxPublicCandidates: -1);
 
             System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
                 await scanner.ScanAsync(options, CancellationToken.None);
@@ -134,7 +136,8 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 includeTestOnly: true,
                 includeKept: true,
                 ReportFormat.Table,
-                failOnHighConfidence: false);
+                failOnHighConfidence: false,
+                maxPublicCandidates: -1);
 
             System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
                 await scanner.ScanAsync(options, CancellationToken.None);
@@ -269,6 +272,47 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 && issue.FullName.Contains("IsExternalInit", StringComparison.Ordinal)), Is.False);
         }
 
+        /// <summary>
+        /// Verifies that Newtonsoft ShouldSerialize{Property} methods are kept as
+        /// KeptByUnityOrReflection and are not reported as PublicCandidate.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenShouldSerializeMethodHasNoDirectReferences_ShouldReportKeptAndNotPublicCandidate()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: true);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("ShouldSerializeOptionalNote", StringComparison.Ordinal)), Is.True);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("ShouldSerializeOptionalNote", StringComparison.Ordinal)), Is.False);
+        }
+
+        /// <summary>
+        /// Verifies that a ShouldSerialize* method without a matching property/field is not kept.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenShouldSerializeMethodHasNoMatchingMember_ShouldNotReportKept()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: true);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("ShouldSerializeMissingMember", StringComparison.Ordinal)), Is.False);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("ShouldSerializeMissingMember", StringComparison.Ordinal)), Is.True);
+        }
+
         private static ScanOptions CreatePublicScopeOptions(string rootPath, bool includeKept)
         {
             return new ScanOptions(
@@ -280,7 +324,8 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 includeTestOnly: true,
                 includeKept,
                 ReportFormat.Table,
-                failOnHighConfidence: false);
+                failOnHighConfidence: false,
+                maxPublicCandidates: -1);
         }
 
         private static void CreateSampleRepository(string rootPath)
@@ -362,6 +407,21 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
 
                     public sealed class UnreferencedPublicApi
                     {
+                    }
+
+                    public sealed class JsonOptionalPayload
+                    {
+                        public string OptionalNote { get; set; } = string.Empty;
+
+                        public bool ShouldSerializeOptionalNote()
+                        {
+                            return !string.IsNullOrEmpty(OptionalNote);
+                        }
+
+                        public bool ShouldSerializeMissingMember()
+                        {
+                            return false;
+                        }
                     }
 
                     public sealed class TestOnlyFactory

--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
@@ -173,6 +173,49 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
         }
 
         /// <summary>
+        /// Verifies that Packages/src/Runtime asmdefs are loaded as production and scanned for
+        /// unreferenced public symbols.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenRuntimeAsmdefDefinesUnreferencedPublicType_ShouldReportPublicCandidate()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: false);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.SymbolKind == "type"
+                && issue.FullName.Contains("UnreferencedRuntimeApi", StringComparison.Ordinal)
+                && issue.AssemblyName == "Sample.Runtime"), Is.True);
+        }
+
+        /// <summary>
+        /// Verifies that a Runtime internal member referenced from an Editor assembly through
+        /// InternalsVisibleTo is not reported as any finding.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenRuntimeInternalMemberIsReferencedFromEditorViaInternalsVisibleTo_ShouldNotReportFinding()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: false);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.FullName.Contains("RuntimeInternalUsedByEditor", StringComparison.Ordinal)), Is.False);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("RuntimeInternalUsedByEditor", StringComparison.Ordinal)), Is.False);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.TestOnly
+                && issue.FullName.Contains("RuntimeInternalUsedByEditor", StringComparison.Ordinal)), Is.False);
+        }
+
+        /// <summary>
         /// Verifies that compiler-bound awaiter members are kept as KeptByUnityOrReflection
         /// and are not reported as PublicCandidate.
         /// </summary>
@@ -243,9 +286,11 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
         private static void CreateSampleRepository(string rootPath)
         {
             string packageDirectory = Path.Combine(rootPath, "Packages", "src", "Editor", "Sample");
+            string runtimeDirectory = Path.Combine(rootPath, "Packages", "src", "Runtime", "SampleRuntime");
             string assetsDirectory = Path.Combine(rootPath, "Assets", "Tests");
             string assetsTestAsmdefDirectory = Path.Combine(assetsDirectory, "Editor");
             Directory.CreateDirectory(packageDirectory);
+            Directory.CreateDirectory(runtimeDirectory);
             Directory.CreateDirectory(assetsDirectory);
             Directory.CreateDirectory(assetsTestAsmdefDirectory);
 
@@ -254,7 +299,7 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 """
                 {
                   "name": "Sample.Editor",
-                  "references": [],
+                  "references": ["GUID:33333333333333333333333333333333"],
                   "includePlatforms": ["Editor"],
                   "versionDefines": []
                 }
@@ -298,6 +343,7 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                             usedField++;
                             int unusedLocal = 1;
                             UsedPrivateMethod();
+                            usedField += Sample.Runtime.RuntimeInternalApi.RuntimeInternalUsedByEditor();
                         }
 
                         private void UsedPrivateMethod()
@@ -354,6 +400,44 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 {
                     public sealed class IsExternalInit
                     {
+                    }
+                }
+                """);
+            WriteFile(
+                Path.Combine(runtimeDirectory, "Sample.Runtime.asmdef"),
+                """
+                {
+                  "name": "Sample.Runtime",
+                  "references": [],
+                  "includePlatforms": [],
+                  "versionDefines": []
+                }
+                """);
+            WriteFile(
+                Path.Combine(runtimeDirectory, "Sample.Runtime.asmdef.meta"),
+                """
+                fileFormatVersion: 2
+                guid: 33333333333333333333333333333333
+                """);
+            WriteFile(
+                Path.Combine(runtimeDirectory, "RuntimeCode.cs"),
+                """
+                using System.Runtime.CompilerServices;
+
+                [assembly: InternalsVisibleTo("Sample.Editor")]
+
+                namespace Sample.Runtime
+                {
+                    public sealed class UnreferencedRuntimeApi
+                    {
+                    }
+
+                    public static class RuntimeInternalApi
+                    {
+                        internal static int RuntimeInternalUsedByEditor()
+                        {
+                            return 1;
+                        }
                     }
                 }
                 """);

--- a/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
+++ b/tests/UnityCliLoop.DeadCodeScanner.Tests/DeadCodeScannerTests.cs
@@ -151,12 +151,103 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 && issue.FullName.Contains("UsedProductionApi", StringComparison.Ordinal)), Is.True);
         }
 
+        /// <summary>
+        /// Verifies that an internal production member referenced through InternalsVisibleTo from an
+        /// Assets asmdef is classified as TestOnly instead of PublicCandidate.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenInternalMemberIsReferencedViaAssetsAsmdefInternalsVisibleTo_ShouldReportTestOnly()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: false);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.TestOnly
+                && issue.FullName.Contains("CreateForTesting", StringComparison.Ordinal)), Is.True);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("CreateForTesting", StringComparison.Ordinal)), Is.False);
+        }
+
+        /// <summary>
+        /// Verifies that compiler-bound awaiter members are kept as KeptByUnityOrReflection
+        /// and are not reported as PublicCandidate.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenAwaitPatternMembersHaveNoDirectReferences_ShouldReportKeptAndNotPublicCandidate()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: true);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("SampleAwaitable.Awaiter.IsCompleted", StringComparison.Ordinal)), Is.True);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("SampleAwaitable.Awaiter.GetResult", StringComparison.Ordinal)), Is.True);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("SampleAwaitable.GetAwaiter", StringComparison.Ordinal)), Is.True);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("SampleAwaitable.Awaiter.IsCompleted", StringComparison.Ordinal)), Is.False);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("SampleAwaitable.Awaiter.GetResult", StringComparison.Ordinal)), Is.False);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("SampleAwaitable.GetAwaiter", StringComparison.Ordinal)), Is.False);
+        }
+
+        /// <summary>
+        /// Verifies that the IsExternalInit polyfill type is kept as KeptByUnityOrReflection
+        /// and is not reported as PublicCandidate.
+        /// </summary>
+        [Test]
+        public async Task ScanAsync_WhenIsExternalInitPolyfillHasNoDirectReferences_ShouldReportKeptAndNotPublicCandidate()
+        {
+            DeadCodeScanner scanner = new();
+            ScanOptions options = CreatePublicScopeOptions(_rootPath, includeKept: true);
+
+            System.Collections.Generic.IReadOnlyList<DeadCodeIssue> issues =
+                await scanner.ScanAsync(options, CancellationToken.None);
+
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.KeptByUnityOrReflection
+                && issue.FullName.Contains("IsExternalInit", StringComparison.Ordinal)), Is.True);
+            Assert.That(issues.Any(issue =>
+                issue.Category == DeadCodeCategory.PublicCandidate
+                && issue.FullName.Contains("IsExternalInit", StringComparison.Ordinal)), Is.False);
+        }
+
+        private static ScanOptions CreatePublicScopeOptions(string rootPath, bool includeKept)
+        {
+            return new ScanOptions(
+                rootPath,
+                ScanScope.Public,
+                includeTypes: true,
+                includeMembers: true,
+                includeLocals: false,
+                includeTestOnly: true,
+                includeKept,
+                ReportFormat.Table,
+                failOnHighConfidence: false);
+        }
+
         private static void CreateSampleRepository(string rootPath)
         {
             string packageDirectory = Path.Combine(rootPath, "Packages", "src", "Editor", "Sample");
             string assetsDirectory = Path.Combine(rootPath, "Assets", "Tests");
+            string assetsTestAsmdefDirectory = Path.Combine(assetsDirectory, "Editor");
             Directory.CreateDirectory(packageDirectory);
             Directory.CreateDirectory(assetsDirectory);
+            Directory.CreateDirectory(assetsTestAsmdefDirectory);
 
             WriteFile(
                 Path.Combine(packageDirectory, "Sample.asmdef"),
@@ -178,6 +269,9 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                 Path.Combine(packageDirectory, "SampleCode.cs"),
                 """
                 using System;
+                using System.Runtime.CompilerServices;
+
+                [assembly: InternalsVisibleTo("Sample.Tests")]
 
                 namespace Sample
                 {
@@ -227,6 +321,40 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                     public sealed class TestOnlyFactory
                     {
                     }
+
+                    public sealed class InternalVisibleApi
+                    {
+                        internal static int CreateForTesting()
+                        {
+                            return 1;
+                        }
+                    }
+
+                    public struct SampleAwaitable
+                    {
+                        public Awaiter GetAwaiter() => new();
+
+                        public struct Awaiter : INotifyCompletion
+                        {
+                            public bool IsCompleted => true;
+
+                            public void GetResult()
+                            {
+                            }
+
+                            public void OnCompleted(Action continuation)
+                            {
+                                continuation();
+                            }
+                        }
+                    }
+                }
+
+                namespace System.Runtime.CompilerServices
+                {
+                    public sealed class IsExternalInit
+                    {
+                    }
                 }
                 """);
             WriteFile(
@@ -239,6 +367,36 @@ namespace UnityCliLoop.DeadCodeScanner.Tests
                         public object Create()
                         {
                             return new Sample.TestOnlyFactory();
+                        }
+                    }
+                }
+                """);
+            WriteFile(
+                Path.Combine(assetsTestAsmdefDirectory, "Sample.Tests.asmdef"),
+                """
+                {
+                  "name": "Sample.Tests",
+                  "references": ["Sample.Editor"],
+                  "includePlatforms": ["Editor"],
+                  "versionDefines": []
+                }
+                """);
+            WriteFile(
+                Path.Combine(assetsTestAsmdefDirectory, "Sample.Tests.asmdef.meta"),
+                """
+                fileFormatVersion: 2
+                guid: 22222222222222222222222222222222
+                """);
+            WriteFile(
+                Path.Combine(assetsTestAsmdefDirectory, "SampleInternalUsage.cs"),
+                """
+                namespace SampleConsumer
+                {
+                    public sealed class SampleInternalUsage
+                    {
+                        public int Create()
+                        {
+                            return Sample.InternalVisibleApi.CreateForTesting();
                         }
                     }
                 }

--- a/tools/UnityCliLoop.DeadCodeScanner/AsmdefWorkspaceBuilder.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/AsmdefWorkspaceBuilder.cs
@@ -27,9 +27,11 @@ namespace UnityCliLoop.DeadCodeScanner
 
         public WorkspaceBuildResult Build(string rootPath)
         {
-            string editorRoot = Path.Combine(rootPath, "Packages", "src", "Editor");
+            // Why: production code lives under both Editor and Runtime; loading only Editor
+            // drops Runtime asmdefs so IVT/friend references and Runtime finding coverage break.
+            string packageSrcRoot = Path.Combine(rootPath, "Packages", "src");
             string assetsRoot = Path.Combine(rootPath, "Assets");
-            IReadOnlyList<AsmdefProjectInfo> productionAsmdefs = LoadAsmdefs(editorRoot);
+            IReadOnlyList<AsmdefProjectInfo> productionAsmdefs = LoadAsmdefs(packageSrcRoot);
             IReadOnlyList<AsmdefProjectInfo> assetsAsmdefs = Directory.Exists(assetsRoot)
                 ? LoadAsmdefs(assetsRoot)
                 : Array.Empty<AsmdefProjectInfo>();

--- a/tools/UnityCliLoop.DeadCodeScanner/AsmdefWorkspaceBuilder.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/AsmdefWorkspaceBuilder.cs
@@ -28,7 +28,12 @@ namespace UnityCliLoop.DeadCodeScanner
         public WorkspaceBuildResult Build(string rootPath)
         {
             string editorRoot = Path.Combine(rootPath, "Packages", "src", "Editor");
-            IReadOnlyList<AsmdefProjectInfo> asmdefs = LoadAsmdefs(editorRoot);
+            string assetsRoot = Path.Combine(rootPath, "Assets");
+            IReadOnlyList<AsmdefProjectInfo> productionAsmdefs = LoadAsmdefs(editorRoot);
+            IReadOnlyList<AsmdefProjectInfo> assetsAsmdefs = Directory.Exists(assetsRoot)
+                ? LoadAsmdefs(assetsRoot)
+                : Array.Empty<AsmdefProjectInfo>();
+
             Dictionary<string, ProjectId> projectIdsByName = new(StringComparer.Ordinal);
             Dictionary<string, ProjectId> projectIdsByGuid = new(StringComparer.OrdinalIgnoreCase);
             Dictionary<ProjectId, ProjectAnalysisInfo> projectInfoById = new();
@@ -36,8 +41,56 @@ namespace UnityCliLoop.DeadCodeScanner
             Solution solution = workspace.CurrentSolution;
             ImmutableArray<MetadataReference> metadataReferences = CreateMetadataReferences();
 
+            solution = AddAsmdefProjects(
+                solution,
+                productionAsmdefs,
+                isProduction: true,
+                projectIdsByName,
+                projectIdsByGuid,
+                projectInfoById,
+                metadataReferences);
+            ProjectId[] productionProjectIds = projectInfoById
+                .Where(pair => pair.Value.IsProduction)
+                .Select(pair => pair.Key)
+                .ToArray();
+
+            solution = AddAsmdefProjects(
+                solution,
+                assetsAsmdefs,
+                isProduction: false,
+                projectIdsByName,
+                projectIdsByGuid,
+                projectInfoById,
+                metadataReferences);
+
+            AsmdefProjectInfo[] allAsmdefs = productionAsmdefs.Concat(assetsAsmdefs).ToArray();
+            solution = AddAsmdefProjectReferences(solution, allAsmdefs, projectIdsByName, projectIdsByGuid);
+            solution = AddOrphanAssetsProject(
+                assetsRoot,
+                assetsAsmdefs,
+                solution,
+                productionProjectIds,
+                projectInfoById,
+                metadataReferences);
+            return new WorkspaceBuildResult(solution, projectInfoById);
+        }
+
+        private static Solution AddAsmdefProjects(
+            Solution solution,
+            IReadOnlyList<AsmdefProjectInfo> asmdefs,
+            bool isProduction,
+            Dictionary<string, ProjectId> projectIdsByName,
+            Dictionary<string, ProjectId> projectIdsByGuid,
+            Dictionary<ProjectId, ProjectAnalysisInfo> projectInfoById,
+            ImmutableArray<MetadataReference> metadataReferences)
+        {
             foreach (AsmdefProjectInfo asmdef in asmdefs)
             {
+                if (projectIdsByName.ContainsKey(asmdef.Name))
+                {
+                    throw new InvalidOperationException($"Duplicate asmdef assembly name: {asmdef.Name}");
+                }
+
                 ProjectId projectId = ProjectId.CreateNewId(asmdef.Name);
                 projectIdsByName[asmdef.Name] = projectId;
                 string guid = ReadAsmdefGuid(asmdef.DirectoryPath, asmdef.Name);
@@ -57,7 +110,7 @@ namespace UnityCliLoop.DeadCodeScanner
                     metadataReferences: metadataReferences);
 
                 solution = solution.AddProject(projectInfo);
-                projectInfoById[projectId] = new ProjectAnalysisInfo(projectId, isProduction: true);
+                projectInfoById[projectId] = new ProjectAnalysisInfo(projectId, isProduction);
 
                 foreach (string sourceFile in asmdef.SourceFiles)
                 {
@@ -67,14 +120,17 @@ namespace UnityCliLoop.DeadCodeScanner
                 }
             }
 
-            solution = AddAsmdefProjectReferences(solution, asmdefs, projectIdsByName, projectIdsByGuid);
-            solution = AddAssetsProject(rootPath, solution, projectIdsByName.Values.ToArray(), projectInfoById, metadataReferences);
-            return new WorkspaceBuildResult(solution, projectInfoById);
+            return solution;
         }
 
-        private static IReadOnlyList<AsmdefProjectInfo> LoadAsmdefs(string editorRoot)
+        private static IReadOnlyList<AsmdefProjectInfo> LoadAsmdefs(string rootDirectory)
         {
-            string[] asmdefPaths = Directory.GetFiles(editorRoot, "*.asmdef", SearchOption.AllDirectories)
+            if (!Directory.Exists(rootDirectory))
+            {
+                return Array.Empty<AsmdefProjectInfo>();
+            }
+
+            string[] asmdefPaths = Directory.GetFiles(rootDirectory, "*.asmdef", SearchOption.AllDirectories)
                 .OrderBy(path => path, StringComparer.Ordinal)
                 .ToArray();
             List<AsmdefProjectInfo> projects = new();
@@ -85,7 +141,7 @@ namespace UnityCliLoop.DeadCodeScanner
             foreach (string asmdefPath in asmdefPaths)
             {
                 AsmdefJson json = ReadAsmdefJson(asmdefPath);
-                string directoryPath = Path.GetDirectoryName(asmdefPath) ?? editorRoot;
+                string directoryPath = Path.GetDirectoryName(asmdefPath) ?? rootDirectory;
                 string[] sourceFiles = Directory.GetFiles(directoryPath, "*.cs", SearchOption.AllDirectories)
                     .Where(path => IsOwnedByAsmdefDirectory(path, directoryPath, asmdefDirectories))
                     .OrderBy(path => path, StringComparer.Ordinal)
@@ -191,23 +247,29 @@ namespace UnityCliLoop.DeadCodeScanner
             return projectIdsByName.TryGetValue(reference, out ProjectId? namedProjectId) ? namedProjectId : null;
         }
 
-        private static Solution AddAssetsProject(
-            string rootPath,
+        // Why: Unity puts leftover Assets scripts into Assembly-CSharp(-Editor); keep that fallback so
+        // files outside any Assets asmdef still contribute non-production references.
+        private static Solution AddOrphanAssetsProject(
+            string assetsRoot,
+            IReadOnlyList<AsmdefProjectInfo> assetsAsmdefs,
             Solution solution,
             ProjectId[] productionProjectIds,
             Dictionary<ProjectId, ProjectAnalysisInfo> projectInfoById,
             ImmutableArray<MetadataReference> metadataReferences)
         {
-            string assetsRoot = Path.Combine(rootPath, "Assets");
             if (!Directory.Exists(assetsRoot))
             {
                 return solution;
             }
 
-            string[] sourceFiles = Directory.GetFiles(assetsRoot, "*.cs", SearchOption.AllDirectories)
+            HashSet<string> ownedSourceFiles = assetsAsmdefs
+                .SelectMany(asmdef => asmdef.SourceFiles)
+                .ToHashSet(StringComparer.Ordinal);
+            string[] orphanSourceFiles = Directory.GetFiles(assetsRoot, "*.cs", SearchOption.AllDirectories)
+                .Where(path => !ownedSourceFiles.Contains(path))
                 .OrderBy(path => path, StringComparer.Ordinal)
                 .ToArray();
-            if (sourceFiles.Length == 0)
+            if (orphanSourceFiles.Length == 0)
             {
                 return solution;
             }
@@ -230,7 +292,7 @@ namespace UnityCliLoop.DeadCodeScanner
                 solution = solution.AddProjectReference(projectId, new ProjectReference(productionProjectId));
             }
 
-            foreach (string sourceFile in sourceFiles)
+            foreach (string sourceFile in orphanSourceFiles)
             {
                 DocumentId documentId = DocumentId.CreateNewId(projectId, sourceFile);
                 SourceText sourceText = SourceText.From(File.ReadAllText(sourceFile));

--- a/tools/UnityCliLoop.DeadCodeScanner/CommandLineOptions.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/CommandLineOptions.cs
@@ -20,6 +20,7 @@ namespace UnityCliLoop.DeadCodeScanner
             bool includeKept = defaults.IncludeKept;
             ReportFormat format = defaults.Format;
             bool failOnHighConfidence = defaults.FailOnHighConfidence;
+            int maxPublicCandidates = defaults.MaxPublicCandidates;
 
             for (int index = 0; index < args.Length; index++)
             {
@@ -78,6 +79,14 @@ namespace UnityCliLoop.DeadCodeScanner
                     continue;
                 }
 
+                if (argument == "--max-public-candidates")
+                {
+                    maxPublicCandidates = ParseMaxPublicCandidates(
+                        ReadValue(args, ref index, argument),
+                        argument);
+                    continue;
+                }
+
                 if (argument == "--help" || argument == "-h")
                 {
                     throw new ArgumentException(CreateHelpText());
@@ -95,7 +104,8 @@ namespace UnityCliLoop.DeadCodeScanner
                 includeTestOnly,
                 includeKept,
                 format,
-                failOnHighConfidence);
+                failOnHighConfidence,
+                maxPublicCandidates);
         }
 
         public static string CreateHelpText()
@@ -113,7 +123,9 @@ namespace UnityCliLoop.DeadCodeScanner
                 "  --include-test-only true|false   Include test-only findings. Defaults to true.",
                 "  --include-kept true|false        Include Unity/reflection-kept findings. Defaults to false.",
                 "  --format table|json              Output format. Defaults to table.",
-                "  --fail-on none|high-confidence   Exit 1 for high confidence findings.");
+                "  --fail-on none|high-confidence   Exit 1 for high confidence findings.",
+                "  --max-public-candidates <n>      Exit 1 when PublicCandidate count exceeds n.",
+                "                                   Negative or omitted disables the limit.");
         }
 
         private static string ReadValue(string[] args, ref int index, string optionName)
@@ -179,6 +191,16 @@ namespace UnityCliLoop.DeadCodeScanner
             }
 
             throw new ArgumentException($"Unsupported fail-on value '{value}'.");
+        }
+
+        private static int ParseMaxPublicCandidates(string value, string optionName)
+        {
+            if (!int.TryParse(value.Trim(), out int parsed))
+            {
+                throw new ArgumentException($"{optionName} expects an integer.");
+            }
+
+            return parsed;
         }
 
         private static bool ParseBoolean(string value, string optionName)

--- a/tools/UnityCliLoop.DeadCodeScanner/DeadCodeModels.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/DeadCodeModels.cs
@@ -50,6 +50,11 @@ namespace UnityCliLoop.DeadCodeScanner
         public ReportFormat Format { get; }
         public bool FailOnHighConfidence { get; }
 
+        /// <summary>
+        /// Maximum allowed PublicCandidate count. Negative means no limit.
+        /// </summary>
+        public int MaxPublicCandidates { get; }
+
         public ScanOptions(
             string rootPath,
             ScanScope scope,
@@ -59,7 +64,8 @@ namespace UnityCliLoop.DeadCodeScanner
             bool includeTestOnly,
             bool includeKept,
             ReportFormat format,
-            bool failOnHighConfidence)
+            bool failOnHighConfidence,
+            int maxPublicCandidates)
         {
             RootPath = rootPath;
             Scope = scope;
@@ -70,6 +76,7 @@ namespace UnityCliLoop.DeadCodeScanner
             IncludeKept = includeKept;
             Format = format;
             FailOnHighConfidence = failOnHighConfidence;
+            MaxPublicCandidates = maxPublicCandidates;
         }
 
         public static ScanOptions Default(string rootPath)
@@ -83,7 +90,8 @@ namespace UnityCliLoop.DeadCodeScanner
                 includeTestOnly: true,
                 includeKept: false,
                 ReportFormat.Table,
-                failOnHighConfidence: false);
+                failOnHighConfidence: false,
+                maxPublicCandidates: -1);
         }
     }
 

--- a/tools/UnityCliLoop.DeadCodeScanner/Program.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/Program.cs
@@ -29,7 +29,13 @@ namespace UnityCliLoop.DeadCodeScanner
             IReadOnlyList<DeadCodeIssue> issues = await scanner.ScanAsync(options, ct);
             DeadCodeReporter.Write(issues, options);
 
-            if (options.FailOnHighConfidence && issues.Any(issue => issue.IsHighConfidenceDeletionCandidate()))
+            bool failedOnHighConfidence = options.FailOnHighConfidence
+                && issues.Any(issue => issue.IsHighConfidenceDeletionCandidate());
+            bool failedOnPublicCandidateLimit = options.MaxPublicCandidates >= 0
+                && issues.Count(issue => issue.Category == DeadCodeCategory.PublicCandidate)
+                    > options.MaxPublicCandidates;
+
+            if (failedOnHighConfidence || failedOnPublicCandidateLimit)
             {
                 return 1;
             }

--- a/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
@@ -91,6 +91,14 @@ namespace UnityCliLoop.DeadCodeScanner
                     "Member is part of the compiler-bound awaiter pattern.");
             }
 
+            // Why: Newtonsoft.Json discovers ShouldSerialize{Property} by name convention and
+            // invokes it via reflection, so reference search never sees call sites.
+            if (IsNewtonsoftShouldSerializeMethod(symbol))
+            {
+                return KeeperDecision.Keep(
+                    "Method matches the Newtonsoft.Json ShouldSerialize{Property} naming convention.");
+            }
+
             if (symbol is INamedTypeSymbol namedType && HasKeptBaseType(namedType))
             {
                 return KeeperDecision.Keep("Type derives from a Unity entry-point base class.");
@@ -155,6 +163,37 @@ namespace UnityCliLoop.DeadCodeScanner
             }
 
             return IsAwaiterType(symbol.ContainingType);
+        }
+
+        private static bool IsNewtonsoftShouldSerializeMethod(ISymbol symbol)
+        {
+            if (symbol is not IMethodSymbol methodSymbol)
+            {
+                return false;
+            }
+
+            if (methodSymbol.IsStatic || methodSymbol.Parameters.Length != 0)
+            {
+                return false;
+            }
+
+            if (methodSymbol.ReturnType.SpecialType != SpecialType.System_Boolean)
+            {
+                return false;
+            }
+
+            const string Prefix = "ShouldSerialize";
+            if (!methodSymbol.Name.StartsWith(Prefix, StringComparison.Ordinal)
+                || methodSymbol.Name.Length <= Prefix.Length)
+            {
+                return false;
+            }
+
+            // Why: Newtonsoft only invokes ShouldSerialize{PropertyName} when that member exists.
+            // Keeping every ShouldSerialize* name would let dead methods silence the scanner.
+            string propertyName = methodSymbol.Name.Substring(Prefix.Length);
+            return methodSymbol.ContainingType.GetMembers(propertyName)
+                .Any(member => member is IPropertySymbol || member is IFieldSymbol);
         }
 
         private static bool IsAwaiterType(ITypeSymbol typeSymbol)

--- a/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
+++ b/tools/UnityCliLoop.DeadCodeScanner/UnityKeeperClassifier.cs
@@ -59,12 +59,36 @@ namespace UnityCliLoop.DeadCodeScanner
             "OnValidate"
         };
 
+        private static readonly HashSet<string> AwaiterMemberNames = new(StringComparer.Ordinal)
+        {
+            "IsCompleted",
+            "GetResult",
+            "OnCompleted",
+            "UnsafeOnCompleted"
+        };
+
         public static KeeperDecision Classify(ISymbol symbol)
         {
             string attributeReason = FindKeptAttributeReason(symbol);
             if (!string.IsNullOrEmpty(attributeReason))
             {
                 return KeeperDecision.Keep(attributeReason);
+            }
+
+            // Why: the C# compiler resolves init accessors by this exact type name, so Roslyn
+            // reference search never sees call sites even though deleting the polyfill breaks builds.
+            if (IsCompilerRequiredIsExternalInit(symbol))
+            {
+                return KeeperDecision.Keep(
+                    "Type is the compiler-required IsExternalInit polyfill for init accessors.");
+            }
+
+            // Why: await expressions bind GetAwaiter/IsCompleted/GetResult/OnCompleted by name;
+            // SymbolFinder therefore reports zero references for these members.
+            if (IsCompilerRequiredAwaitPatternMember(symbol))
+            {
+                return KeeperDecision.Keep(
+                    "Member is part of the compiler-bound awaiter pattern.");
             }
 
             if (symbol is INamedTypeSymbol namedType && HasKeptBaseType(namedType))
@@ -96,6 +120,61 @@ namespace UnityCliLoop.DeadCodeScanner
             }
 
             return KeeperDecision.Scan();
+        }
+
+        private static bool IsCompilerRequiredIsExternalInit(ISymbol symbol)
+        {
+            if (symbol is not INamedTypeSymbol typeSymbol)
+            {
+                return false;
+            }
+
+            if (!string.Equals(typeSymbol.Name, "IsExternalInit", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            string containingNamespace = typeSymbol.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+            return string.Equals(
+                containingNamespace,
+                "System.Runtime.CompilerServices",
+                StringComparison.Ordinal);
+        }
+
+        private static bool IsCompilerRequiredAwaitPatternMember(ISymbol symbol)
+        {
+            if (symbol is IMethodSymbol getAwaiterMethod
+                && string.Equals(getAwaiterMethod.Name, "GetAwaiter", StringComparison.Ordinal))
+            {
+                return IsAwaiterType(getAwaiterMethod.ReturnType);
+            }
+
+            if (!AwaiterMemberNames.Contains(symbol.Name) || symbol.ContainingType == null)
+            {
+                return false;
+            }
+
+            return IsAwaiterType(symbol.ContainingType);
+        }
+
+        private static bool IsAwaiterType(ITypeSymbol typeSymbol)
+        {
+            return typeSymbol.AllInterfaces.Any(IsCompilerServicesAwaiterInterface);
+        }
+
+        private static bool IsCompilerServicesAwaiterInterface(INamedTypeSymbol interfaceType)
+        {
+            if (!string.Equals(interfaceType.Name, "INotifyCompletion", StringComparison.Ordinal)
+                && !string.Equals(interfaceType.Name, "ICriticalNotifyCompletion", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            string containingNamespace = interfaceType.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+            return string.Equals(
+                containingNamespace,
+                "System.Runtime.CompilerServices",
+                StringComparison.Ordinal);
         }
 
         private static string FindKeptAttributeReason(ISymbol symbol)


### PR DESCRIPTION
## Summary

Closes the PublicCandidate triage for issue #1997: scanner accuracy fixes, bucketed deletion/keep decisions, intentional-keep documentation, Newtonsoft `ShouldSerialize*` structural keep, and a CI ceiling on `PublicCandidate` count.

Closes #1997

## PublicCandidate progression

| Milestone | PublicCandidate | Notes |
|---|---:|---|
| Pre-scanner-fix baseline | **185** | Issue starting point |
| After PR-0 + PR-0b (scanner accuracy + Runtime in production scan) | **113** | Assets asmdef accuracy; Runtime included |
| After PR-1 (internal) | **95** | internal PC → 0 |
| After PR-3 (ExecuteDynamicCode) | **86** | deleted unused members; kept `Error` + `ShouldSerialize*` |
| After PR-4 (Domain/Application/Infrastructure/Presentation) | **47** | kept ErrorData.type family |
| After PR-5 (FirstPartyTools + Runtime) | **33** | Skill/CLI/reflection keepers retained |
| After PR-6 (ToolContracts) | **28** | documented extension API keeps |
| After PR-7 (`ShouldSerialize*` keep + PC gate) | **22** | CI `--max-public-candidates 22` |

High-confidence findings stayed at **0** throughout.

## What each PR did

| PR | What changed |
|---|---|
| **PR-0** (#2000) | Accurate Assets asmdef classification; keep await-pattern / `IsExternalInit` |
| **PR-0b** (#2002) | Include `Packages/src` Runtime asmdefs in production scan |
| **PR-1** (#2004) | Remove unreferenced internal PublicCandidates (+ boy-scout private leftovers) |
| **PR-2** | Folded into PR-1 during triage; the number is intentionally unused. |
| **PR-3** (#2005) | Triage ExecuteDynamicCode public members |
| **PR-4** (#2006) | Triage Domain / Application / Infrastructure / Presentation |
| **PR-5** (#2007) | Triage remaining FirstPartyTools + Runtime |
| **PR-6** (#2009) | Triage ToolContracts; document intentional keeps (registrar, migration capture façade, `Error`) |
| **PR-7** (#2010) | Keep Newtonsoft `ShouldSerialize{Property}` structurally; add `--max-public-candidates` CI gate at **22** |

Intentionally retained PublicCandidates are listed in `docs/dead-code-scanner.md`.

## Out of scope

- Known EditMode failures in `NativeCliInstallerTests` / `ToolSkillSynchronizerTests` are tracked as **#2001** and are **out of scope for this PR**.
- Post-triage cleanup such as dead `showUnityCliLoopSecuritySetting` carry (plan To-Do 7b) remains a separate follow-up.

## Test plan

- [x] Dead Code workflow runs on this PR (not skipped) and is green with `--max-public-candidates 22`
- [ ] Other required CI checks green
- [ ] Confirm docs table + gate docs land on `v3-beta`
