### PR TITLE
fix: Reject non-name key inputs in simulate-keyboard

### DIFF
--- a/Assets/Tests/Editor/KeyboardKeyNameSuggesterTests.cs
+++ b/Assets/Tests/Editor/KeyboardKeyNameSuggesterTests.cs
@@ -19,6 +19,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(suggestions, Does.Contain("Numpad3"));
         }
 
+        // Verifies non-ASCII digits do not produce Digit/Numpad names that no Key enum value has.
+        [Test]
+        public void Suggest_ForFullWidthDigit_DoesNotSuggestDigitNames()
+        {
+            IReadOnlyList<string> suggestions = KeyboardKeyNameSuggester.Suggest("３");
+
+            Assert.That(suggestions, Does.Not.Contain("Digit３"));
+            Assert.That(suggestions, Does.Not.Contain("Numpad３"));
+            Assert.That(suggestions.Any(name => name.StartsWith("Digit")), Is.False);
+        }
+
         // Verifies partial key names still return close enum matches.
         [Test]
         public void Suggest_ForPartialName_ReturnsPrefixMatches()

--- a/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
+++ b/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
@@ -652,6 +652,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             Assert.IsFalse(lastResponse.Success, "A bare digit must not be accepted as a Key enum ordinal");
             StringAssert.Contains("Digit3", lastResponse.Message);
             StringAssert.Contains("Numpad3", lastResponse.Message);
+            StringAssert.Contains("Digits are not key names", lastResponse.Message);
+            StringAssert.Contains("re-check any earlier results", lastResponse.Message);
         }
 
         /// <summary>
@@ -669,6 +671,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             });
 
             Assert.IsFalse(lastResponse.Success, "A signed numeric key must not be accepted as a Key enum ordinal");
+            StringAssert.Contains("Digits are not key names", lastResponse.Message);
+            StringAssert.Contains("re-check any earlier results", lastResponse.Message);
         }
 
         /// <summary>
@@ -704,6 +708,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             });
 
             Assert.IsFalse(lastResponse.Success, "An undefined numeric key must fail validation rather than throw");
+            StringAssert.Contains("Digits are not key names", lastResponse.Message);
+            StringAssert.Contains("re-check any earlier results", lastResponse.Message);
         }
 
         /// <summary>

--- a/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
+++ b/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
@@ -690,6 +690,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             });
 
             Assert.IsFalse(lastResponse.Success, "A comma-separated key list must not be OR-ed into a single key");
+            StringAssert.Contains("Invalid key name", lastResponse.Message);
+            // The digit guidance is scoped to numeric input, so it must not appear here.
+            StringAssert.DoesNotContain("Digits are not key names", lastResponse.Message);
+        }
+
+        /// <summary>
+        /// Verifies that a whitespace-padded digit is rejected, closing the Enum.TryParse path that
+        /// trimmed the input before reading it as an enum ordinal.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Press_WithPaddedDigitKey_Should_ReturnFailure()
+        {
+            yield return null;
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = " 3 "
+            });
+
+            Assert.IsFalse(lastResponse.Success, "A whitespace-padded digit must not be accepted as a Key enum ordinal");
+            StringAssert.Contains("Digits are not key names", lastResponse.Message);
         }
 
         /// <summary>

--- a/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
+++ b/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
@@ -752,6 +752,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         }
 
         /// <summary>
+        /// Verifies that key names resolve case-insensitively, which the whitelist must preserve
+        /// because Enum.TryParse was previously called with ignoreCase.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Press_WithLowercaseKeyName_Should_Succeed()
+        {
+            yield return null;
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = "space"
+            });
+
+            Assert.IsTrue(lastResponse.Success, lastResponse.Message);
+        }
+
+        /// <summary>
+        /// Verifies that Digit3, the name the rejection message advertises for bare digits, is
+        /// actually accepted.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Press_WithDigitKeyName_Should_Succeed()
+        {
+            yield return null;
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = "Digit3"
+            });
+
+            Assert.IsTrue(lastResponse.Success, lastResponse.Message);
+        }
+
+        /// <summary>
         /// Verifies that a whitespace-padded valid key name keeps resolving, since padded correct
         /// input was already accepted before key names were whitelisted.
         /// </summary>

--- a/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
+++ b/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
@@ -634,6 +634,95 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             StringAssert.Contains("Invalid key name", lastResponse.Message);
         }
 
+        /// <summary>
+        /// Verifies that a bare digit key is rejected instead of being parsed as an enum ordinal,
+        /// and that the failure message offers both the Digit and Numpad candidates.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Press_WithBareDigitKey_Should_ReturnFailureSuggestingDigitAndNumpad()
+        {
+            yield return null;
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = "3"
+            });
+
+            Assert.IsFalse(lastResponse.Success, "A bare digit must not be accepted as a Key enum ordinal");
+            StringAssert.Contains("Digit3", lastResponse.Message);
+            StringAssert.Contains("Numpad3", lastResponse.Message);
+        }
+
+        /// <summary>
+        /// Verifies that a signed numeric key is rejected, closing the Enum.TryParse signed-ordinal path.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Press_WithSignedNumericKey_Should_ReturnFailure()
+        {
+            yield return null;
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = "+3"
+            });
+
+            Assert.IsFalse(lastResponse.Success, "A signed numeric key must not be accepted as a Key enum ordinal");
+        }
+
+        /// <summary>
+        /// Verifies that a comma-separated key list is rejected, closing the Enum.TryParse flag-OR path.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Press_WithCommaSeparatedKeyNames_Should_ReturnFailure()
+        {
+            yield return null;
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = "Space,Enter"
+            });
+
+            Assert.IsFalse(lastResponse.Success, "A comma-separated key list must not be OR-ed into a single key");
+        }
+
+        /// <summary>
+        /// Verifies that an out-of-range numeric key fails as a validation error instead of throwing
+        /// ArgumentOutOfRangeException from the keyboard indexer.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Press_WithUndefinedNumericKey_Should_ReturnFailure()
+        {
+            yield return null;
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = "300"
+            });
+
+            Assert.IsFalse(lastResponse.Success, "An undefined numeric key must fail validation rather than throw");
+        }
+
+        /// <summary>
+        /// Verifies that the existing Return-to-Enter alias still resolves after key names are whitelisted.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Press_WithReturnAlias_Should_Succeed()
+        {
+            yield return null;
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = "Return"
+            });
+
+            Assert.IsTrue(lastResponse.Success, lastResponse.Message);
+        }
+
         [UnityTest]
         public IEnumerator Press_WithEmptyKey_Should_ReturnFailure()
         {

--- a/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
+++ b/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
@@ -751,6 +751,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             Assert.IsTrue(lastResponse.Success, lastResponse.Message);
         }
 
+        /// <summary>
+        /// Verifies that a whitespace-padded valid key name keeps resolving, since padded correct
+        /// input was already accepted before key names were whitelisted.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Press_WithPaddedKeyName_Should_Succeed()
+        {
+            yield return null;
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = " Space "
+            });
+
+            Assert.IsTrue(lastResponse.Success, lastResponse.Message);
+        }
+
+        /// <summary>
+        /// Verifies that the Return-to-Enter alias still applies when the name is whitespace-padded.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Press_WithPaddedReturnAlias_Should_Succeed()
+        {
+            yield return null;
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = " Return "
+            });
+
+            Assert.IsTrue(lastResponse.Success, lastResponse.Message);
+        }
+
         [UnityTest]
         public IEnumerator Press_WithEmptyKey_Should_ReturnFailure()
         {

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardKeyNameSuggester.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardKeyNameSuggester.cs
@@ -26,7 +26,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string trimmed = invalidKeyName.Trim();
             List<string> suggestions = new();
 
-            if (trimmed.Length == 1 && char.IsDigit(trimmed[0]))
+            // Why not char.IsDigit: it is true for non-ASCII digits such as "３", which have no
+            // Digit/Numpad enum name, so suggesting them would point at keys that do not exist.
+            if (trimmed.Length == 1 && trimmed[0] >= '0' && trimmed[0] <= '9')
             {
                 string digit = trimmed;
                 AddUnique(suggestions, $"Digit{digit}");

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -86,7 +86,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Key key = Key.None;
             if (isKnownKeyName)
             {
-                Enum.TryParse(normalizedKey, ignoreCase: true, out key);
+                bool parsed = Enum.TryParse(normalizedKey, ignoreCase: true, out key);
+                UnityEngine.Debug.Assert(parsed, $"A whitelisted Key name must parse: {normalizedKey}");
             }
 
             if (!isKnownKeyName || key == Key.None)
@@ -270,7 +271,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             for (int index = 0; index < trimmed.Length; index++)
             {
-                if (!char.IsDigit(trimmed[index]))
+                // Why not char.IsDigit: it is true for non-ASCII digits, which Enum.TryParse never
+                // accepted as ordinals. Claiming they used to press another key would be false.
+                if (trimmed[index] < '0' || trimmed[index] > '9')
                 {
                     return false;
                 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -72,23 +72,39 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return new SimulateKeyboardResponse
                 {
                     Success = false,
-                    Message = "Key parameter is required. Examples: \"W\", \"Space\", \"LeftShift\", \"A\", \"Enter\".",
+                    Message = "Key parameter is required. Examples: \"W\", \"Space\", \"LeftShift\", \"A\", \"Enter\", \"Digit3\".",
                     Action = parameters.Action.ToString()
                 };
             }
 
+            // Why not Enum.TryParse alone: it also accepts ordinals ("3"), signed ordinals ("+3"),
+            // whitespace-padded input, comma-separated names OR-ed together ("Space,Enter"), and
+            // undefined ordinals ("300") that later throw from the keyboard indexer. Only a name
+            // that is defined on the Key enum may resolve to a key.
             string normalizedKey = NormalizeKeyName(parameters.Key);
-            if (!Enum.TryParse<Key>(normalizedKey, ignoreCase: true, out Key key) || key == Key.None)
+            bool isKnownKeyName = DefinedKeyNames.Contains(normalizedKey);
+            Key key = Key.None;
+            if (isKnownKeyName)
+            {
+                Enum.TryParse(normalizedKey, ignoreCase: true, out key);
+            }
+
+            if (!isKnownKeyName || key == Key.None)
             {
                 IReadOnlyList<string> suggestions = KeyboardKeyNameSuggester.Suggest(parameters.Key);
                 string suggestionText = suggestions.Count == 0
                     ? string.Empty
                     : $" Did you mean: {string.Join(", ", suggestions)}?";
+                // Why: digits used to resolve silently to unrelated keys, so earlier runs that
+                // reported success may have pressed something else and need to be re-checked.
+                string ordinalHistoryText = LooksLikeNumericKeyInput(parameters.Key)
+                    ? " Digits are not key names: bare digits were previously parsed as enum ordinals (e.g. \"3\" pressed Tab), so re-check any earlier results or scripts that passed digits."
+                    : string.Empty;
                 return new SimulateKeyboardResponse
                 {
                     Success = false,
                     Message =
-                        $"Invalid key name: \"{parameters.Key}\". Use Input System Key enum names (e.g. \"W\", \"Space\", \"LeftShift\", \"A\", \"Enter\").{suggestionText}",
+                        $"Invalid key name: \"{parameters.Key}\". Use Input System Key enum names (e.g. \"W\", \"Space\", \"LeftShift\", \"A\", \"Enter\", \"Digit3\").{suggestionText}{ordinalHistoryText}",
                     Action = parameters.Action.ToString()
                 };
             }
@@ -228,6 +244,39 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static void EnsureOverlayExists()
         {
             OverlayCanvasFactory.EnsureExists();
+        }
+
+        // Immutable whitelist of the names defined on the Input System Key enum, so key resolution
+        // never falls back to Enum.TryParse's ordinal and flag-combination behavior.
+        private static readonly HashSet<string> DefinedKeyNames =
+            new(Enum.GetNames(typeof(Key)), StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Reports whether the raw key input is the numeric form that Enum.TryParse used to accept
+        /// as an enum ordinal, so the rejection can explain what earlier runs actually pressed.
+        /// </summary>
+        private static bool LooksLikeNumericKeyInput(string keyName)
+        {
+            string trimmed = keyName.Trim();
+            if (trimmed.Length > 0 && (trimmed[0] == '+' || trimmed[0] == '-'))
+            {
+                trimmed = trimmed.Substring(1);
+            }
+
+            if (trimmed.Length == 0)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < trimmed.Length; index++)
+            {
+                if (!char.IsDigit(trimmed[index]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static string NormalizeKeyName(string keyName)

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -82,15 +82,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // undefined ordinals ("300") that later throw from the keyboard indexer. Only a name
             // that is defined on the Key enum may resolve to a key.
             string normalizedKey = NormalizeKeyName(parameters.Key);
-            bool isKnownKeyName = DefinedKeyNames.Contains(normalizedKey);
-            Key key = Key.None;
-            if (isKnownKeyName)
-            {
-                bool parsed = Enum.TryParse(normalizedKey, ignoreCase: true, out key);
-                UnityEngine.Debug.Assert(parsed, $"A whitelisted Key name must parse: {normalizedKey}");
-            }
-
-            if (!isKnownKeyName || key == Key.None)
+            if (!DefinedKeysByName.TryGetValue(normalizedKey, out Key key) || key == Key.None)
             {
                 // Suggest from the normalized form so padding does not degrade the candidates,
                 // while the message below still reports the raw input verbatim.
@@ -249,10 +241,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             OverlayCanvasFactory.EnsureExists();
         }
 
-        // Immutable whitelist of the names defined on the Input System Key enum, so key resolution
-        // never falls back to Enum.TryParse's ordinal and flag-combination behavior.
-        private static readonly HashSet<string> DefinedKeyNames =
-            new(Enum.GetNames(typeof(Key)), StringComparer.OrdinalIgnoreCase);
+        // Immutable name-to-value map of the Input System Key enum, so key resolution never falls
+        // back to Enum.TryParse's ordinal and flag-combination behavior.
+        private static readonly IReadOnlyDictionary<string, Key> DefinedKeysByName = BuildDefinedKeysByName();
+
+        private static IReadOnlyDictionary<string, Key> BuildDefinedKeysByName()
+        {
+            string[] names = Enum.GetNames(typeof(Key));
+            Array values = Enum.GetValues(typeof(Key));
+            Dictionary<string, Key> keysByName = new(names.Length, StringComparer.OrdinalIgnoreCase);
+            for (int index = 0; index < names.Length; index++)
+            {
+                keysByName[names[index]] = (Key)values.GetValue(index);
+            }
+
+            return keysByName;
+        }
 
         /// <summary>
         /// Reports whether the raw key input is the numeric form that Enum.TryParse used to accept

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -92,7 +92,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (!isKnownKeyName || key == Key.None)
             {
-                IReadOnlyList<string> suggestions = KeyboardKeyNameSuggester.Suggest(parameters.Key);
+                // Suggest from the normalized form so padding does not degrade the candidates,
+                // while the message below still reports the raw input verbatim.
+                IReadOnlyList<string> suggestions = KeyboardKeyNameSuggester.Suggest(normalizedKey);
                 string suggestionText = suggestions.Count == 0
                     ? string.Empty
                     : $" Did you mean: {string.Join(", ", suggestions)}?";
@@ -284,11 +286,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static string NormalizeKeyName(string keyName)
         {
-            if (string.Equals(keyName, "Return", StringComparison.OrdinalIgnoreCase))
+            // Why trim here rather than at the whitelist comparison: Enum.TryParse used to accept
+            // whitespace-padded names, so padded correct input already worked. Blocking ambiguous
+            // input must not narrow correct input, and the alias has to see the padded form too.
+            string trimmed = keyName.Trim();
+            if (string.Equals(trimmed, "Return", StringComparison.OrdinalIgnoreCase))
             {
                 return Key.Enter.ToString();
             }
-            return keyName;
+            return trimmed;
         }
 
 #endif


### PR DESCRIPTION
## Summary

- `simulate-keyboard --key` now fails loudly on inputs that are not Input System `Key` names, instead of silently pressing an unrelated key.
- A rejected digit explains both valid forms (`Digit3` / `Numpad3`) and warns that earlier runs may have pressed something else.

## User Impact

Before, `--key 3` returned `Success: true` and pressed `Tab`. `Enum.TryParse` accepted much more than key names:

| Input | Old behavior |
|---|---|
| `3` | `Success: true`, pressed `Tab` (parsed as the enum ordinal) |
| `+3` | `Success: true`, same ordinal path |
| `Space,Enter` | `Success: true`, comma-separated names OR-ed into one value |
| `300` | Passed the `Key.None` guard, then threw `ArgumentOutOfRangeException` from the keyboard indexer |

A run that pressed the wrong key still reported success, so verification results silently described input that never happened — the worst case for anyone using these results as evidence.

After this change all four inputs return `Success: false` with a candidate list. Rejecting a numeric key also states that bare digits used to be parsed as enum ordinals (e.g. `"3"` pressed `Tab`), so earlier results and scripts that passed digits can be re-checked rather than trusted.

Correct input is not narrowed. `--key Return` keeps working through the existing `Return` to `Enter` alias, and whitespace-padded names such as `--key " Space "` keep resolving — `Enum.TryParse` used to trim, so padded correct input already worked and rejecting it would break valid scripts. `" 3 "` still fails, because after trimming it is `3`, which is not a name defined on the `Key` enum.

## Changes

- Resolve a key only when the normalized name matches a name defined on the `Key` enum, using an immutable case-insensitive whitelist built from `Enum.GetNames(typeof(Key))`.
- Normalize once at the input entry point, trimming before the alias is applied, so padded names and the padded alias both keep working.
- Scope the digit guidance to ASCII numeric input. `char.IsDigit` is also true for non-ASCII digits, which `Enum.TryParse` never read as ordinals, so the message would otherwise claim an earlier run pressed another key when it did not.
- Keep the existing `Key.None` guard and route every rejection through the existing suggester error path, preserving the `Invalid key name` wording that tests pin.
- `KeyboardKeyNameSuggester` keeps its suggestion logic. Its digit suggestions were already implemented but unreachable for `1`-`9`, because `Enum.TryParse` resolved those to a key before the suggester could run. `0` was the exception: it parsed to `Key.None` and was caught by the guard, so that one digit did reach the suggester.
- Match ASCII digits in the suggester too. `char.IsDigit` is true for non-ASCII digits such as `３`, which would have suggested a `Digit３` name that no `Key` value has.
- Add `Digit3` to the example key names in both validation messages, so the error-prone form appears where the mistake is made.

## Verification

Tests were written first and confirmed failing before the fix (4 red, plus the `Return` alias case green), then re-run after it.

- `uloop compile` — `ErrorCount: 0`, `WarningCount: 0`
- `uloop run-tests --test-mode PlayMode` filtered to `SimulateKeyboardTests` — 47 tests, 47 passed, 0 failed
- `uloop run-tests --test-mode EditMode` filtered to `KeyboardKeyNameSuggesterTests` — 3 tests, 3 passed, 0 failed
- `uloop run-tests --test-mode EditMode` filtered to `StaticFacadeStateGuardTests` — 20 tests, 20 passed, 0 failed, confirming the new `static readonly` lookup does not trip the mutable-static guard

Red-state evidence before the fix: `--key "3"` / `"+3"` / `"Space,Enter"` each failed with `Expected: False But was: True`, and `--key "300"` failed with an unhandled `ArgumentOutOfRangeException`, confirming both silent-success paths and the exception path.

Note on CI: repository workflows are scoped to `pull_request.branches [main, v3-beta]`, so none of them run on a pull request targeting this integration branch. The results above are local runs; CI validation happens on the final integration pull request.
