### PR TITLE
fix: Stop reporting Unity as running when the process check itself failed

### DIFF
--- a/cli/project-runner/internal/projectrunner/connection_retry.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry.go
@@ -258,6 +258,13 @@ func sendWithTransientConnectionRetryWithDeps(
 			)
 		}
 
+		// A caller that cancelled the command gets that cancellation back, as everywhere else that
+		// waits on Unity. Why here: the probe below inherits the cancellation and fails, and its
+		// failure would otherwise be reported as an unreachable Unity — telling the user to launch
+		// an editor they never asked about, and recording a probe warning for their own Ctrl-C.
+		if ctx.Err() != nil {
+			return outcome, ctx.Err()
+		}
 		runningProcess, processErr := deps.findRunningUnityProcess(retryContext, connection.ProjectRoot)
 		if finished, finalOutcome, finalErr := finishUndispatchedRetryProbe(
 			retryContext,

--- a/cli/project-runner/internal/projectrunner/connection_retry.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry.go
@@ -260,7 +260,6 @@ func sendWithTransientConnectionRetryWithDeps(
 
 		runningProcess, processErr := deps.findRunningUnityProcess(retryContext, connection.ProjectRoot)
 		if finished, finalOutcome, finalErr := finishUndispatchedRetryProbe(
-			ctx,
 			retryContext,
 			connection,
 			sendAttempt{

--- a/cli/project-runner/internal/projectrunner/connection_retry_flow.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_flow.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 	"github.com/hatayama/unity-cli-loop/common/unityprocess"
+	"github.com/hatayama/unity-cli-loop/common/vibelog"
 )
 
 func newConnectionRetryClient(
@@ -93,8 +94,13 @@ type sendAttempt struct {
 	err     error
 }
 
+// finishUndispatchedRetryProbe decides whether the retry loop keeps waiting after a dial that
+// never reached Unity. The process probe's only job here is to promote the diagnosis from "not
+// reachable" to "running but not responding", so a probe that failed cannot promote anything: it
+// observed no process, and claiming one would be an assertion this code has no evidence for.
+// Both probe outcomes therefore report the dial error the caller can act on, and the probe
+// failure goes to the CLI vibe log instead of replacing that error.
 func finishUndispatchedRetryProbe(
-	ctx context.Context,
 	retryContext context.Context,
 	connection unityipc.Connection,
 	currentAttempt sendAttempt,
@@ -103,29 +109,35 @@ func finishUndispatchedRetryProbe(
 	lastAttempt sendAttempt,
 ) (bool, unityipc.UnitySendOutcome, error) {
 	if processErr != nil {
-		if retryContext.Err() == nil {
-			return true, currentAttempt.outcome, processErr
-		}
-		if ctx.Err() != nil {
-			return true, currentAttempt.outcome, ctx.Err()
-		}
-		// A busy response seen during the window is the truer diagnosis than a
-		// final dial cut short by the expiring retry context.
-		if isUnityServerBusyRPCError(lastAttempt.err) {
-			return true, lastAttempt.outcome, lastAttempt.err
-		}
-		return true, currentAttempt.outcome, newUnityServerNotRespondingError(connection, currentAttempt.err)
+		logUnityProcessProbeFailure(connection, currentAttempt.err, processErr)
 	}
 	if runningProcess != nil {
 		return false, currentAttempt.outcome, nil
 	}
-	// Same masking as the probe-error path: a busy response seen during the
-	// window proves a server answered moments ago, so it is a truer diagnosis
-	// than a final dial cut short by the expiring retry context.
+	// A busy response seen during the window proves a server answered moments ago, so it is a
+	// truer diagnosis than a final dial cut short by the expiring retry context.
 	if retryContext.Err() != nil && isUnityServerBusyRPCError(lastAttempt.err) {
 		return true, lastAttempt.outcome, lastAttempt.err
 	}
 	return true, currentAttempt.outcome, currentAttempt.err
+}
+
+// Records a process probe that could not answer whether Unity is running. Why log it at all: the
+// probe failure no longer shows up in the returned error, and it is the only clue that the
+// diagnosis was decided without a process reading — a sysctl refusal on macOS, or a PowerShell
+// launch failure or process-list timeout on Windows.
+func logUnityProcessProbeFailure(connection unityipc.Connection, dialErr error, probeErr error) {
+	_ = vibelog.WriteCLIVibeLog(connection.ProjectRoot, vibelog.CLIVibeLogEntry{
+		Level:     "WARNING",
+		Operation: "cli_unity_process_probe_failed",
+		Message:   "Could not determine whether Unity is running while recovering an unreachable request.",
+		Context: map[string]any{
+			"endpoint":   connection.Endpoint.Address,
+			"dial_cause": clicore.ErrorMessage(dialErr),
+			"cause":      clicore.ErrorMessage(probeErr),
+		},
+		CorrelationID: vibelog.NewCLIVibeCorrelationID(),
+	})
 }
 
 func finishUnityAliveRetryWait(

--- a/cli/project-runner/internal/projectrunner/connection_retry_flow_test.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_flow_test.go
@@ -1,9 +1,19 @@
 package projectrunner
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
 	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+	"github.com/hatayama/unity-cli-loop/common/unityprocess"
+	"github.com/hatayama/unity-cli-loop/common/vibelog"
 )
 
 // Verifies only execute-dynamic-code gets main-thread stall tolerance: other commands'
@@ -17,5 +27,149 @@ func TestCommandNeedsSelfInducedStallToleranceOnlyForExecuteDynamicCode(t *testi
 	}
 	if commandNeedsSelfInducedStallTolerance("run-tests") {
 		t.Fatal("expected run-tests to not need self-induced stall tolerance")
+	}
+}
+
+func refusedDialAttempt() sendAttempt {
+	return sendAttempt{
+		outcome: unityipc.UnitySendOutcome{},
+		err: &unityipc.ConnectionAttemptError{
+			ProjectRoot: "/projects/sample",
+			Endpoint:    "/tmp/uloop/sample.sock",
+			Cause:       errors.New("dial unix /tmp/uloop/sample.sock: connect: connection refused"),
+		},
+	}
+}
+
+func expiredRetryContext() context.Context {
+	expired, cancel := context.WithCancel(context.Background())
+	cancel()
+	return expired
+}
+
+// Verifies a failed process probe never upgrades the diagnosis to "Unity is running": the probe
+// observed nothing, so the dial error must be reported exactly as it is on the no-process path.
+func TestFinishUndispatchedRetryProbeDoesNotClaimUnityIsRunningWhenTheProbeFailed(t *testing.T) {
+	currentAttempt := refusedDialAttempt()
+
+	finished, _, err := finishUndispatchedRetryProbe(
+		expiredRetryContext(),
+		unityipc.Connection{ProjectRoot: t.TempDir()},
+		currentAttempt,
+		errors.New("sysctl kern.proc.all: operation not permitted"),
+		nil,
+		sendAttempt{},
+	)
+
+	if !finished {
+		t.Fatal("expected the retry loop to finish after a failed probe with an expired window")
+	}
+	var notResponding clierrors.UnityServerNotRespondingError
+	if errors.As(err, &notResponding) {
+		t.Fatalf("a failed probe must not report Unity as running: %v", err)
+	}
+	if err != currentAttempt.err {
+		t.Fatalf("expected the dial error verbatim, got: %v", err)
+	}
+}
+
+// Verifies the same fallback applies while the retry window is still alive: the probe failure
+// alone would hide the dial error, which is the fact the caller acts on.
+func TestFinishUndispatchedRetryProbeReportsTheDialErrorWhileTheWindowIsAlive(t *testing.T) {
+	currentAttempt := refusedDialAttempt()
+	probeErr := errors.New("listing Unity processes timed out")
+
+	finished, _, err := finishUndispatchedRetryProbe(
+		context.Background(),
+		unityipc.Connection{ProjectRoot: t.TempDir()},
+		currentAttempt,
+		probeErr,
+		nil,
+		sendAttempt{},
+	)
+
+	if !finished {
+		t.Fatal("expected the retry loop to finish after a failed probe")
+	}
+	if err != currentAttempt.err {
+		t.Fatalf("expected the dial error verbatim, got: %v", err)
+	}
+}
+
+// Verifies a busy response seen earlier in the window still wins over the final dial error when
+// the probe failed, because a server that answered moments ago is the truer diagnosis.
+func TestFinishUndispatchedRetryProbeKeepsABusyResponseWhenTheProbeFailed(t *testing.T) {
+	busyAttempt := sendAttempt{
+		err: &unityipc.RPCError{
+			Code:    -32603,
+			Message: "Unity is busy running 'compile'.",
+			Data:    []byte(`{"type":"server_busy"}`),
+		},
+	}
+
+	finished, _, err := finishUndispatchedRetryProbe(
+		expiredRetryContext(),
+		unityipc.Connection{ProjectRoot: t.TempDir()},
+		refusedDialAttempt(),
+		errors.New("sysctl kern.proc.all: operation not permitted"),
+		nil,
+		busyAttempt,
+	)
+
+	if !finished {
+		t.Fatal("expected the retry loop to finish after a failed probe with an expired window")
+	}
+	if err != busyAttempt.err {
+		t.Fatalf("expected the busy response to be preserved, got: %v", err)
+	}
+}
+
+// Verifies a probe that found a running process still lets the retry loop continue.
+func TestFinishUndispatchedRetryProbeContinuesWhenUnityIsRunning(t *testing.T) {
+	finished, _, err := finishUndispatchedRetryProbe(
+		context.Background(),
+		unityipc.Connection{ProjectRoot: t.TempDir()},
+		refusedDialAttempt(),
+		nil,
+		&unityprocess.UnityProcess{Pid: 4321},
+		sendAttempt{},
+	)
+
+	if finished {
+		t.Fatalf("expected the retry loop to continue while Unity is running, got: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("expected no error while continuing, got: %v", err)
+	}
+}
+
+// Verifies the swallowed probe failure is still recorded: dropping the diagnosis from the error
+// must not drop it from the diagnostics too.
+func TestFinishUndispatchedRetryProbeRecordsTheProbeFailureInTheVibeLog(t *testing.T) {
+	projectRoot := t.TempDir()
+	t.Setenv(vibelog.CLIVibeLogEnvName, "1")
+
+	_, _, _ = finishUndispatchedRetryProbe(
+		expiredRetryContext(),
+		unityipc.Connection{ProjectRoot: projectRoot},
+		refusedDialAttempt(),
+		errors.New("sysctl kern.proc.all: operation not permitted"),
+		nil,
+		sendAttempt{},
+	)
+
+	entries, globErr := filepath.Glob(filepath.Join(projectRoot, vibelog.CLIVibeLogDirectory, "*.json"))
+	if globErr != nil {
+		t.Fatalf("reading the vibe log directory failed: %v", globErr)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected the failed process probe to be written to the CLI vibe log")
+	}
+	contents, readErr := os.ReadFile(entries[0])
+	if readErr != nil {
+		t.Fatalf("reading the vibe log failed: %v", readErr)
+	}
+	if !strings.Contains(string(contents), "operation not permitted") {
+		t.Fatalf("the probe failure was not recorded: %s", contents)
 	}
 }

--- a/cli/project-runner/internal/projectrunner/connection_retry_test.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_test.go
@@ -203,8 +203,10 @@ func TestSendWithTransientConnectionRetryWritesFocusFailureVibeLog(t *testing.T)
 	}
 }
 
-// Verifies process probe timeouts keep the structured server-not-responding error.
-func TestSendWithTransientConnectionRetryClassifiesProcessProbeTimeout(t *testing.T) {
+// Verifies a process probe that timed out reports the dial error instead of the
+// server-not-responding error: a probe that never read the process table cannot be the evidence
+// for claiming Unity is running.
+func TestSendWithTransientConnectionRetryReportsTheDialErrorWhenTheProcessProbeTimesOut(t *testing.T) {
 	deps := defaultConnectionRetryDeps()
 	deps.findRunningUnityProcess = func(ctx context.Context, projectRoot string) (*clicore.UnityProcess, error) {
 		<-ctx.Done()
@@ -231,8 +233,12 @@ func TestSendWithTransientConnectionRetryClassifiesProcessProbeTimeout(t *testin
 		deps)
 
 	var notRespondingErr clierrors.UnityServerNotRespondingError
-	if !errors.As(err, &notRespondingErr) {
-		t.Fatalf("expected unityServerNotRespondingError, got %v", err)
+	if errors.As(err, &notRespondingErr) {
+		t.Fatalf("a failed process probe must not report Unity as running: %v", err)
+	}
+	var connectionErr *unityipc.ConnectionAttemptError
+	if !errors.As(err, &connectionErr) {
+		t.Fatalf("expected the connection attempt error, got %v", err)
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/connection_retry_test.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_test.go
@@ -218,7 +218,7 @@ func TestSendWithTransientConnectionRetryReportsTheDialErrorWhenTheProcessProbeT
 	connection := unityipc.Connection{
 		Endpoint: unityipc.Endpoint{
 			Network: "unix",
-			Address: t.TempDir() + "/missing.sock",
+			Address: endpointDirectoryWithRequiredMode(t) + "/missing.sock",
 		},
 		ProjectRoot: t.TempDir(),
 	}
@@ -239,6 +239,66 @@ func TestSendWithTransientConnectionRetryReportsTheDialErrorWhenTheProcessProbeT
 	var connectionErr *unityipc.ConnectionAttemptError
 	if !errors.As(err, &connectionErr) {
 		t.Fatalf("expected the connection attempt error, got %v", err)
+	}
+}
+
+// Endpoint validation rejects any directory that is not 0700, which a plain t.TempDir() is not.
+// Tests that need the dial itself to fail must get past that check first.
+func endpointDirectoryWithRequiredMode(t *testing.T) string {
+	t.Helper()
+	directory := t.TempDir()
+	if err := os.Chmod(directory, 0o700); err != nil {
+		t.Fatalf("failed to set the endpoint directory mode: %v", err)
+	}
+	return directory
+}
+
+// Verifies a cancelled command reports the cancellation rather than an unreachable Unity: the
+// process probe inherits the cancellation and fails, and that failure must not be turned into
+// "Unity may be closed, run uloop launch" guidance for a user who pressed Ctrl-C.
+func TestSendWithTransientConnectionRetryPreservesParentCancellation(t *testing.T) {
+	projectRoot := t.TempDir()
+	t.Setenv(vibelog.CLIVibeLogEnvName, "1")
+
+	deps := defaultConnectionRetryDeps()
+	deps.findRunningUnityProcess = func(ctx context.Context, projectRoot string) (*clicore.UnityProcess, error) {
+		return nil, ctx.Err()
+	}
+	deps.retryPoll = time.Nanosecond
+
+	cancelledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := sendWithTransientConnectionRetryWithDeps(
+		cancelledContext,
+		unityipc.Connection{
+			Endpoint: unityipc.Endpoint{
+				Network: "unix",
+				Address: endpointDirectoryWithRequiredMode(t) + "/missing.sock",
+			},
+			ProjectRoot: projectRoot,
+		},
+		"get-logs",
+		map[string]any{},
+		nil,
+		0,
+		deps)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the cancellation to be preserved, got %v", err)
+	}
+	logFiles, globErr := filepath.Glob(filepath.Join(projectRoot, vibelog.CLIVibeLogDirectory, "*.json"))
+	if globErr != nil {
+		t.Fatalf("reading the vibe log directory failed: %v", globErr)
+	}
+	for _, logFile := range logFiles {
+		contents, readErr := os.ReadFile(logFile)
+		if readErr != nil {
+			t.Fatalf("reading the vibe log failed: %v", readErr)
+		}
+		if strings.Contains(string(contents), "cli_unity_process_probe_failed") {
+			t.Fatalf("a cancelled command must not record a process probe failure: %s", contents)
+		}
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/connection_retry_test.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_test.go
@@ -284,7 +284,10 @@ func TestSendWithTransientConnectionRetryPreservesParentCancellation(t *testing.
 		0,
 		deps)
 
-	if !errors.Is(err, context.Canceled) {
+	// Identity, not errors.Is: a dial cut short by the cancellation wraps context.Canceled too, so
+	// errors.Is holds with or without the guard. The contract is that the cancellation itself comes
+	// back, because anything wrapping it is classified as an unreachable Unity.
+	if err != context.Canceled {
 		t.Fatalf("expected the cancellation to be preserved, got %v", err)
 	}
 	logFiles, globErr := filepath.Glob(filepath.Join(projectRoot, vibelog.CLIVibeLogDirectory, "*.json"))


### PR DESCRIPTION
## Summary
- A failed Unity process check no longer makes the CLI claim Unity is running.
- When the check cannot answer, the command reports the connection error it actually got, so the suggested next step matches what happened.

## User Impact
Before: whenever the process check failed — it could not read the process list at all — the command still answered

> Unity is running for this project, but the Unity CLI Loop server is not responding.

with `Retryable: true` and `SafeToRetry: true`, i.e. "wait and retry". That claim was made without ever looking at a process, and the reason the check failed was dropped entirely, so nothing in the output hinted that the diagnosis was a guess.

After: the connection error is reported verbatim, exactly as it already is when the check runs and finds no Unity process, with the guidance that belongs to it. The check failure itself is written to the CLI vibe log (`ULOOP_DEBUG`), so it stays diagnosable without being presented to the user as a conclusion.

This is a potential path whose symptoms could match the "Unity is running but not responding" report seen on 2026-07-26; that report was not reproduced, and this change is not claimed to be its root cause. The branch asserts something it has no evidence for regardless of whether that incident ever took it.

Reachable in ordinary operation: a `sysctl` failure when listing processes on macOS, and a PowerShell launch failure or a process-list timeout on Windows.

## Changes
- `finishUndispatchedRetryProbe`: a process-check error no longer selects its own branch. The check exists only to promote the diagnosis from "not reachable" to "running but not responding"; a check that observed nothing cannot promote anything, so both outcomes now return the same dial error. No new error type and no new envelope field.
- The branch that returned the check error alone while the retry window was still alive is aligned with the same fallback. It was honest, but it discarded the dial error, which is the fact the caller acts on. The `ctx.Err()` branch goes away with it, matching the existing no-process path.
- The check failure is recorded with VibeLogger (`cli_unity_process_probe_failed`, WARNING) including the dial cause, instead of being swallowed.
- The removed `ctx` parameter is dropped from the signature and the call site.
- The cancellation check the removed branch also carried is kept, moved to the caller ahead of the process check. It is the convention everywhere else that waits on Unity, and without it an interrupted command (Ctrl-C, SIGTERM) would cancel the process check and get "Unity may be closed, run `uloop launch`" back — plus a check-failure warning in the vibe log — for an interruption the user caused. Running it before the check also means a cancelled command never scans the process table.

## Verification
- TDD: 3 new unit tests were red first (`a failed probe must not report Unity as running: Unity is running but the Unity CLI Loop server is not responding: ...`), green after the change.
- New tests in `connection_retry_flow_test.go`: probe failure with an expired window returns the dial error; probe failure with a live window does the same; an earlier `server_busy` response is still preserved; a successful probe still continues retrying; the probe failure is written to the vibe log.
- `connection_retry_test.go`: the existing end-to-end test that asserted the old behavior is inverted — a probe timeout must now yield the connection attempt error and must not yield the server-not-responding error. Its endpoint directory is now given the 0700 mode endpoint validation requires, so the failure comes from the dial rather than from validation.
- New end-to-end test: a cancelled parent context yields `context.Canceled` and writes no `cli_unity_process_probe_failed` entry. Removing the guard makes it fail on both counts.
- Mutation check: reinstating the old `newUnityServerNotRespondingError` return makes both the unit test and the end-to-end test fail with the old message; restored afterwards.
- `sh scripts/check-go-cli.sh` passes (format, vet, lint `0 issues.`, all module tests, binary rebuild).
- No non-test `cli/common` sources changed, so `scripts/stamp-release-inputs.sh` does not apply.
