### PR TITLE
fix: Reject non-name key filters in record-input

### DIFF
--- a/.agents/skills/uloop-record-input/SKILL.md
+++ b/.agents/skills/uloop-record-input/SKILL.md
@@ -30,7 +30,7 @@ uloop record-input --action Stop --output-path scripts/my-play.json
 |-----------|------|---------|-------------|
 | `--action` | enum | `Start` | `Start` - begin recording input, `Stop` - stop recording and save to file |
 | `--output-path` | string | auto | Save path for the recording JSON. When empty, auto-generates under `.uloop/outputs/InputRecordings/` |
-| `--keys` | string | `""` | Comma-separated key filter (for example `W,A,S,D,Space`). Empty records all common game keys |
+| `--keys` | string | `""` | Comma-separated key filter of Input System Key enum names (for example `W,A,S,D,Space`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`; a name that matches no key is rejected instead of being dropped from the filter. Empty records all common game keys |
 | `--delay-seconds` | integer | `3` | Countdown delay in seconds before recording starts (0-10). Gives time to switch focus to Game View. |
 | `--no-show-overlay` | flag | - | Hide the recording countdown and REC indicator overlay |
 

--- a/.agents/skills/uloop-record-input/SKILL.md
+++ b/.agents/skills/uloop-record-input/SKILL.md
@@ -30,7 +30,7 @@ uloop record-input --action Stop --output-path scripts/my-play.json
 |-----------|------|---------|-------------|
 | `--action` | enum | `Start` | `Start` - begin recording input, `Stop` - stop recording and save to file |
 | `--output-path` | string | auto | Save path for the recording JSON. When empty, auto-generates under `.uloop/outputs/InputRecordings/` |
-| `--keys` | string | `""` | Comma-separated key filter of Input System Key enum names (for example `W,A,S,D,Space`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`; a name that matches no key is rejected instead of being dropped from the filter. Empty records all common game keys |
+| `--keys` | string | `""` | Comma-separated key filter of Input System Key enum names (for example `W,A,S,D,Space`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`; a name that matches no key fails the command instead of being dropped from the filter. Empty records all common game keys |
 | `--delay-seconds` | integer | `3` | Countdown delay in seconds before recording starts (0-10). Gives time to switch focus to Game View. |
 | `--no-show-overlay` | flag | - | Hide the recording countdown and REC indicator overlay |
 

--- a/.claude/skills/uloop-record-input/SKILL.md
+++ b/.claude/skills/uloop-record-input/SKILL.md
@@ -30,7 +30,7 @@ uloop record-input --action Stop --output-path scripts/my-play.json
 |-----------|------|---------|-------------|
 | `--action` | enum | `Start` | `Start` - begin recording input, `Stop` - stop recording and save to file |
 | `--output-path` | string | auto | Save path for the recording JSON. When empty, auto-generates under `.uloop/outputs/InputRecordings/` |
-| `--keys` | string | `""` | Comma-separated key filter (for example `W,A,S,D,Space`). Empty records all common game keys |
+| `--keys` | string | `""` | Comma-separated key filter of Input System Key enum names (for example `W,A,S,D,Space`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`; a name that matches no key is rejected instead of being dropped from the filter. Empty records all common game keys |
 | `--delay-seconds` | integer | `3` | Countdown delay in seconds before recording starts (0-10). Gives time to switch focus to Game View. |
 | `--no-show-overlay` | flag | - | Hide the recording countdown and REC indicator overlay |
 

--- a/.claude/skills/uloop-record-input/SKILL.md
+++ b/.claude/skills/uloop-record-input/SKILL.md
@@ -30,7 +30,7 @@ uloop record-input --action Stop --output-path scripts/my-play.json
 |-----------|------|---------|-------------|
 | `--action` | enum | `Start` | `Start` - begin recording input, `Stop` - stop recording and save to file |
 | `--output-path` | string | auto | Save path for the recording JSON. When empty, auto-generates under `.uloop/outputs/InputRecordings/` |
-| `--keys` | string | `""` | Comma-separated key filter of Input System Key enum names (for example `W,A,S,D,Space`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`; a name that matches no key is rejected instead of being dropped from the filter. Empty records all common game keys |
+| `--keys` | string | `""` | Comma-separated key filter of Input System Key enum names (for example `W,A,S,D,Space`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`; a name that matches no key fails the command instead of being dropped from the filter. Empty records all common game keys |
 | `--delay-seconds` | integer | `3` | Countdown delay in seconds before recording starts (0-10). Gives time to switch focus to Game View. |
 | `--no-show-overlay` | flag | - | Hide the recording countdown and REC indicator overlay |
 

--- a/Assets/Tests/Editor/InputRecordingKeyFilterTests.cs
+++ b/Assets/Tests/Editor/InputRecordingKeyFilterTests.cs
@@ -51,6 +51,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// Tests that a filter made only of empty entries is reported invalid: it would otherwise
+        /// record every key while looking like no filter was requested.
+        /// </summary>
+        [Test]
+        public void ParseKeyFilter_WhenEveryEntryIsEmpty_ReportsTheRawInputInvalid()
+        {
+            KeyFilterParseResult result = InputRecordingFileHelper.ParseKeyFilter(", ,");
+
+            Assert.AreEqual(new[] { ", ," }, result.InvalidKeyNames);
+            Assert.IsNull(result.Filter);
+        }
+
+        /// <summary>
+        /// Tests that a trailing comma is harmless once another entry names a key.
+        /// </summary>
+        [Test]
+        public void ParseKeyFilter_WhenAnEntryIsEmptyBesideANamedKey_KeepsTheKey()
+        {
+            KeyFilterParseResult result = InputRecordingFileHelper.ParseKeyFilter("W,");
+
+            Assert.IsEmpty(result.InvalidKeyNames);
+            Assert.AreEqual(new HashSet<Key> { Key.W }, result.Filter);
+        }
+
+        /// <summary>
         /// Tests that no filter and no invalid name is reported when the parameter is omitted.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/InputRecordingKeyFilterTests.cs
+++ b/Assets/Tests/Editor/InputRecordingKeyFilterTests.cs
@@ -1,0 +1,66 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.InputSystem;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies the record-input key filter accepts only defined key names.
+    /// </summary>
+    public sealed class InputRecordingKeyFilterTests
+    {
+        /// <summary>
+        /// Tests that named keys are accepted case-insensitively and no name is reported invalid.
+        /// </summary>
+        [Test]
+        public void ParseKeyFilter_WhenGivenKeyNames_KeepsThemAll()
+        {
+            KeyFilterParseResult result = InputRecordingFileHelper.ParseKeyFilter("space, w");
+
+            Assert.IsEmpty(result.InvalidKeyNames);
+            Assert.IsNotNull(result.Filter);
+            Assert.AreEqual(new HashSet<Key> { Key.Space, Key.W }, result.Filter);
+        }
+
+        /// <summary>
+        /// Tests that a bare digit is reported invalid instead of silently filtering the key whose
+        /// enum ordinal it happens to be.
+        /// </summary>
+        [Test]
+        public void ParseKeyFilter_WhenGivenAnOrdinal_ReportsItInvalid()
+        {
+            KeyFilterParseResult result = InputRecordingFileHelper.ParseKeyFilter("3");
+
+            Assert.AreEqual(new[] { "3" }, result.InvalidKeyNames);
+            Assert.IsNull(result.Filter);
+        }
+
+        /// <summary>
+        /// Tests that an invalid entry alongside a valid one is still reported, so a partially
+        /// applied filter is never mistaken for the requested one.
+        /// </summary>
+        [Test]
+        public void ParseKeyFilter_WhenOneEntryIsInvalid_ReportsThatEntry()
+        {
+            KeyFilterParseResult result = InputRecordingFileHelper.ParseKeyFilter("W, 3");
+
+            Assert.AreEqual(new[] { "3" }, result.InvalidKeyNames);
+        }
+
+        /// <summary>
+        /// Tests that no filter and no invalid name is reported when the parameter is omitted.
+        /// </summary>
+        [Test]
+        public void ParseKeyFilter_WhenGivenNothing_ReportsNoFilter()
+        {
+            KeyFilterParseResult result = InputRecordingFileHelper.ParseKeyFilter("");
+
+            Assert.IsEmpty(result.InvalidKeyNames);
+            Assert.IsNull(result.Filter);
+        }
+    }
+}
+#endif

--- a/Assets/Tests/Editor/InputRecordingKeyFilterTests.cs.meta
+++ b/Assets/Tests/Editor/InputRecordingKeyFilterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8afa56a901fe140609ebf4a9c0e8a193
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/KeyNameResolverTests.cs
+++ b/Assets/Tests/Editor/KeyNameResolverTests.cs
@@ -1,0 +1,111 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+using NUnit.Framework;
+using UnityEngine.InputSystem;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies key names resolve only through defined Key enum names.
+    /// </summary>
+    public sealed class KeyNameResolverTests
+    {
+        /// <summary>
+        /// Tests that a defined key name resolves regardless of the casing it was written in.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenGivenADefinedNameInAnyCasing_ResolvesTheKey()
+        {
+            (bool resolved, Key key) = KeyNameResolver.Resolve("space");
+
+            Assert.IsTrue(resolved);
+            Assert.AreEqual(Key.Space, key);
+        }
+
+        /// <summary>
+        /// Tests that surrounding whitespace does not stop a defined name from resolving.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenGivenAPaddedName_ResolvesTheKey()
+        {
+            (bool resolved, Key key) = KeyNameResolver.Resolve("  W  ");
+
+            Assert.IsTrue(resolved);
+            Assert.AreEqual(Key.W, key);
+        }
+
+        /// <summary>
+        /// Tests that "Return" keeps resolving to Enter, the alias callers already relied on.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenGivenTheReturnAlias_ResolvesEnter()
+        {
+            (bool resolved, Key key) = KeyNameResolver.Resolve("Return");
+
+            Assert.IsTrue(resolved);
+            Assert.AreEqual(Key.Enter, key);
+        }
+
+        /// <summary>
+        /// Tests that a bare digit is rejected instead of being read as an enum ordinal.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenGivenAnOrdinal_IsRejected()
+        {
+            (bool resolved, Key key) = KeyNameResolver.Resolve("3");
+
+            Assert.IsFalse(resolved);
+            Assert.AreEqual(Key.None, key);
+        }
+
+        /// <summary>
+        /// Tests that a signed ordinal is rejected: Enum.TryParse accepted it as a value too.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenGivenASignedOrdinal_IsRejected()
+        {
+            (bool resolved, Key key) = KeyNameResolver.Resolve("-1");
+
+            Assert.IsFalse(resolved);
+            Assert.AreEqual(Key.None, key);
+        }
+
+        /// <summary>
+        /// Tests that an ordinal outside the enum is rejected rather than producing an undefined key.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenGivenAnUndefinedOrdinal_IsRejected()
+        {
+            (bool resolved, Key key) = KeyNameResolver.Resolve("300");
+
+            Assert.IsFalse(resolved);
+            Assert.AreEqual(Key.None, key);
+        }
+
+        /// <summary>
+        /// Tests that comma-separated names are rejected instead of being OR-ed into one value.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenGivenCommaSeparatedNames_IsRejected()
+        {
+            (bool resolved, Key key) = KeyNameResolver.Resolve("Space,Enter");
+
+            Assert.IsFalse(resolved);
+            Assert.AreEqual(Key.None, key);
+        }
+
+        /// <summary>
+        /// Tests that the placeholder None value is rejected: it names no physical key.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenGivenNone_IsRejected()
+        {
+            (bool resolved, Key key) = KeyNameResolver.Resolve("None");
+
+            Assert.IsFalse(resolved);
+            Assert.AreEqual(Key.None, key);
+        }
+    }
+}
+#endif

--- a/Assets/Tests/Editor/KeyNameResolverTests.cs.meta
+++ b/Assets/Tests/Editor/KeyNameResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1157c682c6684c189f34872ba911a8a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/RecordInputKeyFilterRejectionTests.cs
+++ b/Assets/Tests/PlayMode/RecordInputKeyFilterRejectionTests.cs
@@ -1,0 +1,57 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Collections;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
+{
+    /// <summary>
+    /// Test fixture that verifies record-input refuses to start when the key filter names no key.
+    /// Runs in PlayMode because the rejection sits behind the PlayMode preflight.
+    /// </summary>
+    public sealed class RecordInputKeyFilterRejectionTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            // A regression here starts a real recording, which would leak into the next test.
+            if (InputRecorder.IsRecording)
+            {
+                InputRecorder.StopRecording();
+            }
+        }
+
+        /// <summary>
+        /// Tests that a key filter naming no key fails the command instead of recording every key.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator RecordInput_WhenTheKeyFilterNamesNoKey_FailsWithoutRecording()
+        {
+            RecordInputSchema request = new()
+            {
+                Action = RecordInputAction.Start,
+                Keys = "3",
+                DelaySeconds = 0,
+                ShowOverlay = false
+            };
+
+            Task<RecordInputResponse> execution = new RecordInputUseCase().RecordInputAsync(request, CancellationToken.None);
+            while (!execution.IsCompleted)
+            {
+                yield return null;
+            }
+
+            RecordInputResponse response = execution.Result;
+            Assert.IsFalse(response.Success, response.Message);
+            StringAssert.Contains("Invalid key name(s) in the keys filter: 3", response.Message);
+            Assert.IsFalse(InputRecorder.IsRecording);
+        }
+    }
+}
+#endif

--- a/Assets/Tests/PlayMode/RecordInputKeyFilterRejectionTests.cs.meta
+++ b/Assets/Tests/PlayMode/RecordInputKeyFilterRejectionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2181da05a0170455b82212942745e63d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecordingFileHelper.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecordingFileHelper.cs
@@ -92,14 +92,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return files.OrderByDescending(f => File.GetLastWriteTimeUtc(f)).First();
         }
 
-        public static HashSet<Key>? ParseKeyFilter(string keys)
+        /// <summary>
+        /// Parses the comma-separated key filter into the keys to record. Entries that name no key
+        /// are reported rather than skipped: dropping them silently would record a different set of
+        /// keys than the caller asked for, and dropping all of them would record every key.
+        /// </summary>
+        public static KeyFilterParseResult ParseKeyFilter(string keys)
         {
             if (string.IsNullOrEmpty(keys))
             {
-                return null;
+                return new KeyFilterParseResult(null, System.Array.Empty<string>());
             }
 
             HashSet<Key> filter = new();
+            List<string> invalidKeyNames = new();
             string[] parts = keys.Split(',');
 
             for (int i = 0; i < parts.Length; i++)
@@ -110,17 +116,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                if (Enum.TryParse<Key>(trimmed, ignoreCase: true, out Key key) && key != Key.None)
+                (bool resolved, Key key) = KeyNameResolver.Resolve(trimmed);
+                if (!resolved)
                 {
-                    filter.Add(key);
+                    invalidKeyNames.Add(trimmed);
+                    continue;
                 }
-                else
-                {
-                    Debug.LogWarning($"[InputRecordingFileHelper] Unknown key name in filter: '{trimmed}'");
-                }
+
+                filter.Add(key);
             }
 
-            return filter.Count > 0 ? filter : null;
+            return new KeyFilterParseResult(filter.Count > 0 ? filter : null, invalidKeyNames);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecordingFileHelper.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecordingFileHelper.cs
@@ -101,7 +101,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (string.IsNullOrEmpty(keys))
             {
-                return new KeyFilterParseResult(null, System.Array.Empty<string>());
+                return new KeyFilterParseResult(null, Array.Empty<string>());
             }
 
             HashSet<Key> filter = new();
@@ -124,6 +124,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 filter.Add(key);
+            }
+
+            if (filter.Count == 0 && invalidKeyNames.Count == 0)
+            {
+                // Every entry was empty (for example "," or " "), so the filter would fall back to
+                // recording every key while the response looked like no filter was ever given.
+                // Why not reject the empty entries themselves: a trailing comma in "W," is harmless
+                // once at least one entry names a key.
+                invalidKeyNames.Add(keys);
             }
 
             return new KeyFilterParseResult(filter.Count > 0 ? filter : null, invalidKeyNames);

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/KeyFilterParseResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/KeyFilterParseResult.cs
@@ -1,0 +1,27 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Collections.Generic;
+using UnityEngine.InputSystem;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Outcome of parsing a comma-separated key filter: the keys to record, plus every entry that
+    /// named no key. Why carry the rejected entries instead of dropping them: a filter that lost
+    /// entries records something other than what was asked for, and the caller cannot tell that
+    /// from a filter that was never given.
+    /// </summary>
+    internal sealed class KeyFilterParseResult
+    {
+        public KeyFilterParseResult(HashSet<Key>? filter, IReadOnlyList<string> invalidKeyNames)
+        {
+            Filter = filter;
+            InvalidKeyNames = invalidKeyNames;
+        }
+
+        public HashSet<Key>? Filter { get; }
+
+        public IReadOnlyList<string> InvalidKeyNames { get; }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/KeyFilterParseResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/KeyFilterParseResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6ed0f03d8bd4407691333639c5611fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/KeyNameResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/KeyNameResolver.cs
@@ -1,0 +1,68 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+using System;
+using System.Collections.Generic;
+using UnityEngine.InputSystem;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Resolves Input System Key values from the key names tools accept, so every tool applies the
+    /// same rule for what counts as a key name.
+    /// </summary>
+    internal static class KeyNameResolver
+    {
+        // Immutable name-to-value map of the Input System Key enum, so key resolution never falls
+        // back to Enum.TryParse's ordinal and flag-combination behavior.
+        private static readonly IReadOnlyDictionary<string, Key> DefinedKeysByName = BuildDefinedKeysByName();
+
+        /// <summary>
+        /// Resolves a raw key name to its Key value, reporting whether it named a key at all.
+        /// </summary>
+        public static (bool resolved, Key key) Resolve(string keyName)
+        {
+            // Why not Enum.TryParse: it also accepts ordinals ("3"), signed ordinals ("+3"),
+            // whitespace-padded input, comma-separated names OR-ed together ("Space,Enter"), and
+            // undefined ordinals ("300") that later throw from the keyboard indexer. Only a name
+            // that is defined on the Key enum may resolve to a key.
+            string normalizedKey = NormalizeKeyName(keyName);
+            if (!DefinedKeysByName.TryGetValue(normalizedKey, out Key key) || key == Key.None)
+            {
+                return (false, Key.None);
+            }
+
+            return (true, key);
+        }
+
+        /// <summary>
+        /// Trims the raw name and applies the Return alias, giving callers the form the whitelist
+        /// is keyed by so their diagnostics can describe the same value that was looked up.
+        /// </summary>
+        public static string NormalizeKeyName(string keyName)
+        {
+            // Why trim here rather than at the whitelist comparison: Enum.TryParse used to accept
+            // whitespace-padded names, so padded correct input already worked. Blocking ambiguous
+            // input must not narrow correct input, and the alias has to see the padded form too.
+            string trimmed = keyName.Trim();
+            if (string.Equals(trimmed, "Return", StringComparison.OrdinalIgnoreCase))
+            {
+                return Key.Enter.ToString();
+            }
+
+            return trimmed;
+        }
+
+        private static IReadOnlyDictionary<string, Key> BuildDefinedKeysByName()
+        {
+            string[] names = Enum.GetNames(typeof(Key));
+            Array values = Enum.GetValues(typeof(Key));
+            Dictionary<string, Key> keysByName = new(names.Length, StringComparer.OrdinalIgnoreCase);
+            for (int index = 0; index < names.Length; index++)
+            {
+                keysByName[names[index]] = (Key)values.GetValue(index);
+            }
+
+            return keysByName;
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/KeyNameResolver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/KeyNameResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3c265151ed404bb1aa2e42f44205e01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputUseCase.cs
@@ -141,7 +141,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             int delaySeconds = Mathf.Clamp(request.DelaySeconds, RecordInputConstants.MIN_DELAY_SECONDS, RecordInputConstants.MAX_DELAY_SECONDS);
-            HashSet<Key>? keyFilter = InputRecordingFileHelper.ParseKeyFilter(request.Keys);
+            KeyFilterParseResult keyFilterResult = InputRecordingFileHelper.ParseKeyFilter(request.Keys);
+            if (keyFilterResult.InvalidKeyNames.Count > 0)
+            {
+                // Why reject instead of recording what did parse: a recording is taken once, and a
+                // filter that quietly lost entries produces a file that looks like the requested
+                // one. Entries that all failed would record every key, the opposite of the request.
+                return new RecordInputResponse
+                {
+                    Success = false,
+                    Message =
+                        $"Invalid key name(s) in the keys filter: {string.Join(", ", keyFilterResult.InvalidKeyNames)}. " +
+                        "Use Input System Key enum names (e.g. \"W\", \"Space\", \"LeftShift\", \"Digit3\").",
+                    Action = RecordInputAction.Start.ToString()
+                };
+            }
+
+            HashSet<Key>? keyFilter = keyFilterResult.Filter;
 
             if (request.ShowOverlay)
             {

--- a/Packages/src/Editor/FirstPartyTools/RecordInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RecordInput/Skill/SKILL.md
@@ -30,7 +30,7 @@ uloop record-input --action Stop --output-path scripts/my-play.json
 |-----------|------|---------|-------------|
 | `--action` | enum | `Start` | `Start` - begin recording input, `Stop` - stop recording and save to file |
 | `--output-path` | string | auto | Save path for the recording JSON. When empty, auto-generates under `.uloop/outputs/InputRecordings/` |
-| `--keys` | string | `""` | Comma-separated key filter (for example `W,A,S,D,Space`). Empty records all common game keys |
+| `--keys` | string | `""` | Comma-separated key filter of Input System Key enum names (for example `W,A,S,D,Space`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`; a name that matches no key is rejected instead of being dropped from the filter. Empty records all common game keys |
 | `--delay-seconds` | integer | `3` | Countdown delay in seconds before recording starts (0-10). Gives time to switch focus to Game View. |
 | `--no-show-overlay` | flag | - | Hide the recording countdown and REC indicator overlay |
 

--- a/Packages/src/Editor/FirstPartyTools/RecordInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RecordInput/Skill/SKILL.md
@@ -30,7 +30,7 @@ uloop record-input --action Stop --output-path scripts/my-play.json
 |-----------|------|---------|-------------|
 | `--action` | enum | `Start` | `Start` - begin recording input, `Stop` - stop recording and save to file |
 | `--output-path` | string | auto | Save path for the recording JSON. When empty, auto-generates under `.uloop/outputs/InputRecordings/` |
-| `--keys` | string | `""` | Comma-separated key filter of Input System Key enum names (for example `W,A,S,D,Space`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`; a name that matches no key is rejected instead of being dropped from the filter. Empty records all common game keys |
+| `--keys` | string | `""` | Comma-separated key filter of Input System Key enum names (for example `W,A,S,D,Space`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`; a name that matches no key fails the command instead of being dropped from the filter. Empty records all common game keys |
 | `--delay-seconds` | integer | `3` | Countdown delay in seconds before recording starts (0-10). Gives time to switch focus to Game View. |
 | `--no-show-overlay` | flag | - | Hide the recording countdown and REC indicator overlay |
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -77,12 +77,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 };
             }
 
-            string normalizedKey = KeyNameResolver.NormalizeKeyName(parameters.Key);
             (bool resolved, Key key) = KeyNameResolver.Resolve(parameters.Key);
             if (!resolved)
             {
                 // Suggest from the normalized form so padding does not degrade the candidates,
                 // while the message below still reports the raw input verbatim.
+                string normalizedKey = KeyNameResolver.NormalizeKeyName(parameters.Key);
                 IReadOnlyList<string> suggestions = KeyboardKeyNameSuggester.Suggest(normalizedKey);
                 string suggestionText = suggestions.Count == 0
                     ? string.Empty

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -78,12 +77,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 };
             }
 
-            // Why not Enum.TryParse alone: it also accepts ordinals ("3"), signed ordinals ("+3"),
-            // whitespace-padded input, comma-separated names OR-ed together ("Space,Enter"), and
-            // undefined ordinals ("300") that later throw from the keyboard indexer. Only a name
-            // that is defined on the Key enum may resolve to a key.
-            string normalizedKey = NormalizeKeyName(parameters.Key);
-            if (!DefinedKeysByName.TryGetValue(normalizedKey, out Key key) || key == Key.None)
+            string normalizedKey = KeyNameResolver.NormalizeKeyName(parameters.Key);
+            (bool resolved, Key key) = KeyNameResolver.Resolve(parameters.Key);
+            if (!resolved)
             {
                 // Suggest from the normalized form so padding does not degrade the candidates,
                 // while the message below still reports the raw input verbatim.
@@ -242,23 +238,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             OverlayCanvasFactory.EnsureExists();
         }
 
-        // Immutable name-to-value map of the Input System Key enum, so key resolution never falls
-        // back to Enum.TryParse's ordinal and flag-combination behavior.
-        private static readonly IReadOnlyDictionary<string, Key> DefinedKeysByName = BuildDefinedKeysByName();
-
-        private static IReadOnlyDictionary<string, Key> BuildDefinedKeysByName()
-        {
-            string[] names = Enum.GetNames(typeof(Key));
-            Array values = Enum.GetValues(typeof(Key));
-            Dictionary<string, Key> keysByName = new(names.Length, StringComparer.OrdinalIgnoreCase);
-            for (int index = 0; index < names.Length; index++)
-            {
-                keysByName[names[index]] = (Key)values.GetValue(index);
-            }
-
-            return keysByName;
-        }
-
         /// <summary>
         /// Reports whether the raw key input is the numeric form that Enum.TryParse used to accept
         /// as an enum ordinal, so the rejection can explain what earlier runs actually pressed.
@@ -289,18 +268,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return true;
         }
 
-        private static string NormalizeKeyName(string keyName)
-        {
-            // Why trim here rather than at the whitelist comparison: Enum.TryParse used to accept
-            // whitespace-padded names, so padded correct input already worked. Blocking ambiguous
-            // input must not narrow correct input, and the alias has to see the padded form too.
-            string trimmed = keyName.Trim();
-            if (string.Equals(trimmed, "Return", StringComparison.OrdinalIgnoreCase))
-            {
-                return Key.Enter.ToString();
-            }
-            return trimmed;
-        }
 
 #endif
     }

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -654,7 +654,7 @@
           },
           "Keys": {
             "type": "string",
-            "description": "Comma-separated key filter of Input System Key enum names (for example W,A,S,D,Space). Case-insensitive. Digit keys use Digit0-Digit9 or Numpad0-Numpad9, not bare 0-9; a name that matches no key is rejected instead of being dropped from the filter. Empty records all common game keys",
+            "description": "Comma-separated key filter of Input System Key enum names (for example W,A,S,D,Space). Case-insensitive. Digit keys use Digit0-Digit9 or Numpad0-Numpad9, not bare 0-9; a name that matches no key fails the command instead of being dropped from the filter. Empty records all common game keys",
             "default": ""
           },
           "DelaySeconds": {

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -654,7 +654,7 @@
           },
           "Keys": {
             "type": "string",
-            "description": "Comma-separated key filter (for example W,A,S,D,Space). Empty records all common game keys",
+            "description": "Comma-separated key filter of Input System Key enum names (for example W,A,S,D,Space). Case-insensitive. Digit keys use Digit0-Digit9 or Numpad0-Numpad9, not bare 0-9; a name that matches no key is rejected instead of being dropped from the filter. Empty records all common game keys",
             "default": ""
           },
           "DelaySeconds": {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "b9bc288d3a76099a1fe4cee8843e510bf5bbe632"
+  "sharedInputsHash": "0313515f1add4e1c394e1957c0aff7215e39e678"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "f6f1ad4c29722943c9a66a64cfc68d706ff8b141"
+  "sharedInputsHash": "b85b6271eda91daf75fb620f635266c7a709f90b"
 }


### PR DESCRIPTION
## Summary
- `record-input --keys` now accepts only real key names, so a filter never silently records different keys than the ones asked for.
- A name that matches no key is reported back in the response instead of being dropped.

## User Impact
Before: `--keys` was parsed with `Enum.TryParse<Key>`, which also accepts enum ordinals. `uloop record-input --action Start --keys 3` started a recording filtered to `Key.Tab` and reported success, with only an Editor Console warning that an agent driving the CLI never sees. If every entry was rejected, the filter collapsed to "no filter" and the recording captured **all** keys — the opposite of what was asked — and the response looked identical to a run with no `--keys` at all.

After: `--keys 3` fails immediately with

> Invalid key name(s) in the keys filter: 3. Use Input System Key enum names (e.g. "W", "Space", "LeftShift", "Digit3").

Valid names keep working exactly as before, case-insensitively, and `Return` is accepted as `Enter` just as `simulate-keyboard` accepts it.

## Changes
- Key-name resolution moves into `KeyNameResolver` in the shared `Common/InputSystem` assembly that both `simulate-keyboard` and the input-recording assembly already reference. `SimulateKeyboardUseCase` now uses it instead of its own private copy, so both tools apply one rule.
- `ParseKeyFilter` returns a result carrying the parsed keys plus every entry that named no key, and `record-input` rejects the request when that list is non-empty.
- Rejecting the whole request rather than filtering with the entries that did parse: a recording is taken once, and a partially applied filter produces a file that looks like the requested one. The all-rejected case is worse still, silently recording everything.
- The Console warning is gone; the same information now reaches the caller in the response.
- A filter made only of empty entries (`,` or ` `) is rejected too: it would otherwise record every key with a response indistinguishable from omitting `--keys`. A trailing comma beside a named key stays harmless.
- Skill parameter table for `--keys` documents the name rule; the generated tool catalog, the `.claude`/`.agents` copies, and the shared release-input stamps are regenerated from it.

## Verification
- TDD: the new tests were written first and failed to compile against the missing API (`error CS0103: The name 'KeyNameResolver' does not exist in the current context`).
- `uloop compile`: 0 errors, 0 warnings.
- `uloop run-tests` (EditMode, `KeyNameResolverTests|InputRecordingKeyFilterTests`): 14/14 passed. Covers ordinals (`3`), signed ordinals (`-1`), undefined ordinals (`300`), comma-OR-ed names (`Space,Enter`), `None`, casing, padding, the `Return` alias, and the filter's mixed valid/invalid case.
- `uloop run-tests` (PlayMode, `RecordInputKeyFilterRejectionTests|SimulateKeyboardTests|KeyboardKeyNameSuggesterTests`): 48/48 passed — the shared resolver does not change `simulate-keyboard` behavior, and the new PlayMode test pins the rejection itself.
- Mutation check: deleting the rejection branch fails the PlayMode test, and dropping the empty-entry guard fails the EditMode test; both restored.
- `go run ./cmd/check-release-triggers --base HEAD~2`: `Release trigger guard passed.` after running `scripts/stamp-release-inputs.sh`.
