### PR TITLE
chore: Fix the skill-target layout test that pointed at a removed directory

### DIFF
--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -102,12 +102,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void AreSkillsInstalled_WhenLegacyManagedDirectoryIsEmpty_StillDetectsFlatLayout()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
-            string targetRoot = Path.Combine(temporaryRoot, ".cursor");
+            string targetRoot = Path.Combine(temporaryRoot, ".codex");
             Directory.CreateDirectory(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
             SkillInstallationDetector detector = new();
 
-            Assert.IsTrue(detector.AreSkillsInstalledForLayout(temporaryRoot, ".cursor", false));
-            Assert.IsFalse(detector.AreSkillsInstalledForLayout(temporaryRoot, ".cursor", true));
+            Assert.IsTrue(detector.AreSkillsInstalledForLayout(temporaryRoot, ".codex", false));
+            Assert.IsFalse(detector.AreSkillsInstalledForLayout(temporaryRoot, ".codex", true));
         }
 
         // Tests that Unity-side discovery includes CLI-only skills from the packaged core CLI.

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -894,7 +894,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void DetectTargets_WhenGroupedLayoutRequested_DetectsEmptyFlatManagedDirectories()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
-            string targetRoot = Path.Combine(temporaryRoot, ".cursor");
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
             Directory.CreateDirectory(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
 
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(


### PR DESCRIPTION
## Summary
- Fixes the one failing EditMode test in `ToolSkillSynchronizerTests`, which was failing for a reason unrelated to what it verifies.

## User Impact
None — test-only. Nothing about skill detection or installation changes.

## Changes
`DetectTargets_WhenGroupedLayoutRequested_DetectsEmptyFlatManagedDirectories` built its fixture under `.cursor`. That directory stopped being a skill target when the target list was trimmed to Claude Code, Codex CLI, Common and Antigravity, so detection skipped it and returned no targets at all. The test then failed on `Assert.That(detectedTargets.Length, Is.EqualTo(1))` before reaching the layout assertions it exists for.

The fixture now uses `.claude`, the directory every other single-target test in this file uses, so the test exercises the grouped-versus-flat layout detection it was written to cover.

`SkillInstallLayoutTests` named the same removed directory in one fixture. It passed either way because that API takes the directory name directly, but it is the same staleness, so it now uses `.codex` like the case beside it. No `.cursor` reference is left in the tests.

Triage result: the failure was in the test, not in the product. `SkillTargetDetector` correctly ignores directories that are not skill targets.

## Verification
- `uloop run-tests` (EditMode, `ToolSkillSynchronizerTests|SkillInstallLayoutTests`): 70/70 passed. Before this change `ToolSkillSynchronizerTests` was 51/52 with `Expected: 1 But was: 0` at line 907.
