### PR TITLE
fix: V2 delegation notice now names the V2 CLI version that ran

### DIFF
--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_run.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_run.go
@@ -87,6 +87,12 @@ func dispatcherV2ProjectDetectedError(projectRoot string, v2Project dispatcherV2
 	}
 }
 
+// dispatcherV2ModeNotice builds the stderr notice announcing delegation to the V2 CLI.
+// Why: delegation happens implicitly, so the executed CLI generation and version are otherwise invisible to the caller.
+func dispatcherV2ModeNotice(version string) string {
+	return "uloop: executing in V2 mode (" + dispatcherV2CLIPackageName + "@" + version + ")\n"
+}
+
 // runDispatcherV2CLI installs and executes the V2 CLI while preserving the original command arguments.
 // Why: the dispatcher must select the CLI generation before command parsing can change user-supplied arguments.
 func runDispatcherV2CLI(ctx context.Context, version string, args []string, stdout io.Writer, stderr io.Writer) (int, error) {
@@ -106,7 +112,7 @@ func runDispatcherV2CLI(ctx context.Context, version string, args []string, stdo
 	if err != nil {
 		return 0, err
 	}
-	_, err = io.WriteString(stderr, "uloop: executing in V2 mode\n")
+	_, err = io.WriteString(stderr, dispatcherV2ModeNotice(version))
 	if err != nil {
 		return 0, err
 	}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_run_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_run_test.go
@@ -1,0 +1,13 @@
+package dispatcher
+
+import "testing"
+
+func TestDispatcherV2ModeNoticeReportsDelegatedPackageAndVersion(t *testing.T) {
+	// Verifies the notice names the delegated V2 CLI package and its version so the caller can identify the executed generation.
+	notice := dispatcherV2ModeNotice("2.2.0")
+
+	want := "uloop: executing in V2 mode (" + dispatcherV2CLIPackageName + "@2.2.0)\n"
+	if notice != want {
+		t.Fatalf("notice = %q, want %q", notice, want)
+	}
+}


### PR DESCRIPTION
## Summary
- The V2 delegation notice now names the V2 CLI version that actually served the command.

## User Impact

When a Unity project resolves to the V2 `io.github.hatayama.uloopmcp` package, the dispatcher silently delegates the command to a V2 `uloop-cli` installed in the versioned user cache. The single stderr notice was the only signal that this happened, and it read:

```
uloop: executing in V2 mode
```

That told you the generation but not the version, so when a V3-documented command or option did not behave as expected, there was nothing to point at the concrete CLI that ran. Identifying it meant inspecting the user cache by hand.

The notice now carries the delegated package and version:

```
uloop: executing in V2 mode (uloop-cli@2.2.0)
```

The notice stays on stderr and remains one line, so stdout is still exclusively the delegated command's output.

## Changes
- Build the notice from the delegated version already passed into the V2 execution path, reusing the existing package-name constant instead of hardcoding it.
- Extract the notice text into a pure function so it is testable without launching node.
- Add a unit test asserting the notice names the delegated package and version and ends in exactly one newline.

## Verification
- `scripts/check-go-cli.sh` — passes (gofmt, vet, lint with 0 issues across all three modules, and all module tests).
- The new test was confirmed to fail before the implementation and pass after it.
- Not verified against a live V2 project: no V2-package project was available locally, and exercising the path would pull the real V2 CLI from npm. The unit test covers the notice text.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

