### PR TITLE
fix: reattach a retried compile to the timed-out in-flight compile

### DIFF
--- a/cli/project-runner/internal/projectrunner/compile_attach.go
+++ b/cli/project-runner/internal/projectrunner/compile_attach.go
@@ -18,6 +18,17 @@ import (
 const (
 	compileAttachProbeTimeout  = 10 * time.Second
 	compileAttachProbeInterval = 1 * time.Second
+	// Why 3: a single Ready&&!HasResult sample can race the completion→store window.
+	compileAttachMissingResultStreak = 3
+)
+
+type attachWaitOutcome int
+
+const (
+	attachWaitCompleted attachWaitOutcome = iota
+	attachWaitTimedOut
+	attachWaitDisappeared
+	attachWaitFailed
 )
 
 // tryAttachToPendingCompile reattaches to a previously timed-out compile when a
@@ -43,16 +54,20 @@ func tryAttachToPendingCompile(
 		return false, 0
 	}
 
-	if !status.Ready {
-		return true, attachWaitForPendingCompile(ctx, connection, record, waitTimeout, stdout, stderr, deps)
-	}
-
+	// Why HasResult first: Ready is editor-wide (!compiling/!updating/!reload), not
+	// scoped to record.RequestID. Only HasResult is request-specific, and results are
+	// stored only after that request finishes — so a result is definitive even when
+	// the editor is busy with unrelated work.
 	if status.HasResult && len(status.Result) > 0 {
 		if compileForceRecompileEnabled(params) {
 			clearCompilePendingRecord(connection.ProjectRoot)
 			return false, 0
 		}
 		return true, returnAttachedStoredCompileResult(ctx, connection, record, status.Result, stdout, stderr)
+	}
+
+	if !status.Ready {
+		return attachWaitForPendingCompile(ctx, connection, record, params, waitTimeout, stdout, stderr, deps)
 	}
 
 	clearCompilePendingRecord(connection.ProjectRoot)
@@ -103,22 +118,33 @@ func attachWaitForPendingCompile(
 	ctx context.Context,
 	connection unityipc.Connection,
 	record compilePendingRecord,
+	params map[string]any,
 	waitTimeout time.Duration,
 	stdout io.Writer,
 	stderr io.Writer,
 	deps compileWaitDeps,
-) int {
+) (bool, int) {
+	if compileForceRecompileEnabled(params) {
+		_, _ = fmt.Fprintf(
+			stderr,
+			"warning: reattaching to an in-flight compile; --force-recompile is not applied. Re-run with --force-recompile after this compile finishes if you still need a forced recompile.\n",
+		)
+	}
+
 	startedAt := time.Now()
 	logCompileAttachStart(connection, record.RequestID, "waiting")
 	spinner := clicore.NewToolSpinner(stderr, clicore.CompileCommandName)
 	spinner.Update("Reattaching to in-flight compile...")
 
-	result, completed, waitErr := waitForCompileCompletionWithDeps(ctx, compileCompletionOptions{
-		connection:     connection,
-		requestID:      record.RequestID,
-		forceRecompile: false,
-		timeout:        waitTimeout,
-		pollInterval:   compileWaitPollInterval,
+	pollInterval := deps.attachWaitPollInterval
+	if pollInterval <= 0 {
+		pollInterval = compileWaitPollInterval
+	}
+	result, outcome, waitErr := waitForAttachedCompileCompletion(ctx, compileCompletionOptions{
+		connection:   connection,
+		requestID:    record.RequestID,
+		timeout:      waitTimeout,
+		pollInterval: pollInterval,
 	}, deps)
 	if waitErr != nil {
 		spinner.Stop()
@@ -127,19 +153,87 @@ func attachWaitForPendingCompile(
 			ProjectRoot: connection.ProjectRoot,
 			Command:     clicore.CompileCommandName,
 		})
-		return 1
+		return true, 1
 	}
-	if !completed {
+
+	switch outcome {
+	case attachWaitDisappeared:
+		spinner.Stop()
+		clearCompilePendingRecord(connection.ProjectRoot)
+		logCompileAttachResult(connection, record.RequestID, "disappeared", true)
+		return false, 0
+	case attachWaitTimedOut:
 		spinner.Stop()
 		// Why not refresh TimedOutAtUtc: stale expiry must stay anchored to the first timeout.
 		logCompileAttachResult(connection, record.RequestID, "timeout", false)
 		clierrors.WriteErrorEnvelope(stderr, compileWaitTimeoutError(connection.ProjectRoot, waitTimeout))
-		return 1
+		return true, 1
+	case attachWaitCompleted:
+		clearCompilePendingRecord(connection.ProjectRoot)
+		logCompileAttachResult(connection, record.RequestID, "completed", true)
+		return true, completeCompileResultOutput(ctx, connection, result, stdout, stderr, spinner, startedAt, unityipc.UnitySendOutcome{})
+	default:
+		spinner.Stop()
+		logCompileAttachResult(connection, record.RequestID, "error", false)
+		return true, 1
+	}
+}
+
+func waitForAttachedCompileCompletion(
+	ctx context.Context,
+	options compileCompletionOptions,
+	deps compileWaitDeps,
+) (json.RawMessage, attachWaitOutcome, error) {
+	startedAt := time.Now()
+	deadline := startedAt.Add(options.timeout)
+	attempts := 0
+	missingResultStreak := 0
+	var lastStatus compileStatusResponse
+	var lastErr error
+	lastObservationKey := ""
+
+	logCompileStatusPollStart(options, startedAt, deadline)
+
+	ticker := time.NewTicker(options.pollInterval)
+	defer ticker.Stop()
+	for {
+		now := time.Now()
+		if !now.Before(deadline) {
+			break
+		}
+
+		attempts++
+		status, err := deps.queryCompileStatus(ctx, options.connection, options.requestID)
+		lastErr = err
+		if err == nil {
+			lastStatus = status
+			if status.HasResult && len(status.Result) > 0 {
+				logCompileStatusPollObservedIfChanged(options, startedAt, attempts, status, nil, &lastObservationKey)
+				logCompileStatusPollComplete(options, startedAt, attempts, status)
+				return status.Result, attachWaitCompleted, nil
+			}
+			if status.Ready && !status.HasResult {
+				missingResultStreak++
+				if missingResultStreak >= compileAttachMissingResultStreak {
+					logCompileStatusPollObservedIfChanged(options, startedAt, attempts, status, nil, &lastObservationKey)
+					return nil, attachWaitDisappeared, nil
+				}
+			} else {
+				missingResultStreak = 0
+			}
+		}
+		logCompileStatusPollObservedIfChanged(options, startedAt, attempts, status, err, &lastObservationKey)
+
+		select {
+		case <-ctx.Done():
+			logCompileWaitCancelled(options, startedAt, attempts, lastStatus, lastErr, ctx.Err())
+			return nil, attachWaitFailed, ctx.Err()
+		case <-ticker.C:
+		}
 	}
 
-	clearCompilePendingRecord(connection.ProjectRoot)
-	logCompileAttachResult(connection, record.RequestID, "completed", true)
-	return completeCompileResultOutput(ctx, connection, result, stdout, stderr, spinner, startedAt, unityipc.UnitySendOutcome{})
+	logCompileWaitTimedOut(options, startedAt, attempts, lastStatus, lastErr)
+	return nil, attachWaitTimedOut, nil
 }
 
 func returnAttachedStoredCompileResult(

--- a/cli/project-runner/internal/projectrunner/compile_attach.go
+++ b/cli/project-runner/internal/projectrunner/compile_attach.go
@@ -1,0 +1,231 @@
+package projectrunner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+	"github.com/hatayama/unity-cli-loop/common/ui"
+	"github.com/hatayama/unity-cli-loop/common/vibelog"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+const (
+	compileAttachProbeTimeout  = 10 * time.Second
+	compileAttachProbeInterval = 1 * time.Second
+)
+
+// tryAttachToPendingCompile reattaches to a previously timed-out compile when a
+// pending record still exists. handled=true means the caller must return exitCode.
+func tryAttachToPendingCompile(
+	ctx context.Context,
+	connection unityipc.Connection,
+	params map[string]any,
+	waitTimeout time.Duration,
+	stdout io.Writer,
+	stderr io.Writer,
+	deps compileWaitDeps,
+) (bool, int) {
+	record, ok := readCompilePendingRecord(connection.ProjectRoot)
+	if !ok {
+		return false, 0
+	}
+
+	status, probed := probePendingCompileStatus(ctx, connection, record.RequestID, deps)
+	if !probed {
+		// Why keep the record: probe failures during domain reload are transient and
+		// do not prove the in-flight compile is gone.
+		return false, 0
+	}
+
+	if !status.Ready {
+		return true, attachWaitForPendingCompile(ctx, connection, record, waitTimeout, stdout, stderr, deps)
+	}
+
+	if status.HasResult && len(status.Result) > 0 {
+		if compileForceRecompileEnabled(params) {
+			clearCompilePendingRecord(connection.ProjectRoot)
+			return false, 0
+		}
+		return true, returnAttachedStoredCompileResult(ctx, connection, record, status.Result, stdout, stderr)
+	}
+
+	clearCompilePendingRecord(connection.ProjectRoot)
+	return false, 0
+}
+
+func probePendingCompileStatus(
+	ctx context.Context,
+	connection unityipc.Connection,
+	requestID string,
+	deps compileWaitDeps,
+) (compileStatusResponse, bool) {
+	timeout := deps.attachProbeTimeout
+	if timeout <= 0 {
+		timeout = compileAttachProbeTimeout
+	}
+	interval := deps.attachProbeInterval
+	if interval <= 0 {
+		interval = compileAttachProbeInterval
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		status, err := deps.queryCompileStatus(ctx, connection, requestID)
+		if err == nil {
+			return status, true
+		}
+		if !time.Now().Before(deadline) {
+			return compileStatusResponse{}, false
+		}
+
+		remaining := time.Until(deadline)
+		sleepFor := interval
+		if sleepFor > remaining {
+			sleepFor = remaining
+		}
+		timer := time.NewTimer(sleepFor)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return compileStatusResponse{}, false
+		case <-timer.C:
+		}
+	}
+}
+
+func attachWaitForPendingCompile(
+	ctx context.Context,
+	connection unityipc.Connection,
+	record compilePendingRecord,
+	waitTimeout time.Duration,
+	stdout io.Writer,
+	stderr io.Writer,
+	deps compileWaitDeps,
+) int {
+	startedAt := time.Now()
+	logCompileAttachStart(connection, record.RequestID, "waiting")
+	spinner := clicore.NewToolSpinner(stderr, clicore.CompileCommandName)
+	spinner.Update("Reattaching to in-flight compile...")
+
+	result, completed, waitErr := waitForCompileCompletionWithDeps(ctx, compileCompletionOptions{
+		connection:     connection,
+		requestID:      record.RequestID,
+		forceRecompile: false,
+		timeout:        waitTimeout,
+		pollInterval:   compileWaitPollInterval,
+	}, deps)
+	if waitErr != nil {
+		spinner.Stop()
+		logCompileAttachResult(connection, record.RequestID, "error", false)
+		clierrors.WriteClassifiedError(stderr, waitErr, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     clicore.CompileCommandName,
+		})
+		return 1
+	}
+	if !completed {
+		spinner.Stop()
+		// Why not refresh TimedOutAtUtc: stale expiry must stay anchored to the first timeout.
+		logCompileAttachResult(connection, record.RequestID, "timeout", false)
+		clierrors.WriteErrorEnvelope(stderr, compileWaitTimeoutError(connection.ProjectRoot, waitTimeout))
+		return 1
+	}
+
+	clearCompilePendingRecord(connection.ProjectRoot)
+	logCompileAttachResult(connection, record.RequestID, "completed", true)
+	return completeCompileResultOutput(ctx, connection, result, stdout, stderr, spinner, startedAt, unityipc.UnitySendOutcome{})
+}
+
+func returnAttachedStoredCompileResult(
+	ctx context.Context,
+	connection unityipc.Connection,
+	record compilePendingRecord,
+	result json.RawMessage,
+	stdout io.Writer,
+	stderr io.Writer,
+) int {
+	startedAt := time.Now()
+	logCompileAttachStart(connection, record.RequestID, "stored_result")
+	spinner := clicore.NewToolSpinner(stderr, clicore.CompileCommandName)
+	clearCompilePendingRecord(connection.ProjectRoot)
+	logCompileAttachResult(connection, record.RequestID, "stored_result", true)
+	return completeCompileResultOutput(ctx, connection, result, stdout, stderr, spinner, startedAt, unityipc.UnitySendOutcome{})
+}
+
+func completeCompileResultOutput(
+	ctx context.Context,
+	connection unityipc.Connection,
+	result json.RawMessage,
+	stdout io.Writer,
+	stderr io.Writer,
+	spinner *ui.TerminalSpinner,
+	startedAt time.Time,
+	outcome unityipc.UnitySendOutcome,
+) int {
+	switch compileResultReadinessWaitMode(result) {
+	case compileReadinessWaitWarmup:
+		spinner.Update("Warming execute-dynamic-code after compile...")
+		if err := clicore.WaitForToolReadiness(ctx, connection.ProjectRoot); err != nil {
+			spinner.Stop()
+			writePostCompileWarmupWarning(stderr, err)
+		}
+	}
+	spinner.Stop()
+	clicore.WriteJSON(stdout, result)
+	writeDebugTiming(stderr, clicore.CompileCommandName, time.Since(startedAt), outcome)
+	return toolEnvelopeExitCode(result)
+}
+
+func persistCompilePendingRecordOrWarn(projectRoot string, requestID string, stderr io.Writer) {
+	err := writeCompilePendingRecord(projectRoot, compilePendingRecord{
+		RequestID:     requestID,
+		TimedOutAtUtc: time.Now().UTC(),
+	})
+	if err == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(stderr, "warning: failed to persist pending compile request for retry attach: %v\n", err)
+}
+
+func logCompileAttachStart(connection unityipc.Connection, requestID string, mode string) {
+	writeCompileVibeLog(connection.ProjectRoot, func() vibelog.CLIVibeLogEntry {
+		return vibelog.CLIVibeLogEntry{
+			Level:     "INFO",
+			Operation: "cli_compile_attach_start",
+			Message:   "Reattaching to a previously timed-out compile request.",
+			Context: map[string]any{
+				"command":          clicore.CompileCommandName,
+				"request_id":       requestID,
+				"attach_mode":      mode,
+				"project_identity": vibelog.ProjectIdentity(connection.ProjectRoot),
+				"endpoint":         connection.Endpoint.Address,
+			},
+			CorrelationID: requestID,
+		}
+	})
+}
+
+func logCompileAttachResult(connection unityipc.Connection, requestID string, outcome string, clearedRecord bool) {
+	writeCompileVibeLog(connection.ProjectRoot, func() vibelog.CLIVibeLogEntry {
+		return vibelog.CLIVibeLogEntry{
+			Level:     "INFO",
+			Operation: "cli_compile_attach_result",
+			Message:   "Finished attach attempt for a previously timed-out compile request.",
+			Context: map[string]any{
+				"command":          clicore.CompileCommandName,
+				"request_id":       requestID,
+				"attach_outcome":   outcome,
+				"record_cleared":   clearedRecord,
+				"project_identity": vibelog.ProjectIdentity(connection.ProjectRoot),
+				"endpoint":         connection.Endpoint.Address,
+			},
+			CorrelationID: requestID,
+		}
+	})
+}

--- a/cli/project-runner/internal/projectrunner/compile_attach_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_attach_test.go
@@ -51,6 +51,50 @@ func TestRunCompileAttachWithoutPendingRecordUsesNormalPath(t *testing.T) {
 	}
 }
 
+// Verifies HasResult is returned even when Ready is false (editor-wide busy is unrelated).
+func TestRunCompileAttachReturnsStoredResultWhenEditorNotReady(t *testing.T) {
+	enableCliVibeLog(t)
+	projectRoot := t.TempDir()
+	if err := writeCompilePendingRecord(projectRoot, compilePendingRecord{
+		RequestID:     "compile_attach_busy_stored",
+		TimedOutAtUtc: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("write pending record failed: %v", err)
+	}
+
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		return compileStatusResponse{
+			Ready:       false,
+			IsCompiling: true,
+			HasResult:   true,
+			Result:      json.RawMessage(`{"Success":false,"ErrorCount":7}`),
+		}, nil
+	})
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: "tcp", Address: "127.0.0.1:1"},
+		ProjectRoot: projectRoot,
+	}
+	var stdout, stderr bytes.Buffer
+
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, map[string]any{}, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected failed compile envelope: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"ErrorCount"`) || !strings.Contains(stdout.String(), "7") {
+		t.Fatalf("stored result missing from stdout: %s", stdout.String())
+	}
+	if _, err := os.Stat(compilePendingRecordPath(projectRoot)); !os.IsNotExist(err) {
+		t.Fatalf("pending record should be cleared: %v", err)
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	if !strings.Contains(logContent, `"attach_mode":"stored_result"`) {
+		t.Fatalf("stored-result attach mode missing:\n%s", logContent)
+	}
+	if strings.Contains(logContent, `"operation":"cli_compile_request_prepared"`) {
+		t.Fatalf("stored result must not send a new compile request:\n%s", logContent)
+	}
+}
+
 // Verifies an in-flight pending compile is waited on without sending a new compile request.
 func TestRunCompileAttachWaitsForInFlightCompileAndClearsRecord(t *testing.T) {
 	enableCliVibeLog(t)
@@ -360,6 +404,163 @@ func TestRunCompileAttachProbeFailureKeepsRecordAndStartsNewCompile(t *testing.T
 	case err := <-serverErr:
 		t.Fatalf("server failed: %v", err)
 	default:
+	}
+}
+
+// Verifies three consecutive Ready&&!HasResult observations abandon attach without waiting out the deadline.
+func TestRunCompileAttachDisappearedResultFallsThroughQuickly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
+	}
+
+	enableCliVibeLog(t)
+	endpoint, serverErr := startCompileAcceptOnceServer(t)
+	projectRoot := t.TempDir()
+	if err := writeCompilePendingRecord(projectRoot, compilePendingRecord{
+		RequestID:     "compile_attach_disappeared",
+		TimedOutAtUtc: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("write pending record failed: %v", err)
+	}
+
+	callCount := 0
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		callCount++
+		if callCount == 1 {
+			// Probe: editor busy with unrelated work, no stored result for this RequestId.
+			return compileStatusResponse{Ready: false, IsCompiling: true, HasResult: false}, nil
+		}
+		if callCount <= 1+compileAttachMissingResultStreak {
+			return compileStatusResponse{Ready: true, HasResult: false}, nil
+		}
+		return compileStatusResponse{
+			Ready:     true,
+			HasResult: true,
+			Result:    json.RawMessage(`{"Success":false,"ErrorCount":8}`),
+		}, nil
+	})
+	connection := unityipc.Connection{Endpoint: endpoint, ProjectRoot: projectRoot}
+	params := map[string]any{compileWaitTimeoutParam: 600}
+	var stdout, stderr bytes.Buffer
+
+	startedAt := time.Now()
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, params, &stdout, &stderr, deps)
+	elapsed := time.Since(startedAt)
+	if code != 1 {
+		t.Fatalf("expected failed compile envelope: code=%d stderr=%s", code, stderr.String())
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("disappearance should not wait for the configured timeout: elapsed=%v", elapsed)
+	}
+	if _, err := os.Stat(compilePendingRecordPath(projectRoot)); !os.IsNotExist(err) {
+		t.Fatalf("disappeared attach should clear the pending record: %v", err)
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	if !strings.Contains(logContent, `"attach_outcome":"disappeared"`) {
+		t.Fatalf("disappeared attach outcome missing:\n%s", logContent)
+	}
+	if !strings.Contains(logContent, `"operation":"cli_compile_request_prepared"`) {
+		t.Fatalf("disappearance should fall through to a new compile:\n%s", logContent)
+	}
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed: %v", err)
+	default:
+	}
+}
+
+// Verifies a single Ready&&!HasResult sample does not abort attach (completion/store race).
+func TestRunCompileAttachToleratesTransientReadyWithoutResult(t *testing.T) {
+	enableCliVibeLog(t)
+	projectRoot := t.TempDir()
+	if err := writeCompilePendingRecord(projectRoot, compilePendingRecord{
+		RequestID:     "compile_attach_transient_ready",
+		TimedOutAtUtc: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("write pending record failed: %v", err)
+	}
+
+	callCount := 0
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return compileStatusResponse{Ready: false, IsCompiling: true}, nil
+		case 2:
+			return compileStatusResponse{Ready: true, HasResult: false}, nil
+		default:
+			return compileStatusResponse{
+				Ready:     true,
+				HasResult: true,
+				Result:    json.RawMessage(`{"Success":false,"ErrorCount":6}`),
+			}, nil
+		}
+	})
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: "tcp", Address: "127.0.0.1:1"},
+		ProjectRoot: projectRoot,
+	}
+	var stdout, stderr bytes.Buffer
+
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, map[string]any{}, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected failed compile envelope: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"ErrorCount"`) || !strings.Contains(stdout.String(), "6") {
+		t.Fatalf("attach should continue after one Ready&&!HasResult sample: %s", stdout.String())
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	if strings.Contains(logContent, `"attach_outcome":"disappeared"`) {
+		t.Fatalf("one Ready&&!HasResult sample must not count as disappearance:\n%s", logContent)
+	}
+	if !strings.Contains(logContent, `"attach_outcome":"completed"`) {
+		t.Fatalf("attach should complete after the stored result appears:\n%s", logContent)
+	}
+}
+
+// Verifies ForceRecompile during attach wait warns and does not start a forced recompile.
+func TestRunCompileAttachWarnsWhenForceRecompileIgnoredDuringWait(t *testing.T) {
+	enableCliVibeLog(t)
+	projectRoot := t.TempDir()
+	if err := writeCompilePendingRecord(projectRoot, compilePendingRecord{
+		RequestID:     "compile_attach_force_warn",
+		TimedOutAtUtc: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("write pending record failed: %v", err)
+	}
+
+	callCount := 0
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		callCount++
+		if callCount == 1 {
+			return compileStatusResponse{Ready: false, IsCompiling: true}, nil
+		}
+		return compileStatusResponse{
+			Ready:     true,
+			HasResult: true,
+			Result:    json.RawMessage(`{"Success":false,"ErrorCount":11}`),
+		}, nil
+	})
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: "tcp", Address: "127.0.0.1:1"},
+		ProjectRoot: projectRoot,
+	}
+	params := map[string]any{compileForceParam: true}
+	var stdout, stderr bytes.Buffer
+
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, params, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected failed compile envelope: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--force-recompile is not applied") {
+		t.Fatalf("expected force-recompile ignored warning: %s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"ErrorCount"`) || !strings.Contains(stdout.String(), "11") {
+		t.Fatalf("attach should still return the in-flight result: %s", stdout.String())
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	if strings.Contains(logContent, `"operation":"cli_compile_request_prepared"`) {
+		t.Fatalf("force during attach wait must not send a new compile request:\n%s", logContent)
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/compile_attach_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_attach_test.go
@@ -1,0 +1,397 @@
+package projectrunner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+// Verifies that with no pending record, compile follows the normal request path.
+func TestRunCompileAttachWithoutPendingRecordUsesNormalPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
+	}
+
+	enableCliVibeLog(t)
+	endpoint, serverErr := startCompileAcceptOnceServer(t)
+	projectRoot := t.TempDir()
+	connection := unityipc.Connection{Endpoint: endpoint, ProjectRoot: projectRoot}
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		return compileStatusResponse{
+			Ready:     true,
+			HasResult: true,
+			Result:    json.RawMessage(`{"Success":false,"ErrorCount":1}`),
+		}, nil
+	})
+	var stdout, stderr bytes.Buffer
+
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, map[string]any{}, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected failed compile envelope: code=%d stderr=%s", code, stderr.String())
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	if !strings.Contains(logContent, `"operation":"cli_compile_request_prepared"`) {
+		t.Fatalf("normal path should prepare a compile request:\n%s", logContent)
+	}
+	if strings.Contains(logContent, `"operation":"cli_compile_attach_start"`) {
+		t.Fatalf("attach must not run without a pending record:\n%s", logContent)
+	}
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed: %v", err)
+	default:
+	}
+}
+
+// Verifies an in-flight pending compile is waited on without sending a new compile request.
+func TestRunCompileAttachWaitsForInFlightCompileAndClearsRecord(t *testing.T) {
+	enableCliVibeLog(t)
+	projectRoot := t.TempDir()
+	requestID := "compile_attach_waiting"
+	timedOutAt := time.Now().UTC().Add(-time.Minute)
+	if err := writeCompilePendingRecord(projectRoot, compilePendingRecord{
+		RequestID:     requestID,
+		TimedOutAtUtc: timedOutAt,
+	}); err != nil {
+		t.Fatalf("write pending record failed: %v", err)
+	}
+
+	callCount := 0
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		callCount++
+		if callCount == 1 {
+			return compileStatusResponse{Ready: false, IsCompiling: true}, nil
+		}
+		return compileStatusResponse{
+			Ready:     true,
+			HasResult: true,
+			Result:    json.RawMessage(`{"Success":false,"ErrorCount":2,"WarningCount":0}`),
+		}, nil
+	})
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: "tcp", Address: "127.0.0.1:1"},
+		ProjectRoot: projectRoot,
+	}
+	var stdout, stderr bytes.Buffer
+
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, map[string]any{}, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected failed compile envelope: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"ErrorCount"`) || !strings.Contains(stdout.String(), "2") {
+		t.Fatalf("attached result missing from stdout: %s", stdout.String())
+	}
+	if _, err := os.Stat(compilePendingRecordPath(projectRoot)); !os.IsNotExist(err) {
+		t.Fatalf("pending record should be cleared after attach success: %v", err)
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	for _, expected := range []string{
+		`"operation":"cli_compile_attach_start"`,
+		`"operation":"cli_compile_attach_result"`,
+		`"attach_mode":"waiting"`,
+		`"attach_outcome":"completed"`,
+	} {
+		if !strings.Contains(logContent, expected) {
+			t.Fatalf("attach vibe log missing %q:\n%s", expected, logContent)
+		}
+	}
+	if strings.Contains(logContent, `"operation":"cli_compile_request_prepared"`) {
+		t.Fatalf("attach wait must not send a new compile request:\n%s", logContent)
+	}
+}
+
+// Verifies a completed pending compile returns the stored result without a new request.
+func TestRunCompileAttachReturnsStoredResultAndClearsRecord(t *testing.T) {
+	enableCliVibeLog(t)
+	projectRoot := t.TempDir()
+	requestID := "compile_attach_stored"
+	if err := writeCompilePendingRecord(projectRoot, compilePendingRecord{
+		RequestID:     requestID,
+		TimedOutAtUtc: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("write pending record failed: %v", err)
+	}
+
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		return compileStatusResponse{
+			Ready:     true,
+			HasResult: true,
+			Result:    json.RawMessage(`{"Success":false,"ErrorCount":3}`),
+		}, nil
+	})
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: "tcp", Address: "127.0.0.1:1"},
+		ProjectRoot: projectRoot,
+	}
+	var stdout, stderr bytes.Buffer
+
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, map[string]any{}, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected failed compile envelope: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"ErrorCount"`) || !strings.Contains(stdout.String(), "3") {
+		t.Fatalf("stored result missing from stdout: %s", stdout.String())
+	}
+	if _, err := os.Stat(compilePendingRecordPath(projectRoot)); !os.IsNotExist(err) {
+		t.Fatalf("pending record should be cleared: %v", err)
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	if !strings.Contains(logContent, `"attach_mode":"stored_result"`) {
+		t.Fatalf("stored-result attach mode missing:\n%s", logContent)
+	}
+	if strings.Contains(logContent, `"operation":"cli_compile_request_prepared"`) {
+		t.Fatalf("stored-result attach must not send a compile request:\n%s", logContent)
+	}
+}
+
+// Verifies ForceRecompile clears the pending record and starts a new compile.
+func TestRunCompileAttachForceRecompileClearsRecordAndStartsNewCompile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
+	}
+
+	enableCliVibeLog(t)
+	endpoint, serverErr := startCompileAcceptOnceServer(t)
+	projectRoot := t.TempDir()
+	if err := writeCompilePendingRecord(projectRoot, compilePendingRecord{
+		RequestID:     "compile_attach_force",
+		TimedOutAtUtc: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("write pending record failed: %v", err)
+	}
+
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		return compileStatusResponse{
+			Ready:     true,
+			HasResult: true,
+			Result:    json.RawMessage(`{"Success":false,"ErrorCount":9}`),
+		}, nil
+	})
+	connection := unityipc.Connection{Endpoint: endpoint, ProjectRoot: projectRoot}
+	params := map[string]any{compileForceParam: true}
+	var stdout, stderr bytes.Buffer
+
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, params, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected failed compile envelope: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(compilePendingRecordPath(projectRoot)); !os.IsNotExist(err) {
+		t.Fatalf("pending record should be cleared before forced recompile: %v", err)
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	if !strings.Contains(logContent, `"operation":"cli_compile_request_prepared"`) {
+		t.Fatalf("force recompile should send a new compile request:\n%s", logContent)
+	}
+	if strings.Contains(logContent, `"operation":"cli_compile_attach_start"`) {
+		t.Fatalf("force recompile should not return via attach:\n%s", logContent)
+	}
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed: %v", err)
+	default:
+	}
+}
+
+// Verifies Ready-without-result clears the pending record and starts a new compile.
+func TestRunCompileAttachReadyWithoutResultClearsRecordAndStartsNewCompile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
+	}
+
+	enableCliVibeLog(t)
+	endpoint, serverErr := startCompileAcceptOnceServer(t)
+	projectRoot := t.TempDir()
+	if err := writeCompilePendingRecord(projectRoot, compilePendingRecord{
+		RequestID:     "compile_attach_missing_result",
+		TimedOutAtUtc: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("write pending record failed: %v", err)
+	}
+
+	callCount := 0
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		callCount++
+		if callCount == 1 {
+			return compileStatusResponse{Ready: true, HasResult: false}, nil
+		}
+		return compileStatusResponse{
+			Ready:     true,
+			HasResult: true,
+			Result:    json.RawMessage(`{"Success":false,"ErrorCount":4}`),
+		}, nil
+	})
+	connection := unityipc.Connection{Endpoint: endpoint, ProjectRoot: projectRoot}
+	var stdout, stderr bytes.Buffer
+
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, map[string]any{}, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected failed compile envelope: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(compilePendingRecordPath(projectRoot)); !os.IsNotExist(err) {
+		t.Fatalf("pending record should be cleared when stored result is gone: %v", err)
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	if !strings.Contains(logContent, `"operation":"cli_compile_request_prepared"`) {
+		t.Fatalf("missing stored result should fall through to a new compile:\n%s", logContent)
+	}
+	if strings.Contains(logContent, `"operation":"cli_compile_attach_start"`) {
+		t.Fatalf("missing stored result should not attach:\n%s", logContent)
+	}
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed: %v", err)
+	default:
+	}
+}
+
+// Verifies an attach wait that times out again keeps the original pending record untouched.
+func TestRunCompileAttachRetimesOutPreservesPendingRecord(t *testing.T) {
+	enableCliVibeLog(t)
+	projectRoot := t.TempDir()
+	requestID := "compile_attach_retimeout"
+	timedOutAt := time.Now().UTC().Add(-time.Minute)
+	if err := writeCompilePendingRecord(projectRoot, compilePendingRecord{
+		RequestID:     requestID,
+		TimedOutAtUtc: timedOutAt,
+	}); err != nil {
+		t.Fatalf("write pending record failed: %v", err)
+	}
+
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		return compileStatusResponse{Ready: false, IsCompiling: true}, nil
+	})
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: "tcp", Address: "127.0.0.1:1"},
+		ProjectRoot: projectRoot,
+	}
+	params := map[string]any{compileWaitTimeoutParam: 1}
+	var stdout, stderr bytes.Buffer
+
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, params, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected timeout exit 1: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Compile status wait timed out after 1000ms") {
+		t.Fatalf("reattach timeout message mismatch: %s", stderr.String())
+	}
+
+	got, ok := readCompilePendingRecord(projectRoot)
+	if !ok {
+		t.Fatal("pending record must be preserved after attach timeout")
+	}
+	if got.RequestID != requestID || !got.TimedOutAtUtc.Equal(timedOutAt) {
+		t.Fatalf("pending record mutated on re-timeout: %#v", got)
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	if !strings.Contains(logContent, `"attach_outcome":"timeout"`) {
+		t.Fatalf("attach timeout outcome missing:\n%s", logContent)
+	}
+}
+
+// Verifies probe failures keep the pending record and fall through to a new compile.
+func TestRunCompileAttachProbeFailureKeepsRecordAndStartsNewCompile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
+	}
+
+	enableCliVibeLog(t)
+	endpoint, serverErr := startCompileAcceptOnceServer(t)
+	projectRoot := t.TempDir()
+	requestID := "compile_attach_probe_fail"
+	timedOutAt := time.Now().UTC().Add(-time.Minute)
+	if err := writeCompilePendingRecord(projectRoot, compilePendingRecord{
+		RequestID:     requestID,
+		TimedOutAtUtc: timedOutAt,
+	}); err != nil {
+		t.Fatalf("write pending record failed: %v", err)
+	}
+
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		return compileStatusResponse{}, fmt.Errorf("probe unavailable")
+	})
+	connection := unityipc.Connection{Endpoint: endpoint, ProjectRoot: projectRoot}
+	var stdout, stderr bytes.Buffer
+
+	// After probe failure, normal path queries status again with the new request id.
+	// Replace deps so probe fails, then normal wait succeeds via a second deps wrapper.
+	queryCalls := 0
+	deps.queryCompileStatus = func(ctx context.Context, connection unityipc.Connection, id string) (compileStatusResponse, error) {
+		queryCalls++
+		if id == requestID {
+			return compileStatusResponse{}, fmt.Errorf("probe unavailable")
+		}
+		return compileStatusResponse{
+			Ready:     true,
+			HasResult: true,
+			Result:    json.RawMessage(`{"Success":false,"ErrorCount":5}`),
+		}, nil
+	}
+
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, map[string]any{}, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected failed compile envelope: code=%d stderr=%s", code, stderr.String())
+	}
+	got, ok := readCompilePendingRecord(projectRoot)
+	if !ok {
+		t.Fatal("pending record must remain after probe failure")
+	}
+	if got.RequestID != requestID || !got.TimedOutAtUtc.Equal(timedOutAt) {
+		t.Fatalf("pending record mutated after probe failure: %#v", got)
+	}
+	if queryCalls < 2 {
+		t.Fatalf("expected probe retries then normal status query, got %d calls", queryCalls)
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	if !strings.Contains(logContent, `"operation":"cli_compile_request_prepared"`) {
+		t.Fatalf("probe failure should fall through to a new compile:\n%s", logContent)
+	}
+	if strings.Contains(logContent, `"operation":"cli_compile_attach_start"`) {
+		t.Fatalf("failed probe must not attach:\n%s", logContent)
+	}
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed: %v", err)
+	default:
+	}
+}
+
+// Verifies COMPILE_WAIT_TIMEOUT persistence writes a pending record for later attach.
+func TestRunCompileTimeoutWritesPendingRecord(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
+	}
+
+	endpoint, serverErr := startCompileAcceptOnceServer(t)
+	projectRoot := t.TempDir()
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		return compileStatusResponse{Ready: false, IsCompiling: true}, nil
+	})
+	connection := unityipc.Connection{Endpoint: endpoint, ProjectRoot: projectRoot}
+	params := map[string]any{compileWaitTimeoutParam: 1}
+	var stdout, stderr bytes.Buffer
+
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, params, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected timeout exit 1: code=%d stderr=%s", code, stderr.String())
+	}
+	got, ok := readCompilePendingRecord(projectRoot)
+	if !ok {
+		t.Fatal("timeout should persist a pending compile record")
+	}
+	if got.RequestID == "" || got.TimedOutAtUtc.IsZero() {
+		t.Fatalf("pending record incomplete: %#v", got)
+	}
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed: %v", err)
+	default:
+	}
+}

--- a/cli/project-runner/internal/projectrunner/compile_pending_record.go
+++ b/cli/project-runner/internal/projectrunner/compile_pending_record.go
@@ -1,0 +1,71 @@
+package projectrunner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/hatayama/unity-cli-loop/common/tools"
+)
+
+const (
+	compilePendingRecordFileName = "pending-compile-request.json"
+	// Why match C# CompileResultLifetime (20m): a timed-out CLI can only recover the
+	// Unity-stored result while that retention window still covers TimedOutAtUtc.
+	compilePendingRecordLifetime = 20 * time.Minute
+)
+
+// compilePendingRecord remembers which compile a COMPILE_WAIT_TIMEOUT left in flight
+// so a later uloop compile can reattach instead of starting a new request.
+type compilePendingRecord struct {
+	RequestID     string    `json:"requestId"`
+	TimedOutAtUtc time.Time `json:"timedOutAtUtc"`
+}
+
+func compilePendingRecordPath(projectRoot string) string {
+	return filepath.Join(projectRoot, tools.CacheDirectoryName, compilePendingRecordFileName)
+}
+
+func writeCompilePendingRecord(projectRoot string, record compilePendingRecord) error {
+	if record.RequestID == "" || record.TimedOutAtUtc.IsZero() {
+		return os.ErrInvalid
+	}
+
+	directory := filepath.Join(projectRoot, tools.CacheDirectoryName)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return err
+	}
+
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	// Why UTF-8 without BOM: Windows readers must see the same bytes as macOS/Linux.
+	return os.WriteFile(compilePendingRecordPath(projectRoot), payload, 0o644)
+}
+
+func readCompilePendingRecord(projectRoot string) (compilePendingRecord, bool) {
+	path := compilePendingRecordPath(projectRoot)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return compilePendingRecord{}, false
+	}
+
+	var record compilePendingRecord
+	if json.Unmarshal(content, &record) != nil || record.RequestID == "" || record.TimedOutAtUtc.IsZero() {
+		_ = os.Remove(path)
+		return compilePendingRecord{}, false
+	}
+
+	if time.Since(record.TimedOutAtUtc) > compilePendingRecordLifetime {
+		_ = os.Remove(path)
+		return compilePendingRecord{}, false
+	}
+
+	return record, true
+}
+
+func clearCompilePendingRecord(projectRoot string) {
+	_ = os.Remove(compilePendingRecordPath(projectRoot))
+}

--- a/cli/project-runner/internal/projectrunner/compile_pending_record_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_pending_record_test.go
@@ -1,0 +1,135 @@
+package projectrunner
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/hatayama/unity-cli-loop/common/tools"
+)
+
+// Verifies a pending compile record round-trips through the project .uloop path.
+func TestWriteReadCompilePendingRecordRoundTrip(t *testing.T) {
+	projectRoot := t.TempDir()
+	timedOutAt := time.Date(2026, 7, 28, 7, 0, 0, 0, time.UTC)
+	record := compilePendingRecord{
+		RequestID:     "compile_test_record",
+		TimedOutAtUtc: timedOutAt,
+	}
+
+	if err := writeCompilePendingRecord(projectRoot, record); err != nil {
+		t.Fatalf("writeCompilePendingRecord failed: %v", err)
+	}
+
+	path := compilePendingRecordPath(projectRoot)
+	if filepath.Base(path) != compilePendingRecordFileName {
+		t.Fatalf("unexpected file name: %s", path)
+	}
+	if filepath.Base(filepath.Dir(path)) != tools.CacheDirectoryName {
+		t.Fatalf("record must live under %s: %s", tools.CacheDirectoryName, path)
+	}
+
+	got, ok := readCompilePendingRecord(projectRoot)
+	if !ok {
+		t.Fatal("expected pending record")
+	}
+	if got.RequestID != record.RequestID {
+		t.Fatalf("request id mismatch: %#v", got)
+	}
+	if !got.TimedOutAtUtc.Equal(timedOutAt) {
+		t.Fatalf("timed out at mismatch: %#v", got.TimedOutAtUtc)
+	}
+}
+
+// Verifies invalid JSON is treated as no record and the corrupt file is deleted.
+func TestReadCompilePendingRecordRejectsInvalidJSON(t *testing.T) {
+	projectRoot := t.TempDir()
+	path := compilePendingRecordPath(projectRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"requestId":`), 0o644); err != nil {
+		t.Fatalf("write corrupt record failed: %v", err)
+	}
+
+	if _, ok := readCompilePendingRecord(projectRoot); ok {
+		t.Fatal("invalid JSON must not yield a record")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("invalid JSON file should be deleted: %v", err)
+	}
+}
+
+// Verifies missing required fields are treated as no record and the file is deleted.
+func TestReadCompilePendingRecordRejectsMissingFields(t *testing.T) {
+	projectRoot := t.TempDir()
+	path := compilePendingRecordPath(projectRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"requestId":""}`), 0o644); err != nil {
+		t.Fatalf("write incomplete record failed: %v", err)
+	}
+
+	if _, ok := readCompilePendingRecord(projectRoot); ok {
+		t.Fatal("missing fields must not yield a record")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("incomplete record file should be deleted: %v", err)
+	}
+}
+
+// Verifies stale records older than CompileResultLifetime are deleted on read.
+func TestReadCompilePendingRecordRejectsStaleRecord(t *testing.T) {
+	projectRoot := t.TempDir()
+	record := compilePendingRecord{
+		RequestID:     "compile_stale",
+		TimedOutAtUtc: time.Now().UTC().Add(-(compilePendingRecordLifetime + time.Minute)),
+	}
+	if err := writeCompilePendingRecord(projectRoot, record); err != nil {
+		t.Fatalf("writeCompilePendingRecord failed: %v", err)
+	}
+
+	if _, ok := readCompilePendingRecord(projectRoot); ok {
+		t.Fatal("stale record must not be returned")
+	}
+	if _, err := os.Stat(compilePendingRecordPath(projectRoot)); !os.IsNotExist(err) {
+		t.Fatalf("stale record file should be deleted: %v", err)
+	}
+}
+
+// Verifies clearCompilePendingRecord removes an existing file and tolerates absence.
+func TestClearCompilePendingRecord(t *testing.T) {
+	projectRoot := t.TempDir()
+	record := compilePendingRecord{
+		RequestID:     "compile_clear",
+		TimedOutAtUtc: time.Now().UTC(),
+	}
+	if err := writeCompilePendingRecord(projectRoot, record); err != nil {
+		t.Fatalf("writeCompilePendingRecord failed: %v", err)
+	}
+
+	clearCompilePendingRecord(projectRoot)
+	if _, err := os.Stat(compilePendingRecordPath(projectRoot)); !os.IsNotExist(err) {
+		t.Fatalf("record should be cleared: %v", err)
+	}
+
+	clearCompilePendingRecord(projectRoot)
+}
+
+// Verifies pending-record paths use filepath.Join separators on every OS.
+func TestCompilePendingRecordPathUsesOSSeparators(t *testing.T) {
+	projectRoot := filepath.FromSlash("/tmp/MyProject")
+	path := compilePendingRecordPath(projectRoot)
+	expected := filepath.Join(projectRoot, tools.CacheDirectoryName, compilePendingRecordFileName)
+	if path != expected {
+		t.Fatalf("path mismatch: got %q want %q", path, expected)
+	}
+	if runtime.GOOS == "windows" {
+		if filepath.Separator != '\\' {
+			t.Fatal("expected Windows separator")
+		}
+	}
+}

--- a/cli/project-runner/internal/projectrunner/compile_pending_record_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_pending_record_test.go
@@ -13,7 +13,7 @@ import (
 // Verifies a pending compile record round-trips through the project .uloop path.
 func TestWriteReadCompilePendingRecordRoundTrip(t *testing.T) {
 	projectRoot := t.TempDir()
-	timedOutAt := time.Date(2026, 7, 28, 7, 0, 0, 0, time.UTC)
+	timedOutAt := time.Now().UTC().Truncate(time.Second)
 	record := compilePendingRecord{
 		RequestID:     "compile_test_record",
 		TimedOutAtUtc: timedOutAt,
@@ -119,11 +119,13 @@ func TestClearCompilePendingRecord(t *testing.T) {
 	clearCompilePendingRecord(projectRoot)
 }
 
-// Verifies pending-record paths use filepath.Join separators on every OS.
+// Verifies pending-record paths join .uloop and the file name with OS separators.
 func TestCompilePendingRecordPathUsesOSSeparators(t *testing.T) {
 	projectRoot := filepath.FromSlash("/tmp/MyProject")
 	path := compilePendingRecordPath(projectRoot)
-	expected := filepath.Join(projectRoot, tools.CacheDirectoryName, compilePendingRecordFileName)
+	// Why literal FromSlash expected: building expected with the same Join helpers as the
+	// implementation would make this assertion tautological.
+	expected := filepath.FromSlash("/tmp/MyProject/.uloop/pending-compile-request.json")
 	if path != expected {
 		t.Fatalf("path mismatch: got %q want %q", path, expected)
 	}

--- a/cli/project-runner/internal/projectrunner/compile_wait_deps.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_deps.go
@@ -2,16 +2,21 @@ package projectrunner
 
 import (
 	"context"
+	"time"
 
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
 type compileWaitDeps struct {
-	queryCompileStatus func(context.Context, unityipc.Connection, string) (compileStatusResponse, error)
+	queryCompileStatus  func(context.Context, unityipc.Connection, string) (compileStatusResponse, error)
+	attachProbeTimeout  time.Duration
+	attachProbeInterval time.Duration
 }
 
 func defaultCompileWaitDeps() compileWaitDeps {
 	return compileWaitDeps{
-		queryCompileStatus: queryCompileStatusFromUnity,
+		queryCompileStatus:  queryCompileStatusFromUnity,
+		attachProbeTimeout:  compileAttachProbeTimeout,
+		attachProbeInterval: compileAttachProbeInterval,
 	}
 }

--- a/cli/project-runner/internal/projectrunner/compile_wait_deps.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_deps.go
@@ -8,15 +8,17 @@ import (
 )
 
 type compileWaitDeps struct {
-	queryCompileStatus  func(context.Context, unityipc.Connection, string) (compileStatusResponse, error)
-	attachProbeTimeout  time.Duration
-	attachProbeInterval time.Duration
+	queryCompileStatus     func(context.Context, unityipc.Connection, string) (compileStatusResponse, error)
+	attachProbeTimeout     time.Duration
+	attachProbeInterval    time.Duration
+	attachWaitPollInterval time.Duration
 }
 
 func defaultCompileWaitDeps() compileWaitDeps {
 	return compileWaitDeps{
-		queryCompileStatus:  queryCompileStatusFromUnity,
-		attachProbeTimeout:  compileAttachProbeTimeout,
-		attachProbeInterval: compileAttachProbeInterval,
+		queryCompileStatus:     queryCompileStatusFromUnity,
+		attachProbeTimeout:     compileAttachProbeTimeout,
+		attachProbeInterval:    compileAttachProbeInterval,
+		attachWaitPollInterval: compileWaitPollInterval,
 	}
 }

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -825,7 +825,7 @@ func TestCompileWaitTimeoutError(t *testing.T) {
 	}
 	expectedActions := []string{
 		"Run a light command such as `uloop get-logs --max-count 1` to check whether Unity is responsive before treating this as a freeze.",
-		"Unity-side compile continues after this timeout; retry `uloop compile` — the result remains retrievable for about 10 more minutes without `uloop launch -r`.",
+		"Unity keeps compiling and refuses other commands with UNITY_SERVER_BUSY until it finishes. Re-run `uloop compile`: it will reattach to the in-flight compile and wait for its result instead of starting a new one. The result stays retrievable for roughly 18 more minutes.",
 		clierrors.ApiUpdateConsentModalNextAction,
 		"Only if Unity does not respond to any command, restart it with `uloop launch -r`.",
 	}
@@ -834,8 +834,20 @@ func TestCompileWaitTimeoutError(t *testing.T) {
 	}
 	for i, expected := range expectedActions {
 		if cliErr.NextActions[i] != expected {
-			t.Fatalf("next action %d mismatch: %#v", i, cliErr.NextActions)
+			t.Fatalf("next action %d mismatch:\n got: %#v\nwant: %#v", i, cliErr.NextActions[i], expected)
 		}
+	}
+}
+
+// Verifies a wait that consumes the full retention window omits the remaining-minutes sentence.
+func TestCompileWaitTimeoutErrorOmitsRemainingMinutesWhenNoneLeft(t *testing.T) {
+	cliErr := compileWaitTimeoutError("/tmp/MyProject", compilePendingRecordLifetime)
+	reattach := cliErr.NextActions[1]
+	if strings.Contains(reattach, "retrievable for roughly") {
+		t.Fatalf("remaining-minutes sentence should be omitted: %#v", reattach)
+	}
+	if !strings.Contains(reattach, "reattach to the in-flight compile") {
+		t.Fatalf("reattach guidance missing: %#v", reattach)
 	}
 }
 
@@ -854,6 +866,8 @@ func compileWaitTestDeps(
 	replacement func(context.Context, unityipc.Connection, string) (compileStatusResponse, error),
 ) compileWaitDeps {
 	return compileWaitDeps{
-		queryCompileStatus: replacement,
+		queryCompileStatus:  replacement,
+		attachProbeTimeout:  40 * time.Millisecond,
+		attachProbeInterval: 5 * time.Millisecond,
 	}
 }

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -866,8 +866,9 @@ func compileWaitTestDeps(
 	replacement func(context.Context, unityipc.Connection, string) (compileStatusResponse, error),
 ) compileWaitDeps {
 	return compileWaitDeps{
-		queryCompileStatus:  replacement,
-		attachProbeTimeout:  40 * time.Millisecond,
-		attachProbeInterval: 5 * time.Millisecond,
+		queryCompileStatus:     replacement,
+		attachProbeTimeout:     40 * time.Millisecond,
+		attachProbeInterval:    5 * time.Millisecond,
+		attachWaitPollInterval: 5 * time.Millisecond,
 	}
 }

--- a/cli/project-runner/internal/projectrunner/execution_errors.go
+++ b/cli/project-runner/internal/projectrunner/execution_errors.go
@@ -21,13 +21,31 @@ func compileWaitTimeoutError(projectRoot string, timeout time.Duration) clierror
 		ProjectRoot: projectRoot,
 		Command:     clicore.CompileCommandName,
 		// Why: agents historically treated this timeout as a frozen Editor and ran
-		// launch -r. The real recovery path is retrying compile while C# still holds
-		// the result (CompileResultLifetime 20m = wait 10m + ~10m retrievable window).
-		NextActions: []string{
-			"Run a light command such as `uloop get-logs --max-count 1` to check whether Unity is responsive before treating this as a freeze.",
-			"Unity-side compile continues after this timeout; retry `uloop compile` — the result remains retrievable for about 10 more minutes without `uloop launch -r`.",
-			clierrors.ApiUpdateConsentModalNextAction,
-			"Only if Unity does not respond to any command, restart it with `uloop launch -r`.",
-		},
+		// launch -r. Recovery is reattach via a later uloop compile while Unity still
+		// holds the result (CompileResultLifetime / compilePendingRecordLifetime).
+		NextActions: compileWaitTimeoutNextActions(timeout),
+	}
+}
+
+func compileWaitTimeoutNextActions(timeout time.Duration) []string {
+	reattachAction := "Unity keeps compiling and refuses other commands with UNITY_SERVER_BUSY until it finishes. Re-run `uloop compile`: it will reattach to the in-flight compile and wait for its result instead of starting a new one."
+	remaining := compilePendingRecordLifetime - timeout
+	if remaining < 0 {
+		remaining = 0
+	}
+	remainingMinutes := int(remaining / time.Minute)
+	if remainingMinutes > 0 {
+		reattachAction = fmt.Sprintf(
+			"%s The result stays retrievable for roughly %d more minutes.",
+			reattachAction,
+			remainingMinutes,
+		)
+	}
+
+	return []string{
+		"Run a light command such as `uloop get-logs --max-count 1` to check whether Unity is responsive before treating this as a freeze.",
+		reattachAction,
+		clierrors.ApiUpdateConsentModalNextAction,
+		"Only if Unity does not respond to any command, restart it with `uloop launch -r`.",
 	}
 }

--- a/cli/project-runner/internal/projectrunner/run.go
+++ b/cli/project-runner/internal/projectrunner/run.go
@@ -165,15 +165,6 @@ func runCompileWithDomainReloadWaitWithDeps(
 	stderr io.Writer,
 	compileWait compileWaitDeps,
 ) int {
-	requestID, err := prepareCompileWaitParams(params)
-	if err != nil {
-		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
-			ProjectRoot: connection.ProjectRoot,
-			Command:     clicore.CompileCommandName,
-		})
-		return 1
-	}
-
 	waitTimeout, timeoutErr := compileWaitTimeoutFromParams(params)
 	if timeoutErr != nil {
 		clierrors.WriteClassifiedError(stderr, timeoutErr, clierrors.ErrorContext{
@@ -187,6 +178,19 @@ func runCompileWithDomainReloadWaitWithDeps(
 			stderr,
 			"warning: --compile-wait-timeout-seconds exceeds the Unity-side compile result retention window (20 minutes); if the wait times out, the result may expire before a retry can recover it.\n",
 		)
+	}
+
+	if handled, code := tryAttachToPendingCompile(ctx, connection, params, waitTimeout, stdout, stderr, compileWait); handled {
+		return code
+	}
+
+	requestID, err := prepareCompileWaitParams(params)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     clicore.CompileCommandName,
+		})
+		return 1
 	}
 
 	logCliDebugModeResolved(connection, clicore.CompileCommandName)
@@ -233,21 +237,11 @@ func runCompileWithDomainReloadWaitWithDeps(
 	}
 	if !completed {
 		spinner.Stop()
+		persistCompilePendingRecordOrWarn(connection.ProjectRoot, requestID, stderr)
 		clierrors.WriteErrorEnvelope(stderr, compileWaitTimeoutError(connection.ProjectRoot, waitTimeout))
 		return 1
 	}
-	switch compileResultReadinessWaitMode(result) {
-	case compileReadinessWaitWarmup:
-		spinner.Update("Warming execute-dynamic-code after compile...")
-		if err := clicore.WaitForToolReadiness(ctx, connection.ProjectRoot); err != nil {
-			spinner.Stop()
-			writePostCompileWarmupWarning(stderr, err)
-		}
-	}
-	spinner.Stop()
-	clicore.WriteJSON(stdout, result)
-	writeDebugTiming(stderr, clicore.CompileCommandName, time.Since(startedAt), outcome)
-	return toolEnvelopeExitCode(result)
+	return completeCompileResultOutput(ctx, connection, result, stdout, stderr, spinner, startedAt, outcome)
 }
 
 func writePostCompileWarmupWarning(stderr io.Writer, err error) {


### PR DESCRIPTION
## Summary
- After `COMPILE_WAIT_TIMEOUT`, a later `uloop compile` reattaches to the in-flight or completed compile instead of starting a new one that hits `UNITY_SERVER_BUSY`.
- Timeout guidance now describes that reattach recovery path and the remaining result-retention window.

## User Impact
- Before: retrying `uloop compile` after a wait timeout started a new compile and was often rejected as busy while Unity was still compiling.
- After: retry reuses the timed-out request id, waits for or returns its result, and clears the pending marker when done.

## Changes
- Persist `.uloop/pending-compile-request.json` on wait timeout (20-minute stale window aligned with Unity result retention).
- Before sending a new compile, probe `get-compile-status` with up to 10s of retries, then attach/wait, return a stored result, or fall through per force-recompile / missing-result rules.
- Rewrite `COMPILE_WAIT_TIMEOUT` NextActions for reattach; add attach vibe-log events and branch coverage tests.

## Verification
- `scripts/check-go-cli.sh` passed.
- E2E with `ULOOP_DEBUG=1` and the local dist binary:
  1. `--compile-wait-timeout-seconds 1 --force-recompile` → `COMPILE_WAIT_TIMEOUT` + pending record written
  2. Immediate plain `uloop compile` → not `UNITY_SERVER_BUSY`; attached and cleared pending record
  3. Timeout again, wait until idle, plain `uloop compile` → `cli_compile_attach_result` with `stored_result` and no later `cli_compile_request_prepared` / `cli_compile_request_send_result`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

