### PR TITLE
feat: report last observed compile status in COMPILE_WAIT_TIMEOUT

### DIFF
--- a/cli/common/errors/busy_editor_state.go
+++ b/cli/common/errors/busy_editor_state.go
@@ -18,6 +18,16 @@ func unityServerBusyNextActions(data map[string]any) []string {
 			actions...)
 	}
 
+	// Why only runningToolName == "compile": attach recovery requires a local pending
+	// record from this client's own COMPILE_WAIT_TIMEOUT. Editor-state "unity-compile"
+	// busy and other clients' compiles must not promise reattach.
+	if rpcStringData(data, "runningToolName") == "compile" {
+		actions = append(
+			actions,
+			"A compile can take several minutes on large projects. Wait for it to finish, then retry. If your own `uloop compile` previously failed with COMPILE_WAIT_TIMEOUT, re-running `uloop compile` reattaches to that compile instead of starting a new one.",
+		)
+	}
+
 	if stallSeconds, ok := rpcFloatData(data, "secondsSinceLastMainThreadTick"); ok &&
 		stallSeconds >= unityServerBusyResponsivenessStallThresholdSeconds {
 		actions = append(

--- a/cli/common/errors/busy_editor_state_test.go
+++ b/cli/common/errors/busy_editor_state_test.go
@@ -17,6 +17,42 @@ func TestUnityServerBusyNextActions_WhenCompiling_IncludesCompileGuidance(t *tes
 	}
 }
 
+// Verifies a busy compile tool adds reattach guidance that only applies after the
+// caller's own COMPILE_WAIT_TIMEOUT (not for unrelated clients or unity-compile).
+func TestUnityServerBusyNextActions_WhenRunningCompileTool_IncludesReattachGuidance(t *testing.T) {
+	data := map[string]any{
+		"runningToolName": "compile",
+	}
+
+	actions := unityServerBusyNextActions(data)
+	expected := "A compile can take several minutes on large projects. Wait for it to finish, then retry. If your own `uloop compile` previously failed with COMPILE_WAIT_TIMEOUT, re-running `uloop compile` reattaches to that compile instead of starting a new one."
+	found := false
+	for _, action := range actions {
+		if action == expected {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("compile reattach guidance missing: %#v", actions)
+	}
+}
+
+// Verifies editor-state unity-compile busy does not promise uloop compile reattach.
+func TestUnityServerBusyNextActions_WhenRunningUnityCompile_OmitsReattachGuidance(t *testing.T) {
+	data := map[string]any{
+		"runningToolName": "unity-compile",
+		"isCompiling":     true,
+	}
+
+	actions := unityServerBusyNextActions(data)
+	for _, action := range actions {
+		if action == "A compile can take several minutes on large projects. Wait for it to finish, then retry. If your own `uloop compile` previously failed with COMPILE_WAIT_TIMEOUT, re-running `uloop compile` reattaches to that compile instead of starting a new one." {
+			t.Fatalf("unity-compile busy must not promise reattach: %#v", actions)
+		}
+	}
+}
+
 // Verifies stalled main-thread ticks add a lightweight responsiveness check action.
 func TestUnityServerBusyNextActions_WhenMainThreadStalled_IncludesResponsivenessCheck(t *testing.T) {
 	data := map[string]any{

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "9623e4986ab240e4a131ac65128f62aea9da1f99"
+  "sharedInputsHash": "bf3daa1fb2faad4babcf160026e2e290ec43e7dc"
 }

--- a/cli/project-runner/internal/projectrunner/compile_attach.go
+++ b/cli/project-runner/internal/projectrunner/compile_attach.go
@@ -140,7 +140,8 @@ func attachWaitForPendingCompile(
 	if pollInterval <= 0 {
 		pollInterval = compileWaitPollInterval
 	}
-	result, outcome, waitErr := waitForAttachedCompileCompletion(ctx, compileCompletionOptions{
+	waitStartedAt := time.Now()
+	result, outcome, lastStatus, waitErr := waitForAttachedCompileCompletion(ctx, compileCompletionOptions{
 		connection:   connection,
 		requestID:    record.RequestID,
 		timeout:      waitTimeout,
@@ -166,7 +167,12 @@ func attachWaitForPendingCompile(
 		spinner.Stop()
 		// Why not refresh TimedOutAtUtc: stale expiry must stay anchored to the first timeout.
 		logCompileAttachResult(connection, record.RequestID, "timeout", false)
-		clierrors.WriteErrorEnvelope(stderr, compileWaitTimeoutError(connection.ProjectRoot, waitTimeout))
+		clierrors.WriteErrorEnvelope(stderr, compileWaitTimeoutError(
+			connection.ProjectRoot,
+			waitTimeout,
+			lastStatus,
+			time.Since(waitStartedAt),
+		))
 		return true, 1
 	case attachWaitCompleted:
 		clearCompilePendingRecord(connection.ProjectRoot)
@@ -183,12 +189,13 @@ func waitForAttachedCompileCompletion(
 	ctx context.Context,
 	options compileCompletionOptions,
 	deps compileWaitDeps,
-) (json.RawMessage, attachWaitOutcome, error) {
+) (json.RawMessage, attachWaitOutcome, *compileStatusResponse, error) {
 	startedAt := time.Now()
 	deadline := startedAt.Add(options.timeout)
 	attempts := 0
 	missingResultStreak := 0
 	var lastStatus compileStatusResponse
+	observedStatus := false
 	var lastErr error
 	lastObservationKey := ""
 
@@ -207,16 +214,17 @@ func waitForAttachedCompileCompletion(
 		lastErr = err
 		if err == nil {
 			lastStatus = status
+			observedStatus = true
 			if status.HasResult && len(status.Result) > 0 {
 				logCompileStatusPollObservedIfChanged(options, startedAt, attempts, status, nil, &lastObservationKey)
 				logCompileStatusPollComplete(options, startedAt, attempts, status)
-				return status.Result, attachWaitCompleted, nil
+				return status.Result, attachWaitCompleted, nil, nil
 			}
 			if status.Ready && !status.HasResult {
 				missingResultStreak++
 				if missingResultStreak >= compileAttachMissingResultStreak {
 					logCompileStatusPollObservedIfChanged(options, startedAt, attempts, status, nil, &lastObservationKey)
-					return nil, attachWaitDisappeared, nil
+					return nil, attachWaitDisappeared, lastObservedCompileStatus(lastStatus, observedStatus), nil
 				}
 			} else {
 				missingResultStreak = 0
@@ -227,13 +235,13 @@ func waitForAttachedCompileCompletion(
 		select {
 		case <-ctx.Done():
 			logCompileWaitCancelled(options, startedAt, attempts, lastStatus, lastErr, ctx.Err())
-			return nil, attachWaitFailed, ctx.Err()
+			return nil, attachWaitFailed, lastObservedCompileStatus(lastStatus, observedStatus), ctx.Err()
 		case <-ticker.C:
 		}
 	}
 
 	logCompileWaitTimedOut(options, startedAt, attempts, lastStatus, lastErr)
-	return nil, attachWaitTimedOut, nil
+	return nil, attachWaitTimedOut, lastObservedCompileStatus(lastStatus, observedStatus), nil
 }
 
 func returnAttachedStoredCompileResult(

--- a/cli/project-runner/internal/projectrunner/compile_attach_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_attach_test.go
@@ -326,6 +326,7 @@ func TestRunCompileAttachRetimesOutPreservesPendingRecord(t *testing.T) {
 	if !strings.Contains(stderr.String(), "Compile status wait timed out after 1000ms") {
 		t.Fatalf("reattach timeout message mismatch: %s", stderr.String())
 	}
+	assertCompileWaitTimeoutEnvelopeDetails(t, stderr.Bytes(), true)
 
 	got, ok := readCompilePendingRecord(projectRoot)
 	if !ok {

--- a/cli/project-runner/internal/projectrunner/compile_wait.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait.go
@@ -170,11 +170,16 @@ func isSafeCompileRequestID(requestID string) bool {
 	return true
 }
 
-func waitForCompileCompletionWithDeps(ctx context.Context, options compileCompletionOptions, deps compileWaitDeps) (json.RawMessage, bool, error) {
+func waitForCompileCompletionWithDeps(
+	ctx context.Context,
+	options compileCompletionOptions,
+	deps compileWaitDeps,
+) (json.RawMessage, bool, *compileStatusResponse, error) {
 	startedAt := time.Now()
 	deadline := startedAt.Add(options.timeout)
 	attempts := 0
 	var lastStatus compileStatusResponse
+	observedStatus := false
 	var lastErr error
 	lastObservationKey := ""
 
@@ -194,23 +199,32 @@ func waitForCompileCompletionWithDeps(ctx context.Context, options compileComple
 		if err == nil && status.Ready && status.HasResult && len(status.Result) > 0 {
 			logCompileStatusPollObservedIfChanged(options, startedAt, attempts, status, nil, &lastObservationKey)
 			logCompileStatusPollComplete(options, startedAt, attempts, status)
-			return status.Result, true, nil
+			return status.Result, true, nil, nil
 		}
 		if err == nil {
 			lastStatus = status
+			observedStatus = true
 		}
 		logCompileStatusPollObservedIfChanged(options, startedAt, attempts, status, err, &lastObservationKey)
 
 		select {
 		case <-ctx.Done():
 			logCompileWaitCancelled(options, startedAt, attempts, lastStatus, lastErr, ctx.Err())
-			return nil, false, ctx.Err()
+			return nil, false, lastObservedCompileStatus(lastStatus, observedStatus), ctx.Err()
 		case <-ticker.C:
 		}
 	}
 
 	logCompileWaitTimedOut(options, startedAt, attempts, lastStatus, lastErr)
-	return nil, false, nil
+	return nil, false, lastObservedCompileStatus(lastStatus, observedStatus), nil
+}
+
+func lastObservedCompileStatus(status compileStatusResponse, observed bool) *compileStatusResponse {
+	if !observed {
+		return nil
+	}
+	copied := status
+	return &copied
 }
 
 func compileForceRecompileEnabled(params map[string]any) bool {

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -500,6 +500,7 @@ func TestRunCompileWithDomainReloadWaitUsesConfiguredTimeout(t *testing.T) {
 		!strings.Contains(stderr.String(), `"ErrorCode":"COMPILE_WAIT_TIMEOUT"`) {
 		t.Fatalf("expected COMPILE_WAIT_TIMEOUT envelope: %s", stderr.String())
 	}
+	assertCompileWaitTimeoutEnvelopeDetails(t, stderr.Bytes(), true)
 
 	logContent := readOnlyCliVibeLog(t, projectRoot)
 	if !strings.Contains(logContent, `"timeout_ms":1000`) {
@@ -912,6 +913,37 @@ func TestWaitForCompileCompletionReturnsLastStatusOnTimeout(t *testing.T) {
 	}
 	if !lastStatus.IsCompiling || !lastStatus.IsDomainReloadInProgress {
 		t.Fatalf("last status mismatch: %#v", lastStatus)
+	}
+}
+
+// assertCompileWaitTimeoutEnvelopeDetails checks the run/attach wiring that passes
+// lastStatus and WaitedMs into the COMPILE_WAIT_TIMEOUT stderr envelope.
+func assertCompileWaitTimeoutEnvelopeDetails(t *testing.T, stderr []byte, wantCompiling bool) {
+	t.Helper()
+	jsonStart := bytes.IndexByte(stderr, '{')
+	if jsonStart < 0 {
+		t.Fatalf("stderr has no JSON envelope: %s", string(stderr))
+	}
+	var envelope clierrors.CLIErrorEnvelope
+	if err := json.Unmarshal(stderr[jsonStart:], &envelope); err != nil {
+		t.Fatalf("stderr is not a JSON error envelope: %v\n%s", err, string(stderr))
+	}
+	if envelope.Error.ErrorCode != clierrors.ErrorCodeCompileWaitTimeout {
+		t.Fatalf("error code mismatch: %#v", envelope.Error.ErrorCode)
+	}
+	details := envelope.Error.Details
+	if details == nil {
+		t.Fatal("COMPILE_WAIT_TIMEOUT Details missing")
+	}
+	if details["IsCompiling"] != wantCompiling {
+		t.Fatalf("IsCompiling mismatch: %#v", details["IsCompiling"])
+	}
+	waitedMs, ok := details["WaitedMs"].(float64)
+	if !ok {
+		t.Fatalf("WaitedMs missing or wrong type: %#v", details["WaitedMs"])
+	}
+	if waitedMs < 1000 {
+		t.Fatalf("WaitedMs should cover the configured 1s wait: %#v", waitedMs)
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -185,7 +185,7 @@ func TestWaitForCompileCompletionReturnsReadyStatusResult(t *testing.T) {
 		return compileStatusResponse{Ready: true, HasResult: true, Result: json.RawMessage(`{"Success":true}`)}, nil
 	})
 
-	result, completed, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+	result, completed, _, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
 		connection:   connection,
 		requestID:    requestID,
 		timeout:      time.Second,
@@ -226,7 +226,7 @@ func TestWaitForCompileCompletionWritesPollLifecycleVibeLogs(t *testing.T) {
 		}, nil
 	})
 
-	result, completed, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+	result, completed, _, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
 		connection:   connection,
 		requestID:    requestID,
 		timeout:      time.Second,
@@ -276,7 +276,7 @@ func TestWaitForCompileCompletionForceCompileWaitsForStoredResult(t *testing.T) 
 		}, nil
 	})
 
-	result, completed, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+	result, completed, _, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
 		connection:     connection,
 		requestID:      requestID,
 		forceRecompile: true,
@@ -317,7 +317,7 @@ func TestWaitForCompileCompletionForceCompileTimesOutWithoutStoredResult(t *test
 		return compileStatusResponse{Ready: true, HasResult: false}, nil
 	})
 
-	_, completed, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+	_, completed, _, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
 		connection:     connection,
 		requestID:      requestID,
 		forceRecompile: true,
@@ -341,7 +341,7 @@ func TestWaitForCompileCompletionWritesTimeoutVibeLog(t *testing.T) {
 		return compileStatusResponse{Ready: false, IsCompiling: true, Message: "Compiling"}, nil
 	})
 
-	_, completed, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+	_, completed, _, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
 		connection:   connection,
 		requestID:    requestID,
 		timeout:      20 * time.Millisecond,
@@ -380,7 +380,7 @@ func TestWaitForCompileCompletionWritesCancellationVibeLog(t *testing.T) {
 		return compileStatusResponse{Ready: false, IsDomainReloadInProgress: true}, nil
 	})
 
-	_, completed, err := waitForCompileCompletionWithDeps(ctx, compileCompletionOptions{
+	_, completed, _, err := waitForCompileCompletionWithDeps(ctx, compileCompletionOptions{
 		connection:   connection,
 		requestID:    requestID,
 		timeout:      time.Second,
@@ -783,7 +783,7 @@ func TestWaitForCompileCompletionRespectsConfiguredTimeout(t *testing.T) {
 	})
 
 	startedAt := time.Now()
-	_, completed, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+	_, completed, _, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
 		connection:   connection,
 		requestID:    "compile_configured_timeout",
 		timeout:      40 * time.Millisecond,
@@ -808,7 +808,7 @@ func TestWaitForCompileCompletionRespectsConfiguredTimeout(t *testing.T) {
 // responsiveness instead of assuming a freeze, because agents have terminated
 // whole sessions after misreading this timeout as a frozen Editor.
 func TestCompileWaitTimeoutError(t *testing.T) {
-	cliErr := compileWaitTimeoutError("/tmp/MyProject", 90*time.Second)
+	cliErr := compileWaitTimeoutError("/tmp/MyProject", 90*time.Second, nil, 90*time.Second)
 
 	if cliErr.ErrorCode != clierrors.ErrorCodeCompileWaitTimeout {
 		t.Fatalf("error code mismatch: %#v", cliErr)
@@ -841,13 +841,77 @@ func TestCompileWaitTimeoutError(t *testing.T) {
 
 // Verifies a wait that consumes the full retention window omits the remaining-minutes sentence.
 func TestCompileWaitTimeoutErrorOmitsRemainingMinutesWhenNoneLeft(t *testing.T) {
-	cliErr := compileWaitTimeoutError("/tmp/MyProject", compilePendingRecordLifetime)
+	cliErr := compileWaitTimeoutError("/tmp/MyProject", compilePendingRecordLifetime, nil, compilePendingRecordLifetime)
 	reattach := cliErr.NextActions[1]
 	if strings.Contains(reattach, "retrievable for roughly") {
 		t.Fatalf("remaining-minutes sentence should be omitted: %#v", reattach)
 	}
 	if !strings.Contains(reattach, "reattach to the in-flight compile") {
 		t.Fatalf("reattach guidance missing: %#v", reattach)
+	}
+}
+
+// Verifies COMPILE_WAIT_TIMEOUT Details include the last observed status flags and WaitedMs.
+func TestCompileWaitTimeoutErrorIncludesLastObservedStatusDetails(t *testing.T) {
+	lastStatus := &compileStatusResponse{
+		IsCompiling:              true,
+		IsUpdating:               false,
+		IsDomainReloadInProgress: true,
+	}
+	cliErr := compileWaitTimeoutError("/tmp/MyProject", time.Second, lastStatus, 1234*time.Millisecond)
+	if cliErr.Details["WaitedMs"] != int64(1234) {
+		t.Fatalf("WaitedMs mismatch: %#v", cliErr.Details["WaitedMs"])
+	}
+	if cliErr.Details["IsCompiling"] != true {
+		t.Fatalf("IsCompiling mismatch: %#v", cliErr.Details)
+	}
+	if cliErr.Details["IsUpdating"] != false {
+		t.Fatalf("IsUpdating mismatch: %#v", cliErr.Details)
+	}
+	if cliErr.Details["IsDomainReloadInProgress"] != true {
+		t.Fatalf("IsDomainReloadInProgress mismatch: %#v", cliErr.Details)
+	}
+}
+
+// Verifies timeout Details omit status flags when no compile status was observed.
+func TestCompileWaitTimeoutErrorOmitsStatusDetailsWhenUnobserved(t *testing.T) {
+	cliErr := compileWaitTimeoutError("/tmp/MyProject", time.Second, nil, time.Second)
+	if _, ok := cliErr.Details["IsCompiling"]; ok {
+		t.Fatalf("IsCompiling should be omitted without an observation: %#v", cliErr.Details)
+	}
+	if cliErr.Details["WaitedMs"] != int64(1000) {
+		t.Fatalf("WaitedMs mismatch: %#v", cliErr.Details["WaitedMs"])
+	}
+}
+
+// Verifies the wait helper returns the last successful status observation on timeout.
+func TestWaitForCompileCompletionReturnsLastStatusOnTimeout(t *testing.T) {
+	connection := compileWaitTestConnection(t)
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		return compileStatusResponse{
+			Ready:                    false,
+			IsCompiling:              true,
+			IsDomainReloadInProgress: true,
+		}, nil
+	})
+
+	_, completed, lastStatus, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+		connection:   connection,
+		requestID:    "compile_last_status",
+		timeout:      30 * time.Millisecond,
+		pollInterval: 5 * time.Millisecond,
+	}, deps)
+	if err != nil {
+		t.Fatalf("waitForCompileCompletion failed: %v", err)
+	}
+	if completed {
+		t.Fatal("expected timeout")
+	}
+	if lastStatus == nil {
+		t.Fatal("expected last observed status")
+	}
+	if !lastStatus.IsCompiling || !lastStatus.IsDomainReloadInProgress {
+		t.Fatalf("last status mismatch: %#v", lastStatus)
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/execution_errors.go
+++ b/cli/project-runner/internal/projectrunner/execution_errors.go
@@ -9,7 +9,12 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 )
 
-func compileWaitTimeoutError(projectRoot string, timeout time.Duration) clierrors.CLIError {
+func compileWaitTimeoutError(
+	projectRoot string,
+	timeout time.Duration,
+	lastStatus *compileStatusResponse,
+	waited time.Duration,
+) clierrors.CLIError {
 	return clierrors.CLIError{
 		ErrorCode: clierrors.ErrorCodeCompileWaitTimeout,
 		Phase:     clierrors.ErrorPhaseCompileWaiting,
@@ -24,7 +29,21 @@ func compileWaitTimeoutError(projectRoot string, timeout time.Duration) clierror
 		// launch -r. Recovery is reattach via a later uloop compile while Unity still
 		// holds the result (CompileResultLifetime / compilePendingRecordLifetime).
 		NextActions: compileWaitTimeoutNextActions(timeout),
+		Details:     compileWaitTimeoutDetails(lastStatus, waited),
 	}
+}
+
+func compileWaitTimeoutDetails(lastStatus *compileStatusResponse, waited time.Duration) map[string]any {
+	details := map[string]any{
+		"WaitedMs": waited.Milliseconds(),
+	}
+	if lastStatus == nil {
+		return details
+	}
+	details["IsCompiling"] = lastStatus.IsCompiling
+	details["IsUpdating"] = lastStatus.IsUpdating
+	details["IsDomainReloadInProgress"] = lastStatus.IsDomainReloadInProgress
+	return details
 }
 
 func compileWaitTimeoutNextActions(timeout time.Duration) []string {

--- a/cli/project-runner/internal/projectrunner/run.go
+++ b/cli/project-runner/internal/projectrunner/run.go
@@ -220,7 +220,8 @@ func runCompileWithDomainReloadWaitWithDeps(
 	}
 
 	spinner.Update("Waiting for domain reload to complete...")
-	result, completed, waitErr := waitForCompileCompletionWithDeps(ctx, compileCompletionOptions{
+	waitStartedAt := time.Now()
+	result, completed, lastStatus, waitErr := waitForCompileCompletionWithDeps(ctx, compileCompletionOptions{
 		connection:     connection,
 		requestID:      requestID,
 		forceRecompile: compileForceRecompileEnabled(params),
@@ -238,7 +239,12 @@ func runCompileWithDomainReloadWaitWithDeps(
 	if !completed {
 		spinner.Stop()
 		persistCompilePendingRecordOrWarn(connection.ProjectRoot, requestID, stderr)
-		clierrors.WriteErrorEnvelope(stderr, compileWaitTimeoutError(connection.ProjectRoot, waitTimeout))
+		clierrors.WriteErrorEnvelope(stderr, compileWaitTimeoutError(
+			connection.ProjectRoot,
+			waitTimeout,
+			lastStatus,
+			time.Since(waitStartedAt),
+		))
 		return 1
 	}
 	return completeCompileResultOutput(ctx, connection, result, stdout, stderr, spinner, startedAt, outcome)

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "a4acb2ec0d1e37d45a3ed8a36448929214310be0"
+  "sharedInputsHash": "f1d7256b537c46e46e886b16f113d192b769e6a1"
 }


### PR DESCRIPTION
## Summary
- `COMPILE_WAIT_TIMEOUT` now includes the last observed compile status flags and how long the CLI waited.
- `UNITY_SERVER_BUSY` while the running tool is `compile` explains that a caller's own prior timeout can reattach on retry.

## User Impact
- Before: a wait timeout only said the wait expired, with no signal whether Unity was still compiling/updating/reloading.
- After: the error Details report `IsCompiling` / `IsUpdating` / `IsDomainReloadInProgress` and `WaitedMs`. Busy responses for a running `compile` tool also point to the reattach recovery path without promising it for unrelated `unity-compile` busy states.

## Changes
- `waitForCompileCompletionWithDeps` returns the last observed `*compileStatusResponse` (nil when none).
- Timeout error Details follow the `EditorActivity` precedent on busy errors.
- Busy NextActions add compile-reattach guidance only when `runningToolName == "compile"`.
- Shared release input stamps updated for the `cli/common` change.

## Verification
- `scripts/check-go-cli.sh` passed.
- `scripts/stamp-release-inputs.sh` run and included.
- E2E: `dist/darwin-arm64/uloop compile --compile-wait-timeout-seconds 1 --force-recompile` → Details `{IsCompiling: true, WaitedMs: 1001, ...}`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

