### PR TITLE
fix: separate enable-time patch warnings from pause point hit responses

### DIFF
--- a/.agents/skills/uloop-pause-point/references/captured-variables.md
+++ b/.agents/skills/uloop-pause-point/references/captured-variables.md
@@ -86,6 +86,6 @@ For a self-progressing game, arranging a scenario through real input alone is a 
 
 ## Warnings and Marker Freshness
 
-`await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
+`await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. Enable-time patch diagnostics (for example physics-callback cached dispatch) are not in `Warning`; on `enable-pause-point --await` they appear as `EnableTimeWarning` instead. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
 
 Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time.

--- a/.agents/skills/uloop-pause-point/references/troubleshooting.md
+++ b/.agents/skills/uloop-pause-point/references/troubleshooting.md
@@ -18,7 +18,7 @@ Mono can inline very small target methods into callers, and the pause point then
 
 ## Physics Message Methods and One-Hop Helpers
 
-Physical Unity message methods (`OnCollisionEnter2D`, `OnTriggerEnter2D`, and similar callbacks) can silently miss: a GameObject that already existed at enable time may keep calling the pre-patch code, so `HitCount` stays `0` even though the method body runs. The condition is environment-dependent, and the response `Warning` flags such lines at enable time. The same applies one hop out — a helper called from a physics message method in the same compiled assembly; deeper call chains or callers in other assemblies are not detected by the warning but can fail the same way.
+Physical Unity message methods (`OnCollisionEnter2D`, `OnTriggerEnter2D`, and similar callbacks) can silently miss: a GameObject that already existed at enable time may keep calling the pre-patch code, so `HitCount` stays `0` even though the method body runs. The condition is environment-dependent. On `enable-pause-point --await`, that enable-time patch diagnostic appears as top-level `EnableTimeWarning` (omitted when empty) — it is independent of whether the marker later hits, and it is not folded into hit-time `Warning`. On a non-hit failure, the same text is under `Error.Details.EnableWarning`. The same applies one hop out — a helper called from a physics message method in the same compiled assembly; deeper call chains or callers in other assemblies are not detected by the warning but can fail the same way.
 
 Recovery order:
 

--- a/.claude/skills/uloop-pause-point/references/captured-variables.md
+++ b/.claude/skills/uloop-pause-point/references/captured-variables.md
@@ -86,6 +86,6 @@ For a self-progressing game, arranging a scenario through real input alone is a 
 
 ## Warnings and Marker Freshness
 
-`await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
+`await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. Enable-time patch diagnostics (for example physics-callback cached dispatch) are not in `Warning`; on `enable-pause-point --await` they appear as `EnableTimeWarning` instead. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
 
 Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time.

--- a/.claude/skills/uloop-pause-point/references/troubleshooting.md
+++ b/.claude/skills/uloop-pause-point/references/troubleshooting.md
@@ -18,7 +18,7 @@ Mono can inline very small target methods into callers, and the pause point then
 
 ## Physics Message Methods and One-Hop Helpers
 
-Physical Unity message methods (`OnCollisionEnter2D`, `OnTriggerEnter2D`, and similar callbacks) can silently miss: a GameObject that already existed at enable time may keep calling the pre-patch code, so `HitCount` stays `0` even though the method body runs. The condition is environment-dependent, and the response `Warning` flags such lines at enable time. The same applies one hop out — a helper called from a physics message method in the same compiled assembly; deeper call chains or callers in other assemblies are not detected by the warning but can fail the same way.
+Physical Unity message methods (`OnCollisionEnter2D`, `OnTriggerEnter2D`, and similar callbacks) can silently miss: a GameObject that already existed at enable time may keep calling the pre-patch code, so `HitCount` stays `0` even though the method body runs. The condition is environment-dependent. On `enable-pause-point --await`, that enable-time patch diagnostic appears as top-level `EnableTimeWarning` (omitted when empty) — it is independent of whether the marker later hits, and it is not folded into hit-time `Warning`. On a non-hit failure, the same text is under `Error.Details.EnableWarning`. The same applies one hop out — a helper called from a physics message method in the same compiled assembly; deeper call chains or callers in other assemblies are not detected by the warning but can fail the same way.
 
 Recovery order:
 

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/captured-variables.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/captured-variables.md
@@ -86,6 +86,6 @@ For a self-progressing game, arranging a scenario through real input alone is a 
 
 ## Warnings and Marker Freshness
 
-`await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
+`await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. Enable-time patch diagnostics (for example physics-callback cached dispatch) are not in `Warning`; on `enable-pause-point --await` they appear as `EnableTimeWarning` instead. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
 
 Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/troubleshooting.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/troubleshooting.md
@@ -18,7 +18,7 @@ Mono can inline very small target methods into callers, and the pause point then
 
 ## Physics Message Methods and One-Hop Helpers
 
-Physical Unity message methods (`OnCollisionEnter2D`, `OnTriggerEnter2D`, and similar callbacks) can silently miss: a GameObject that already existed at enable time may keep calling the pre-patch code, so `HitCount` stays `0` even though the method body runs. The condition is environment-dependent, and the response `Warning` flags such lines at enable time. The same applies one hop out — a helper called from a physics message method in the same compiled assembly; deeper call chains or callers in other assemblies are not detected by the warning but can fail the same way.
+Physical Unity message methods (`OnCollisionEnter2D`, `OnTriggerEnter2D`, and similar callbacks) can silently miss: a GameObject that already existed at enable time may keep calling the pre-patch code, so `HitCount` stays `0` even though the method body runs. The condition is environment-dependent. On `enable-pause-point --await`, that enable-time patch diagnostic appears as top-level `EnableTimeWarning` (omitted when empty) — it is independent of whether the marker later hits, and it is not folded into hit-time `Warning`. On a non-hit failure, the same text is under `Error.Details.EnableWarning`. The same applies one hop out — a helper called from a physics message method in the same compiled assembly; deeper call chains or callers in other assemblies are not detected by the warning but can fail the same way.
 
 Recovery order:
 

--- a/cli/project-runner/internal/projectrunner/pause_point_enable.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable.go
@@ -410,13 +410,15 @@ func runPausePointWaitAfterEnable(
 		response = applyPausePointCapturedVariablesMode(response, options.capturedVariablesMode)
 
 		logs, logsErr := fetchMatchingLogs(ctx, connection, options.id, options.matchingLogsMaxCount)
-		// Unity's warning can come from either the enable response or the status poll that observed
-		// the hit, so both are passed; the join drops the repeat when they carry the same text.
+		// Why not join enableFields.Warning into Warning: that text is an enable-time patch
+		// diagnostic (for example "may not hit on pre-existing GameObjects") and contradicts a
+		// successful hit when folded into the hit-time Warning. It is exposed separately.
 		payload := buildPausePointHitPayload(pausePointHitPayloadInputs{
 			response:            response,
 			logs:                logs,
 			logsErr:             logsErr,
-			unityWarning:        joinPausePointWarnings(enableFields.Warning, response.Warning),
+			unityWarning:        response.Warning,
+			enableTimeWarning:   enableFields.Warning,
 			triggerResult:       triggerResult,
 			awaitedPausePointID: options.id,
 			expectations:        expectations,

--- a/cli/project-runner/internal/projectrunner/pause_point_enable.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable.go
@@ -467,10 +467,9 @@ func runPausePointWaitAfterEnable(
 	return 1
 }
 
-// joinPausePointWarnings concatenates the warnings that apply to one response, dropping empty ones
-// and repeats. Repeats are possible because the same text can reach a hit payload from two sources —
-// the enable response and the status poll that observed the hit — and printing it twice reads as two
-// separate problems.
+// joinPausePointWarnings concatenates hit-time warnings for one response, dropping empty ones and
+// repeats. Inputs are status-poll text (usually empty), matching-logs diagnosis, and trigger-refusal
+// text — enable-time patch diagnostics are not joined here; they use EnableTimeWarning.
 func joinPausePointWarnings(warnings ...string) string {
 	unique := make([]string, 0, len(warnings))
 	for _, warning := range warnings {

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_await_diagnosis_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_await_diagnosis_test.go
@@ -84,18 +84,3 @@ func TestRunPausePointWaitAfterEnableKeepsEnableWarningWithTheRefusalWarning(t *
 		t.Errorf("the refusal warning was dropped: %q", result.Warning)
 	}
 }
-
-// Verifies a warning reported by both the enable response and the status poll is printed once:
-// repeating identical text reads as two separate problems.
-func TestRunPausePointWaitAfterEnableReportsARepeatedUnityWarningOnce(t *testing.T) {
-	stubPausePointHit(t, "Same Unity warning.")
-	stubPausePointMatchingLogs(t, nil)
-	stubPausePointTriggerDispatch(t, `{"Success":true}`)
-
-	_, output := runEnableAwaitWithStubbedTrigger(t, "Same Unity warning.")
-
-	result := decodePausePointWaitResult(t, output)
-	if strings.Count(result.Warning, "Same Unity warning.") != 1 {
-		t.Errorf("expected the repeated warning exactly once: %q", result.Warning)
-	}
-}

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_await_diagnosis_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_await_diagnosis_test.go
@@ -61,8 +61,8 @@ func TestRunPausePointWaitAfterEnableWarnsWhenTheTriggerWasRefusedByThisMarker(t
 	}
 }
 
-// Verifies the enable-time warning survives next to the CLI's refusal warning, and that the
-// refusal warning also survives a failed matching-log fetch.
+// Verifies the enable-time warning is exposed as EnableTimeWarning (not folded into Warning) next
+// to the CLI's refusal warning, and that both survive a failed matching-log fetch.
 func TestRunPausePointWaitAfterEnableKeepsEnableWarningWithTheRefusalWarning(t *testing.T) {
 	stubPausePointHit(t, "")
 	stubPausePointMatchingLogs(t, errors.New("unity busy"))
@@ -74,8 +74,11 @@ func TestRunPausePointWaitAfterEnableKeepsEnableWarningWithTheRefusalWarning(t *
 		t.Errorf("a failed fetch must omit MatchingLogs entirely: %s", output)
 	}
 	result := decodePausePointWaitResult(t, output)
-	if !strings.Contains(result.Warning, "Enable-time warning.") {
-		t.Errorf("the enable-time warning was dropped: %q", result.Warning)
+	if result.EnableTimeWarning != "Enable-time warning." {
+		t.Errorf("enable-time warning mismatch: %q", result.EnableTimeWarning)
+	}
+	if strings.Contains(result.Warning, "Enable-time warning.") {
+		t.Errorf("enable-time warning must not be folded into Warning: %q", result.Warning)
 	}
 	if !strings.Contains(result.Warning, "refused") {
 		t.Errorf("the refusal warning was dropped: %q", result.Warning)

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
@@ -203,8 +203,11 @@ func TestRunEnablePausePointCommandAwaitsAfterSuccessfulEnable(t *testing.T) {
 	if response.Status != pausePointStatusHit || response.HitCount != 1 {
 		t.Fatalf("response mismatch: %#v", response)
 	}
-	if !strings.Contains(response.Warning, "cached message dispatch warning") {
-		t.Fatalf("expected enable-time warning to be propagated, got: %q", response.Warning)
+	if !strings.Contains(response.EnableTimeWarning, "cached message dispatch warning") {
+		t.Fatalf("expected enable-time warning on EnableTimeWarning, got: %q", response.EnableTimeWarning)
+	}
+	if strings.Contains(response.Warning, "cached message dispatch warning") {
+		t.Fatalf("enable-time warning must not be folded into Warning: %q", response.Warning)
 	}
 	if statusCallCount != 2 {
 		t.Fatalf("status call count mismatch: %d", statusCallCount)

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_time_warning_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_time_warning_test.go
@@ -1,0 +1,100 @@
+package projectrunner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+const enableTimePatchWarning = "GameObjects that already existed at enable time may never reach the marker."
+
+// Verifies a successful enable --await hit keeps the enable-time patch warning out of Warning and
+// exposes it on EnableTimeWarning instead.
+func TestRunPausePointWaitAfterEnableSeparatesEnableTimeWarningOnHit(t *testing.T) {
+	stubPausePointHit(t, "")
+	stubPausePointMatchingLogs(t, nil)
+	stubPausePointTriggerDispatch(t, `{"Success":true}`)
+
+	code, output := runEnableAwaitWithStubbedTrigger(t, enableTimePatchWarning)
+	if code != 0 {
+		t.Fatalf("expected hit success, got %d: %s", code, output)
+	}
+	result := decodePausePointWaitResult(t, output)
+	if result.EnableTimeWarning != enableTimePatchWarning {
+		t.Fatalf("EnableTimeWarning mismatch: %q", result.EnableTimeWarning)
+	}
+	if strings.Contains(result.Warning, enableTimePatchWarning) {
+		t.Fatalf("enable-time warning must not appear in Warning: %q", result.Warning)
+	}
+}
+
+// Verifies a non-hit enable --await path still surfaces the enable-time warning on the existing
+// Details.EnableWarning key (unchanged; not folded into Details.Warning).
+func TestRunPausePointWaitAfterEnableKeepsEnableWarningDetailOnExpired(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	originalPoll := pausePointStatusPoll
+	pausePointStatusPoll = time.Millisecond
+	defer func() {
+		queryPausePointStatus = originalQuery
+		pausePointStatusPoll = originalPoll
+	}()
+
+	queryPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{
+			Id:          id,
+			Status:      pausePointStatusExpired,
+			Expired:     true,
+			EditorState: pausePointEditorState{IsPlaying: true, CapturedAt: "Current"},
+			Message:     "Pause point expired before it was hit.",
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPausePointWaitAfterEnable(
+		context.Background(),
+		unityipc.Connection{ProjectRoot: "/tmp/MyProject"},
+		waitForPausePointOptions{
+			id:                   "jump",
+			timeoutSeconds:       1,
+			timeout:              time.Second,
+			matchingLogsMaxCount: 5,
+			markerJustEnabled:    true,
+		},
+		enablePausePointPropagatedFields{Warning: enableTimePatchWarning},
+		&stdout,
+		&stderr,
+	)
+	if code != 1 {
+		t.Fatalf("expected non-hit failure, got %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	var envelope struct {
+		Error clierrors.CLIError `json:"Error"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal stderr: %v (%s)", err, stderr.String())
+	}
+	if envelope.Error.ErrorCode != clierrors.ErrorCodePausePointExpired {
+		t.Fatalf("error code mismatch: %s", envelope.Error.ErrorCode)
+	}
+	enableWarning, ok := envelope.Error.Details["EnableWarning"].(string)
+	if !ok || enableWarning != enableTimePatchWarning {
+		t.Fatalf("Details.EnableWarning mismatch: %#v", envelope.Error.Details["EnableWarning"])
+	}
+	if warning, exists := envelope.Error.Details["Warning"]; exists {
+		if warningText, isString := warning.(string); isString && strings.Contains(warningText, enableTimePatchWarning) {
+			t.Fatalf("enable-time warning must stay on EnableWarning, not Details.Warning: %#v", warning)
+		}
+	}
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_logs.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_logs.go
@@ -35,13 +35,13 @@ type pausePointMatchingLogsResult struct {
 
 // pausePointWaitResult extends the hit response with marker-matching logs so
 // agents do not need a separate get-logs call while Unity is paused. Warning
-// carries the only actionable signal that used to live inside a now-removed
-// EvidenceSummary; everything else in that summary duplicated fields already
-// present on pausePointStatusResponse or MatchingLogs.
+// carries hit-time diagnosis only; enable-time patch warnings live in
+// EnableTimeWarning so a successful hit is not contradicted by "may not hit" text.
 type pausePointWaitResult struct {
 	pausePointStatusResponse
-	MatchingLogs []pausePointMatchingLog `json:"MatchingLogs"`
-	Warning      string                  `json:"Warning,omitempty"`
+	MatchingLogs      []pausePointMatchingLog `json:"MatchingLogs"`
+	Warning           string                  `json:"Warning,omitempty"`
+	EnableTimeWarning string                  `json:"EnableTimeWarning,omitempty"`
 
 	// Expectations and AllExpectationsPassed are populated only when --expect was passed, so a
 	// caller that never used --expect sees neither field rather than a vacuous
@@ -64,9 +64,12 @@ type pausePointHitPayloadInputs struct {
 	logs    pausePointMatchingLogsResult
 	logsErr error
 
-	// unityWarning is Unity's own warning for this hit: the status response's on the plain await
-	// path, the enable response's on the enable --await path.
+	// unityWarning is the status-poll warning for this hit (plain await or enable --await).
+	// Enable-time patch warnings must not be folded in here — they go to enableTimeWarning.
 	unityWarning string
+
+	// enableTimeWarning is the enable-pause-point patch diagnostic. Empty on plain await.
+	enableTimeWarning string
 
 	triggerResult       *pausePointTriggerResult
 	awaitedPausePointID string
@@ -86,11 +89,13 @@ func buildPausePointHitPayload(inputs pausePointHitPayloadInputs) any {
 		return struct {
 			pausePointStatusResponse
 			Warning               string                        `json:"Warning,omitempty"`
+			EnableTimeWarning     string                        `json:"EnableTimeWarning,omitempty"`
 			Expectations          []pausePointExpectationResult `json:"Expectations,omitempty"`
 			AllExpectationsPassed *bool                         `json:"AllExpectationsPassed,omitempty"`
 		}{
 			pausePointStatusResponse: response,
 			Warning:                  joinPausePointWarnings(inputs.unityWarning, triggerWarning),
+			EnableTimeWarning:        inputs.enableTimeWarning,
 			Expectations:             inputs.expectations,
 			AllExpectationsPassed:    pausePointAllExpectationsPassedPointer(inputs.expectations),
 		}
@@ -103,6 +108,7 @@ func buildPausePointHitPayload(inputs pausePointHitPayloadInputs) any {
 			inputs.unityWarning,
 			buildPausePointWarning(inputs.logs, response.HitCount),
 			triggerWarning),
+		EnableTimeWarning:     inputs.enableTimeWarning,
 		Expectations:          inputs.expectations,
 		AllExpectationsPassed: pausePointAllExpectationsPassedPointer(inputs.expectations),
 	}

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -31,9 +31,9 @@ type pausePointStatusResponse struct {
 	StatusBeforeClear               string                           `json:"StatusBeforeClear"`
 	LateHitDiscardedAfterClear      bool                             `json:"LateHitDiscardedAfterClear"`
 
-	// Warning carries the enable-time diagnostic (for example the physics-callback cached
-	// message dispatch warning) that PausePointResponse always includes on the Unity side, but
-	// which only the enable-pause-point --await path (pause_point_enable.go) currently reads.
+	// Warning is set by Unity on enable/clear tool responses when this shared type decodes those
+	// envelopes. The status bridge never sets it. On enable-pause-point --await hits, that enable
+	// response text is exposed as EnableTimeWarning on the wait payload, not as hit-time Warning.
 	Warning string `json:"Warning,omitempty"`
 
 	// ResolvedLine / ResolvedLineText / ResolvedMethod / SnapshotTiming are copied from the


### PR DESCRIPTION
## Summary

- Successful `enable-pause-point --await` hits no longer fold enable-time patch warnings into `Warning`.
- Those diagnostics are exposed on the new additive `EnableTimeWarning` field instead.
- Non-hit paths keep the existing `Details.EnableWarning` behavior unchanged.

## User Impact

Agents reading a successful hit response can trust `Warning` for hit-time diagnosis without a conflicting "may not hit" enable-time message.

## Test plan

- [x] `scripts/check-go-cli.sh` exit 0
- [x] New tests: hit separates `EnableTimeWarning`; expired keeps `Details.EnableWarning`
- [x] Existing enable-await diagnosis tests updated for the new field


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

