### PR TITLE
feat: report which captured variables were truncated in pause point responses

### DIFF
--- a/Assets/Tests/Editor/PausePointCaptureModeTests.cs
+++ b/Assets/Tests/Editor/PausePointCaptureModeTests.cs
@@ -172,7 +172,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 value,
                 string.Empty,
                 string.Empty,
-                0);
+                0,
+                truncated: false);
         }
 
         private sealed class FakePausePointPauseController : IUloopPausePointPauseController

--- a/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
@@ -25,6 +25,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             JObject expected = ReadSharedContractFieldShape();
             PausePointStatusResponse response = new()
             {
+                Success = true,
                 Id = "Assets/Scripts/Enemy.cs:42",
                 Status = "Hit",
                 IsEnabled = true,
@@ -33,6 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 TimeoutSeconds = 30,
                 Mode = "continuous",
                 MaxHistory = 20,
+                MaxPreviewElements = 15,
                 CapturedVariableHistory = new List<PausePointStatusCapturedHistoryFrame>
                 {
                     new()
@@ -72,10 +74,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                         Value = "Enemy",
                         UnityObjectKind = "SceneObject",
                         UnityObjectPath = "MainScene:/Root/Enemy",
-                        UnityObjectInstanceId = -1234
+                        UnityObjectInstanceId = -1234,
+                        Truncated = false
                     }
                 },
                 CapturedVariablesTruncated = true,
+                TruncatedVariableNames = new[] { "extraField" },
+                TruncatedVariableCount = 1,
                 ClearedReason = "",
                 StatusBeforeClear = "",
                 LateHitDiscardedAfterClear = false

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -888,7 +888,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30);
             UloopCapturedVariable[] capturedVariables =
             {
-                new("speed", UloopCapturedVariableScope.Local, "System.Int32", "5", string.Empty, string.Empty, 0)
+                new("speed", UloopCapturedVariableScope.Local, "System.Int32", "5", string.Empty, string.Empty, 0, false)
             };
             UloopPausePointRegistry.HitWithCapturedVariables("jump", capturedVariables, true);
             JObject parameters = new() { ["id"] = "jump" };
@@ -1004,7 +1004,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30);
             UloopCapturedVariable[] capturedVariables =
             {
-                new("speed", UloopCapturedVariableScope.Local, "System.Int32", "5", string.Empty, string.Empty, 0)
+                new("speed", UloopCapturedVariableScope.Local, "System.Int32", "5", string.Empty, string.Empty, 0, false)
             };
 
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.HitWithCapturedVariables(
@@ -1027,10 +1027,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     new UloopPausePointCapturedVariableEntry("scores", UloopCapturedVariableScope.Local, scores),
                     new UloopPausePointCapturedVariableEntry("empty", UloopCapturedVariableScope.Local, null)
                 },
-                false);
+                false,
+                System.Array.Empty<string>(),
+                0);
             UloopCapturedVariable[] capturedVariables =
             {
-                new("scores", UloopCapturedVariableScope.Local, "System.Collections.Generic.List`1[System.Int32]", "[10,20,30]", string.Empty, string.Empty, 0)
+                new("scores", UloopCapturedVariableScope.Local, "System.Collections.Generic.List`1[System.Int32]", "[10,20,30]", string.Empty, string.Empty, 0, false)
             };
 
             UloopPausePointRegistry.HitWithCapturedFrame("jump", frame, capturedVariables, false);
@@ -1056,7 +1058,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePointCapturedVariableFrame frame = new(
                 new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 5) },
-                false);
+                false,
+                System.Array.Empty<string>(),
+                0);
             UloopPausePointRegistry.HitWithCapturedFrame(
                 "jump", frame, Array.Empty<UloopCapturedVariable>(), false);
 
@@ -1076,10 +1080,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("land", 30);
             UloopPausePointCapturedVariableFrame jumpFrame = new(
                 new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 1) },
-                false);
+                false,
+                System.Array.Empty<string>(),
+                0);
             UloopPausePointCapturedVariableFrame landFrame = new(
                 new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 2) },
-                false);
+                false,
+                System.Array.Empty<string>(),
+                0);
 
             UloopPausePointRegistry.HitWithCapturedFrame("jump", jumpFrame, Array.Empty<UloopCapturedVariable>(), false);
             UloopPausePointRegistry.HitWithCapturedFrame("land", landFrame, Array.Empty<UloopCapturedVariable>(), false);
@@ -1098,7 +1106,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("land", 30);
             UloopPausePointCapturedVariableFrame landFrame = new(
                 new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 7) },
-                false);
+                false,
+                System.Array.Empty<string>(),
+                0);
             UloopPausePointRegistry.HitWithCapturedFrame("land", landFrame, Array.Empty<UloopCapturedVariable>(), false);
 
             UloopPausePointRegistry.Clear("jump");
@@ -1117,7 +1127,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePointCapturedVariableFrame frame = new(
                 new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 1) },
-                false);
+                false,
+                System.Array.Empty<string>(),
+                0);
             UloopPausePointRegistry.HitWithCapturedFrame("jump", frame, Array.Empty<UloopCapturedVariable>(), false);
 
             UloopPausePointRegistry.Enable("jump", 30);
@@ -1136,7 +1148,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePointCapturedVariableFrame frame = new(
                 new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 1) },
-                false);
+                false,
+                System.Array.Empty<string>(),
+                0);
             UloopPausePointRegistry.HitWithCapturedFrame("jump", frame, Array.Empty<UloopCapturedVariable>(), false);
 
             UloopPausePointRegistry.Enable("jump", 30);

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
@@ -221,8 +221,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Collect_WhenCountCapReachedBeforeThis_OmitsThisAndReportsTruncated()
         {
-            // Verifies that when locals already fill the count cap, the "this" entry is dropped and
-            // truncation is reported per the existing TryAppendEntry contract.
+            // Verifies that when locals already fill the count cap, the "this" entry is dropped from
+            // Entries but still counted in TruncatedVariableNames / TruncatedVariableCount.
             int localCount = SourcePausePointConstants.MaxCapturedVariableCount;
             object[] locals = new object[localCount * 2];
             for (int i = 0; i < localCount; i++)
@@ -239,6 +239,45 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(frame.Entries.Count, Is.EqualTo(SourcePausePointConstants.MaxCapturedVariableCount));
             Assert.That(frame.Entries.Any(entry => entry.Name == "this"), Is.False);
             Assert.That(frame.Truncated, Is.True);
+            Assert.That(frame.TruncatedVariableCount, Is.GreaterThan(0));
+            Assert.That(frame.TruncatedVariableNames, Does.Contain("this"));
+        }
+
+        [Test]
+        public void Collect_WhenVariableCountExceedsCap_ReportsTruncatedNamesUpToLimitAndExactCount()
+        {
+            // Verifies count-cap overflow keeps collecting names (capped at 20) with an exact total.
+            int discarded = SourcePausePointConstants.MaxTruncatedVariableNamesReported + 5;
+            int localCount = SourcePausePointConstants.MaxCapturedVariableCount + discarded;
+            object[] locals = new object[localCount * 2];
+            for (int i = 0; i < localCount; i++)
+            {
+                locals[i * 2] = $"local{i}";
+                locals[i * 2 + 1] = i;
+            }
+
+            UloopPausePointCapturedVariableFrame frame = SourcePausePointVariableCollector.Collect(
+                null, Array.Empty<object>(), locals);
+
+            Assert.That(frame.Entries.Count, Is.EqualTo(SourcePausePointConstants.MaxCapturedVariableCount));
+            Assert.That(frame.Truncated, Is.True);
+            Assert.That(frame.TruncatedVariableCount, Is.EqualTo(discarded));
+            Assert.That(frame.TruncatedVariableNames.Count, Is.EqualTo(SourcePausePointConstants.MaxTruncatedVariableNamesReported));
+            Assert.That(frame.TruncatedVariableNames[0], Is.EqualTo($"local{SourcePausePointConstants.MaxCapturedVariableCount}"));
+        }
+
+        [Test]
+        public void Collect_WhenUnderCountCap_ReportsEmptyTruncatedNames()
+        {
+            // Verifies no truncation metadata when every variable fits under the count cap.
+            object[] locals = { "speed", 5, "damage", 3 };
+
+            UloopPausePointCapturedVariableFrame frame = SourcePausePointVariableCollector.Collect(
+                null, Array.Empty<object>(), locals);
+
+            Assert.That(frame.Truncated, Is.False);
+            Assert.That(frame.TruncatedVariableCount, Is.EqualTo(0));
+            Assert.That(frame.TruncatedVariableNames, Is.Empty);
         }
 
         [Test]

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
@@ -100,6 +100,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(variables.Single().Value.Length, Is.EqualTo(SourcePausePointConstants.MaxCapturedVariableValueLength));
             Assert.That(truncated, Is.True);
+            Assert.That(variables.Single().Truncated, Is.True);
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileSchema.cs
@@ -28,8 +28,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>
         /// How long the CLI waits for compilation to complete, in seconds.
         /// Unity ignores this value; it is consumed by the CLI.
+        /// Why no [Description]: first-party schema properties must keep long-form agent guidance
+        /// in skill files (see FirstPartyToolSchemaMetadataTests), not runtime metadata.
         /// </summary>
-        [Description("How long the CLI waits for compilation to complete, in seconds. Unity ignores this value; it is consumed by the CLI.")]
         public int CompileWaitTimeoutSeconds { get; set; } = 600;
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -192,6 +192,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string UnityObjectKind { get; set; } = string.Empty;
         public string UnityObjectPath { get; set; } = string.Empty;
         public int UnityObjectInstanceId { get; set; }
+        public bool Truncated { get; set; }
 
         internal static PausePointCapturedVariable FromSnapshot(UloopCapturedVariable snapshot)
         {
@@ -208,7 +209,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Value = snapshot.Value,
                 UnityObjectKind = snapshot.UnityObjectKind,
                 UnityObjectPath = snapshot.UnityObjectPath,
-                UnityObjectInstanceId = snapshot.UnityObjectInstanceId
+                UnityObjectInstanceId = snapshot.UnityObjectInstanceId,
+                Truncated = snapshot.Truncated
             };
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -22,6 +22,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Keeps a single hit's payload small enough for the CLI response and for the console-like
         // pause-point evidence to stay skimmable, mirroring the truncation-by-cap pattern MatchingLogs uses.
         public const int MaxCapturedVariableCount = 50;
+        // How many discarded variable names to surface when the count cap drops extras. The exact
+        // discarded count is still reported in full via TruncatedVariableCount.
+        public const int MaxTruncatedVariableNamesReported = 20;
         public const int MaxCapturedVariableValueLength = 256;
         // Mirrors UloopPausePointRegistry.DefaultMaxPreviewElements (the Runtime-owned per-marker
         // default enforced at Enable time) instead of a second independent literal, so the two

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableCollector.cs
@@ -31,44 +31,56 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(localNamesAndValues.Length % 2 == 0, "localNamesAndValues must contain name/value pairs");
 
             List<UloopPausePointCapturedVariableEntry> entries = new();
+            List<string> truncatedVariableNames = new();
+            int truncatedVariableCount = 0;
             bool truncated = false;
             HashSet<string> capturedNames = new();
 
-            bool countCapReached = AppendPairs(
-                entries, capturedNames, ref truncated, localNamesAndValues, UloopCapturedVariableScope.Local);
-            if (!countCapReached)
+            // Why keep scanning after the count cap: callers need the discarded names and the exact
+            // dropped count, not only a Truncated bool. Values past the cap are never retained.
+            AppendPairs(
+                entries, capturedNames, truncatedVariableNames, ref truncatedVariableCount, ref truncated,
+                localNamesAndValues, UloopCapturedVariableScope.Local);
+            AppendPairs(
+                entries, capturedNames, truncatedVariableNames, ref truncatedVariableCount, ref truncated,
+                parameterNamesAndValues, UloopCapturedVariableScope.Parameter);
+
+            if (instance != null)
             {
-                countCapReached = AppendPairs(
-                    entries, capturedNames, ref truncated, parameterNamesAndValues, UloopCapturedVariableScope.Parameter);
+                CollectInstanceFieldVariables(
+                    instance, entries, capturedNames, truncatedVariableNames, ref truncatedVariableCount,
+                    ref truncated);
             }
 
-            if (instance != null && !countCapReached)
-            {
-                CollectInstanceFieldVariables(instance, entries, capturedNames, ref truncated);
-            }
-
-            return new UloopPausePointCapturedVariableFrame(entries, truncated);
+            return new UloopPausePointCapturedVariableFrame(
+                entries, truncated, truncatedVariableNames, truncatedVariableCount);
         }
 
-        private static bool AppendPairs(
-            List<UloopPausePointCapturedVariableEntry> entries, HashSet<string> capturedNames, ref bool truncated,
-            object[] namesAndValues, string scope)
+        private static void AppendPairs(
+            List<UloopPausePointCapturedVariableEntry> entries,
+            HashSet<string> capturedNames,
+            List<string> truncatedVariableNames,
+            ref int truncatedVariableCount,
+            ref bool truncated,
+            object[] namesAndValues,
+            string scope)
         {
             for (int i = 0; i < namesAndValues.Length; i += 2)
             {
                 string name = (string)namesAndValues[i];
                 object value = namesAndValues[i + 1];
-                if (!TryAppendEntry(entries, capturedNames, ref truncated, name, scope, value))
-                {
-                    return true;
-                }
+                TryAppendEntry(
+                    entries, capturedNames, truncatedVariableNames, ref truncatedVariableCount, ref truncated,
+                    name, scope, value);
             }
-
-            return false;
         }
 
         private static void CollectInstanceFieldVariables(
-            object instance, List<UloopPausePointCapturedVariableEntry> entries, HashSet<string> capturedNames,
+            object instance,
+            List<UloopPausePointCapturedVariableEntry> entries,
+            HashSet<string> capturedNames,
+            List<string> truncatedVariableNames,
+            ref int truncatedVariableCount,
             ref bool truncated)
         {
             bool isCompilerGeneratedStateMachine =
@@ -78,34 +90,38 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // count cap keeps prioritizing locals and parameters over instance state.
             if (!isCompilerGeneratedStateMachine)
             {
-                if (!TryAppendEntry(
-                    entries, capturedNames, ref truncated, ThisEntryName, UloopCapturedVariableScope.This, instance))
-                {
-                    return;
-                }
+                TryAppendEntry(
+                    entries, capturedNames, truncatedVariableNames, ref truncatedVariableCount, ref truncated,
+                    ThisEntryName, UloopCapturedVariableScope.This, instance);
             }
 
-            (object outerThis, bool countCapReached) = CollectDirectFieldVariables(
-                instance, entries, capturedNames, ref truncated, followOuterThis: true);
-            if (countCapReached || outerThis == null)
+            object outerThis = CollectDirectFieldVariables(
+                instance, entries, capturedNames, truncatedVariableNames, ref truncatedVariableCount,
+                ref truncated, followOuterThis: true);
+            if (outerThis == null)
             {
                 return;
             }
 
             // Async/coroutine state machine: the real `this` is the hoisted outer instance, never the
             // compiler-generated state machine object. Emit it before the outer instance's fields.
-            if (!TryAppendEntry(
-                entries, capturedNames, ref truncated, ThisEntryName, UloopCapturedVariableScope.This, outerThis))
-            {
-                return;
-            }
+            TryAppendEntry(
+                entries, capturedNames, truncatedVariableNames, ref truncatedVariableCount, ref truncated,
+                ThisEntryName, UloopCapturedVariableScope.This, outerThis);
 
-            CollectDirectFieldVariables(outerThis, entries, capturedNames, ref truncated, followOuterThis: false);
+            CollectDirectFieldVariables(
+                outerThis, entries, capturedNames, truncatedVariableNames, ref truncatedVariableCount,
+                ref truncated, followOuterThis: false);
         }
 
-        private static (object OuterThis, bool CountCapReached) CollectDirectFieldVariables(
-            object source, List<UloopPausePointCapturedVariableEntry> entries, HashSet<string> capturedNames,
-            ref bool truncated, bool followOuterThis)
+        private static object CollectDirectFieldVariables(
+            object source,
+            List<UloopPausePointCapturedVariableEntry> entries,
+            HashSet<string> capturedNames,
+            List<string> truncatedVariableNames,
+            ref int truncatedVariableCount,
+            ref bool truncated,
+            bool followOuterThis)
         {
             object outerThis = null;
             bool isCompilerGeneratedStateMachine = Attribute.IsDefined(source.GetType(), typeof(CompilerGeneratedAttribute));
@@ -124,13 +140,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Match hoistedLocalMatch = HoistedLocalFieldNamePattern.Match(field.Name);
                 if (hoistedLocalMatch.Success)
                 {
-                    if (!TryAppendEntry(
-                        entries, capturedNames, ref truncated, hoistedLocalMatch.Groups[1].Value,
-                        UloopCapturedVariableScope.Local, field.GetValue(source)))
-                    {
-                        return (outerThis, true);
-                    }
-
+                    TryAppendEntry(
+                        entries, capturedNames, truncatedVariableNames, ref truncatedVariableCount, ref truncated,
+                        hoistedLocalMatch.Groups[1].Value, UloopCapturedVariableScope.Local, field.GetValue(source));
                     continue;
                 }
 
@@ -142,13 +154,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                if (!TryAppendEntry(entries, capturedNames, ref truncated, fieldName, plainFieldScope, field.GetValue(source)))
-                {
-                    return (outerThis, true);
-                }
+                TryAppendEntry(
+                    entries, capturedNames, truncatedVariableNames, ref truncatedVariableCount, ref truncated,
+                    fieldName, plainFieldScope, field.GetValue(source));
             }
 
-            return (outerThis, false);
+            return outerThis;
         }
 
         private static IEnumerable<FieldInfo> EnumerateInstanceFields(Type type)
@@ -167,23 +178,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private static bool TryAppendEntry(
-            List<UloopPausePointCapturedVariableEntry> entries, HashSet<string> capturedNames, ref bool truncated,
-            string name, string scope, object rawValue)
+        private static void TryAppendEntry(
+            List<UloopPausePointCapturedVariableEntry> entries,
+            HashSet<string> capturedNames,
+            List<string> truncatedVariableNames,
+            ref int truncatedVariableCount,
+            ref bool truncated,
+            string name,
+            string scope,
+            object rawValue)
         {
             if (!capturedNames.Add(name))
             {
-                return true;
+                return;
             }
 
             if (entries.Count >= SourcePausePointConstants.MaxCapturedVariableCount)
             {
                 truncated = true;
-                return false;
+                truncatedVariableCount++;
+                if (truncatedVariableNames.Count < SourcePausePointConstants.MaxTruncatedVariableNamesReported)
+                {
+                    truncatedVariableNames.Add(name);
+                }
+
+                return;
             }
 
             entries.Add(new UloopPausePointCapturedVariableEntry(name, scope, rawValue));
-            return true;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
@@ -38,18 +38,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool truncated = frame.Truncated;
             foreach (UloopPausePointCapturedVariableEntry entry in frame.Entries)
             {
-                results.Add(FormatVariable(entry.Name, entry.Scope, entry.Value, maxCollectionPreviewElementCount, ref truncated));
+                UloopCapturedVariable variable = FormatVariable(
+                    entry.Name, entry.Scope, entry.Value, maxCollectionPreviewElementCount);
+                results.Add(variable);
+                truncated |= variable.Truncated;
             }
 
             return (results, truncated);
         }
 
         private static UloopCapturedVariable FormatVariable(
-            string name, string scope, object rawValue, int maxCollectionPreviewElementCount, ref bool truncated)
+            string name, string scope, object rawValue, int maxCollectionPreviewElementCount)
         {
             if (rawValue == null)
             {
-                return new UloopCapturedVariable(name, scope, string.Empty, "null", string.Empty, string.Empty, 0);
+                return new UloopCapturedVariable(
+                    name, scope, string.Empty, "null", string.Empty, string.Empty, 0, truncated: false);
             }
 
             string typeName = rawValue.GetType().FullName;
@@ -58,8 +62,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return FormatUnityObjectVariable(name, scope, typeName, unityObjectCandidate);
             }
 
+            // Why a per-variable flag: overall CapturedVariablesTruncated alone cannot tell which
+            // value was clipped after a name filter narrows the list.
+            bool variableTruncated = false;
             if (SourcePausePointCollectionPreviewSerializer.TrySerialize(
-                    rawValue, maxCollectionPreviewElementCount, ref truncated, out string collectionPreview))
+                    rawValue, maxCollectionPreviewElementCount, ref variableTruncated, out string collectionPreview))
             {
                 // Why scale: a per-marker element-count override that raises the element cap
                 // without also raising the byte budget would still get clipped by the fixed
@@ -69,13 +76,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // the default (10 elements, 1024 chars) already implies.
                 int scaledValueLengthCap = SourcePausePointConstants.MaxCollectionPreviewValueLength
                     * maxCollectionPreviewElementCount / UloopPausePointRegistry.DefaultMaxPreviewElements;
-                string cappedPreview = ApplyValueLengthCap(collectionPreview, scaledValueLengthCap, ref truncated);
-                return new UloopCapturedVariable(name, scope, typeName, cappedPreview, string.Empty, string.Empty, 0);
+                string cappedPreview = ApplyValueLengthCap(collectionPreview, scaledValueLengthCap, ref variableTruncated);
+                return new UloopCapturedVariable(
+                    name, scope, typeName, cappedPreview, string.Empty, string.Empty, 0, variableTruncated);
             }
 
             string value = ApplyValueLengthCap(
-                SafeToString(rawValue), SourcePausePointConstants.MaxCapturedVariableValueLength, ref truncated);
-            return new UloopCapturedVariable(name, scope, typeName, value, string.Empty, string.Empty, 0);
+                SafeToString(rawValue), SourcePausePointConstants.MaxCapturedVariableValueLength, ref variableTruncated);
+            return new UloopCapturedVariable(
+                name, scope, typeName, value, string.Empty, string.Empty, 0, variableTruncated);
         }
 
         private static UloopCapturedVariable FormatUnityObjectVariable(
@@ -83,21 +92,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (!MainThreadSwitcher.IsMainThread)
             {
-                return new UloopCapturedVariable(name, scope, typeName, OffMainThreadValue, string.Empty, string.Empty, 0);
+                return new UloopCapturedVariable(
+                    name, scope, typeName, OffMainThreadValue, string.Empty, string.Empty, 0, truncated: false);
             }
 
             if (unityObjectCandidate == null)
             {
                 return new UloopCapturedVariable(
                     name, scope, typeName, DestroyedValue,
-                    UloopCapturedVariableUnityObjectKind.Destroyed, string.Empty, UnityObjectIdentifier.GetInstanceId(unityObjectCandidate));
+                    UloopCapturedVariableUnityObjectKind.Destroyed, string.Empty,
+                    UnityObjectIdentifier.GetInstanceId(unityObjectCandidate), truncated: false);
             }
 
             SourcePausePointUnityObjectClassifier.Classification classification =
                 SourcePausePointUnityObjectClassifier.Classify(unityObjectCandidate);
             return new UloopCapturedVariable(
                 name, scope, typeName, unityObjectCandidate.name,
-                classification.Kind, classification.Path, classification.InstanceId);
+                classification.Kind, classification.Path, classification.InstanceId, truncated: false);
         }
 
         private static string ApplyValueLengthCap(string value, int maxLength, ref bool truncated)

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -132,6 +132,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public IReadOnlyList<PausePointStatusCapturedVariable> CapturedVariables { get; set; } =
             Array.Empty<PausePointStatusCapturedVariable>();
         public bool CapturedVariablesTruncated { get; set; }
+        public IReadOnlyList<string> TruncatedVariableNames { get; set; } = Array.Empty<string>();
+        public int TruncatedVariableCount { get; set; }
         public string ClearedReason { get; set; } = string.Empty;
         public string StatusBeforeClear { get; set; } = string.Empty;
         public bool LateHitDiscardedAfterClear { get; set; }
@@ -174,6 +176,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     .Select(PausePointStatusCapturedVariable.FromCapturedVariable)
                     .ToList(),
                 CapturedVariablesTruncated = snapshot.CapturedVariablesTruncated,
+                TruncatedVariableNames = snapshot.TruncatedVariableNames,
+                TruncatedVariableCount = snapshot.TruncatedVariableCount,
                 ClearedReason = snapshot.ClearedReason,
                 StatusBeforeClear = snapshot.StatusBeforeClear,
                 LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear
@@ -252,6 +256,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public string UnityObjectKind { get; set; } = string.Empty;
         public string UnityObjectPath { get; set; } = string.Empty;
         public int UnityObjectInstanceId { get; set; }
+        public bool Truncated { get; set; }
 
         internal static PausePointStatusCapturedVariable FromCapturedVariable(UloopCapturedVariable capturedVariable)
         {
@@ -268,7 +273,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 Value = capturedVariable.Value,
                 UnityObjectKind = capturedVariable.UnityObjectKind,
                 UnityObjectPath = capturedVariable.UnityObjectPath,
-                UnityObjectInstanceId = capturedVariable.UnityObjectInstanceId
+                UnityObjectInstanceId = capturedVariable.UnityObjectInstanceId,
+                Truncated = capturedVariable.Truncated
             };
         }
     }

--- a/Packages/src/Runtime/PausePoints/UloopCapturedVariable.cs
+++ b/Packages/src/Runtime/PausePoints/UloopCapturedVariable.cs
@@ -17,7 +17,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             string value,
             string unityObjectKind,
             string unityObjectPath,
-            int unityObjectInstanceId)
+            int unityObjectInstanceId,
+            bool truncated)
         {
             Debug.Assert(!string.IsNullOrEmpty(name), "name must not be null or empty");
             Debug.Assert(!string.IsNullOrEmpty(scope), "scope must not be null or empty");
@@ -29,6 +30,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             UnityObjectKind = unityObjectKind ?? string.Empty;
             UnityObjectPath = unityObjectPath ?? string.Empty;
             UnityObjectInstanceId = unityObjectInstanceId;
+            Truncated = truncated;
         }
 
         public string Name { get; }
@@ -38,6 +40,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string UnityObjectKind { get; }
         public string UnityObjectPath { get; }
         public int UnityObjectInstanceId { get; }
+
+        // True when this variable's value/preview was clipped (length, collection elements, or
+        // preview depth). Distinct from the response-level CapturedVariablesTruncated OR.
+        public bool Truncated { get; }
     }
 }
 #endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCapturedVariableFrame.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCapturedVariableFrame.cs
@@ -1,4 +1,5 @@
 #if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 
 namespace io.github.hatayama.UnityCliLoop.Runtime
@@ -9,14 +10,25 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
     internal sealed class UloopPausePointCapturedVariableFrame
     {
         public UloopPausePointCapturedVariableFrame(
-            IReadOnlyList<UloopPausePointCapturedVariableEntry> entries, bool truncated)
+            IReadOnlyList<UloopPausePointCapturedVariableEntry> entries,
+            bool truncated,
+            IReadOnlyList<string> truncatedVariableNames,
+            int truncatedVariableCount)
         {
             Entries = entries;
             Truncated = truncated;
+            TruncatedVariableNames = truncatedVariableNames ?? Array.Empty<string>();
+            TruncatedVariableCount = truncatedVariableCount;
         }
 
         public IReadOnlyList<UloopPausePointCapturedVariableEntry> Entries { get; }
         public bool Truncated { get; }
+
+        // Names dropped by the variable-count cap (at most MaxTruncatedVariableNamesReported).
+        public IReadOnlyList<string> TruncatedVariableNames { get; }
+
+        // Exact number of variables dropped by the count cap (not capped at the names list length).
+        public int TruncatedVariableCount { get; }
     }
 }
 #endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -31,6 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             IsEnabled = true;
             Message = "Pause point enabled.";
             CapturedVariables = Array.Empty<UloopCapturedVariable>();
+            TruncatedVariableNames = Array.Empty<string>();
             _capturedVariableHistory = new Queue<UloopPausePointCapturedHistoryFrame>(maxHistory);
         }
 
@@ -54,6 +55,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string Message { get; private set; }
         public IReadOnlyList<UloopCapturedVariable> CapturedVariables { get; private set; }
         public bool CapturedVariablesTruncated { get; private set; }
+        public IReadOnlyList<string> TruncatedVariableNames { get; private set; }
+        public int TruncatedVariableCount { get; private set; }
         public int HistoryDroppedCount { get; private set; }
         public string ClearedReason { get; private set; } = string.Empty;
         public string StatusBeforeClear { get; private set; } = string.Empty;
@@ -169,10 +172,14 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             int hitSequence,
             int frameCount,
             IReadOnlyList<UloopCapturedVariable> capturedVariables,
-            bool capturedVariablesTruncated)
+            bool capturedVariablesTruncated,
+            IReadOnlyList<string> truncatedVariableNames,
+            int truncatedVariableCount)
         {
             Debug.Assert(hitSequence > 0, "hitSequence must be greater than zero");
             Debug.Assert(capturedVariables != null, "capturedVariables must not be null");
+            Debug.Assert(truncatedVariableNames != null, "truncatedVariableNames must not be null");
+            Debug.Assert(truncatedVariableCount >= 0, "truncatedVariableCount must not be negative");
 
             if (HitCount == 0)
             {
@@ -192,6 +199,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 : "Pause point hit; Unity pause was requested.";
             CapturedVariables = capturedVariables;
             CapturedVariablesTruncated = capturedVariablesTruncated;
+            TruncatedVariableNames = truncatedVariableNames;
+            TruncatedVariableCount = truncatedVariableCount;
 
             if (_capturedVariableHistory.Count == MaxHistory)
             {
@@ -254,6 +263,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 recommendedNextAction,
                 CapturedVariables,
                 CapturedVariablesTruncated,
+                TruncatedVariableNames,
+                TruncatedVariableCount,
                 ClearedReason,
                 StatusBeforeClear,
                 LateHitDiscardedAfterClear);

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -326,9 +326,16 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
             int hitSequence = ++_nextHitSequence;
             int frameCount = Time.frameCount;
+            IReadOnlyList<string> truncatedVariableNames = capturedFrame != null
+                ? capturedFrame.TruncatedVariableNames
+                : Array.Empty<string>();
+            int truncatedVariableCount = capturedFrame != null
+                ? capturedFrame.TruncatedVariableCount
+                : 0;
             entry.RecordHitWithCapturedVariables(
                 now, _pauseController.IsPlaying, _pauseController.IsPaused, hitSequence,
-                frameCount, capturedVariables, capturedVariablesTruncated);
+                frameCount, capturedVariables, capturedVariablesTruncated,
+                truncatedVariableNames, truncatedVariableCount);
             UloopPausePointSnapshot snapshot = entry.ToSnapshot(now, _pauseController);
             _latestHitSnapshot = snapshot;
             _hitSnapshots.RemoveAll(hitSnapshot => hitSnapshot.Id == id);

--- a/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
@@ -37,6 +37,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             string recommendedNextAction,
             IReadOnlyList<UloopCapturedVariable> capturedVariables,
             bool capturedVariablesTruncated,
+            IReadOnlyList<string> truncatedVariableNames,
+            int truncatedVariableCount,
             string clearedReason,
             string statusBeforeClear,
             bool lateHitDiscardedAfterClear)
@@ -68,6 +70,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             RecommendedNextAction = recommendedNextAction ?? string.Empty;
             CapturedVariables = capturedVariables ?? Array.Empty<UloopCapturedVariable>();
             CapturedVariablesTruncated = capturedVariablesTruncated;
+            TruncatedVariableNames = truncatedVariableNames ?? Array.Empty<string>();
+            TruncatedVariableCount = truncatedVariableCount;
             ClearedReason = clearedReason ?? string.Empty;
             StatusBeforeClear = statusBeforeClear ?? string.Empty;
             LateHitDiscardedAfterClear = lateHitDiscardedAfterClear;
@@ -98,6 +102,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string RecommendedNextAction { get; }
         public IReadOnlyList<UloopCapturedVariable> CapturedVariables { get; }
         public bool CapturedVariablesTruncated { get; }
+        public IReadOnlyList<string> TruncatedVariableNames { get; }
+        public int TruncatedVariableCount { get; }
         public string ClearedReason { get; }
         public string StatusBeforeClear { get; }
         public bool LateHitDiscardedAfterClear { get; }
@@ -134,6 +140,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 string.Empty,
                 Array.Empty<UloopCapturedVariable>(),
                 false,
+                Array.Empty<string>(),
+                0,
                 string.Empty,
                 string.Empty,
                 false);

--- a/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter.go
@@ -60,6 +60,13 @@ func filterPausePointCapturedVariablesByName(
 
 	response.CapturedVariableNameFilterNoMatch = totalMatchCount == 0
 	response.CapturedVariableNamesNotFound = unmatchedCapturedVariableNames(names, matchedNames)
+	if response.CapturedVariableNameFilterNoMatch {
+		// Why also Warning: CapturedVariableNameFilterNoMatch is easy to miss when agents only
+		// skim Warning / CapturedVariables. Reuse the already-computed flag — do not re-derive.
+		response.Warning = joinPausePointWarnings(
+			response.Warning,
+			"No captured variable matched the requested names; check CapturedVariableNamesNotFound. Names must exist in the scope of ResolvedMethod.")
+	}
 	return response
 }
 

--- a/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter.go
@@ -36,6 +36,11 @@ func filterPausePointCapturedVariablesByName(
 		return response
 	}
 
+	// Why before filtering: pause-point-status runs this filter without a hit gate. An unhit
+	// marker has empty CapturedVariables/history, which would otherwise look like a name miss
+	// and a Warning blaming the requested names would misdiagnose "not hit yet".
+	hadCapturedVariables := pausePointResponseHasCapturedVariables(response)
+
 	nameSet := make(map[string]struct{}, len(names))
 	for _, name := range names {
 		nameSet[name] = struct{}{}
@@ -60,14 +65,29 @@ func filterPausePointCapturedVariablesByName(
 
 	response.CapturedVariableNameFilterNoMatch = totalMatchCount == 0
 	response.CapturedVariableNamesNotFound = unmatchedCapturedVariableNames(names, matchedNames)
-	if response.CapturedVariableNameFilterNoMatch {
-		// Why also Warning: CapturedVariableNameFilterNoMatch is easy to miss when agents only
-		// skim Warning / CapturedVariables. Reuse the already-computed flag — do not re-derive.
+	// Why Warning only when hadCapturedVariables: machine-readable flags still fire on empty
+	// snapshots (unchanged), but a human Warning must not claim a name miss when the hit has
+	// not produced any variables yet.
+	if hadCapturedVariables && response.CapturedVariableNameFilterNoMatch {
 		response.Warning = joinPausePointWarnings(
 			response.Warning,
-			"No captured variable matched the requested names; check CapturedVariableNamesNotFound. Names must exist in the scope of ResolvedMethod.")
+			"No captured variable matched the requested names; the hit captured other variables. Check CapturedVariableNamesNotFound for the names that were absent.")
 	}
 	return response
+}
+
+// pausePointResponseHasCapturedVariables reports whether the snapshot already holds any
+// captured variable (current or history) before a name filter runs.
+func pausePointResponseHasCapturedVariables(response pausePointStatusResponse) bool {
+	if len(response.CapturedVariables) > 0 {
+		return true
+	}
+	for _, frame := range response.CapturedVariableHistory {
+		if len(frame.CapturedVariables) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // unmatchedCapturedVariableNames lists the requested names that matched nothing, keeping the order

--- a/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter_test.go
@@ -63,6 +63,10 @@ func TestFilterPausePointCapturedVariablesByName(t *testing.T) {
 		if !result.CapturedVariableNameFilterNoMatch {
 			t.Fatal("expected CapturedVariableNameFilterNoMatch to be true when nothing matches")
 		}
+		const wantWarning = "No captured variable matched the requested names; check CapturedVariableNamesNotFound. Names must exist in the scope of ResolvedMethod."
+		if result.Warning != wantWarning {
+			t.Fatalf("expected human-readable Warning for no-match filter: %q", result.Warning)
+		}
 	})
 
 	t.Run("composes with captured-variables names mode: filter first, then strip values", func(t *testing.T) {

--- a/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter_test.go
@@ -63,9 +63,20 @@ func TestFilterPausePointCapturedVariablesByName(t *testing.T) {
 		if !result.CapturedVariableNameFilterNoMatch {
 			t.Fatal("expected CapturedVariableNameFilterNoMatch to be true when nothing matches")
 		}
-		const wantWarning = "No captured variable matched the requested names; check CapturedVariableNamesNotFound. Names must exist in the scope of ResolvedMethod."
+		const wantWarning = "No captured variable matched the requested names; the hit captured other variables. Check CapturedVariableNamesNotFound for the names that were absent."
 		if result.Warning != wantWarning {
 			t.Fatalf("expected human-readable Warning for no-match filter: %q", result.Warning)
+		}
+	})
+
+	t.Run("empty pre-filter snapshot keeps no-match flag but skips Warning", func(t *testing.T) {
+		// Verifies an unhit status (no variables yet) does not blame the requested names.
+		result := filterPausePointCapturedVariablesByName(pausePointStatusResponse{}, []string{"velocity"})
+		if !result.CapturedVariableNameFilterNoMatch {
+			t.Fatal("expected CapturedVariableNameFilterNoMatch to stay true on an empty snapshot")
+		}
+		if result.Warning != "" {
+			t.Fatalf("expected no Warning when the snapshot had no variables before filtering: %q", result.Warning)
 		}
 	})
 

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -27,6 +27,8 @@ type pausePointStatusResponse struct {
 	RecommendedNextAction           string                           `json:"RecommendedNextAction"`
 	CapturedVariables               []pausePointCapturedVariable     `json:"CapturedVariables"`
 	CapturedVariablesTruncated      bool                             `json:"CapturedVariablesTruncated"`
+	TruncatedVariableNames          []string                         `json:"TruncatedVariableNames"`
+	TruncatedVariableCount          int                              `json:"TruncatedVariableCount"`
 	ClearedReason                   string                           `json:"ClearedReason"`
 	StatusBeforeClear               string                           `json:"StatusBeforeClear"`
 	LateHitDiscardedAfterClear      bool                             `json:"LateHitDiscardedAfterClear"`
@@ -126,6 +128,7 @@ type pausePointCapturedVariable struct {
 	UnityObjectKind       string  `json:"UnityObjectKind,omitempty"`
 	UnityObjectPath       string  `json:"UnityObjectPath,omitempty"`
 	UnityObjectInstanceId int     `json:"UnityObjectInstanceId,omitempty"`
+	Truncated             bool    `json:"Truncated"`
 }
 
 // pausePointVariableValue returns a pointer to value for use in pausePointCapturedVariable

--- a/tests/contracts/pause_point_status_response_contract.json
+++ b/tests/contracts/pause_point_status_response_contract.json
@@ -43,10 +43,15 @@
       "Value": "Enemy",
       "UnityObjectKind": "SceneObject",
       "UnityObjectPath": "MainScene:/Root/Enemy",
-      "UnityObjectInstanceId": -1234
+      "UnityObjectInstanceId": -1234,
+      "Truncated": false
     }
   ],
   "CapturedVariablesTruncated": true,
+  "TruncatedVariableNames": [
+    "extraField"
+  ],
+  "TruncatedVariableCount": 1,
   "ClearedReason": "",
   "StatusBeforeClear": "",
   "LateHitDiscardedAfterClear": false


### PR DESCRIPTION
## Summary

- Pause point hit/status responses now expose per-variable `Truncated`, plus top-level `TruncatedVariableNames` / `TruncatedVariableCount` for variables dropped by the capture count cap (names capped at 20; count is exact).
- Existing `CapturedVariablesTruncated` meaning is unchanged (any truncation during capture).
- When a captured-variable name filter matches nothing, the CLI also sets a human-readable `Warning` (alongside the existing machine-readable filter flags).
- Bonus: drop `[Description]` from `CompileWaitTimeoutSeconds` so `FirstPartyToolSchemaMetadataTests` stays green (long-form guidance belongs in skill files).

## User Impact

Agents can see *which* captured values were clipped and which names the count cap discarded, instead of a sticky overall truncated flag after name filters. A zero-match name filter also surfaces a readable Warning so it is harder to misread as a broken capture.

## Test plan

- [x] `ULOOP_PROJECT_RUNNER_PATH=dist/darwin-arm64/uloop-project-runner uloop compile` — 0 errors / 0 warnings
- [x] `scripts/check-go-cli.sh` — exit 0 (includes new name-filter Warning test)
- [x] EditMode suite — 0 failures (2411 tests; 7 skipped pre-existing)
- [x] New collector tests for count-cap names/count and empty truncation metadata
- [ ] CI on this integration-base child PR may not run; local results above are the verification

## Notes

Child PR targeting `feat/pause-point-feedback-r13-integration` (round 13–14 feedback series, PR-3).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

