### PR TITLE
fix: hide the input visualization overlay while capturing screenshots

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/Common/Overlay/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/Overlay/AssemblyInfo.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Screenshot.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Demo.Editor")]

--- a/Packages/src/Editor/FirstPartyTools/Common/Overlay/OverlayCanvasFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/Overlay/OverlayCanvasFactory.cs
@@ -30,19 +30,61 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _instance = null;
         }
 
+        // Why no create: screenshot must hide an already-visible overlay without spawning one.
+        public GameObject TryGetExisting()
+        {
+            ReclaimExistingInstance();
+            if (_instance == null)
+            {
+                return null;
+            }
+
+            return _instance.gameObject;
+        }
+
         public void EnsureExists()
+        {
+            if (_instance != null)
+            {
+                // Why reactivate: screenshot hide leaves the canvas inactive; the next simulate-*
+                // call must bring it back without instantiating a second DontDestroyOnLoad copy.
+                EnsureActive(_instance.gameObject);
+                return;
+            }
+
+            ReclaimExistingInstance();
+            if (_instance != null)
+            {
+                EnsureActive(_instance.gameObject);
+                return;
+            }
+
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(CANVAS_PREFAB_PATH);
+            Debug.Assert(prefab != null, $"InputVisualizationCanvas prefab not found at {CANVAS_PREFAB_PATH}");
+
+            GameObject go = (GameObject)PrefabUtility.InstantiatePrefab(prefab);
+            Object.DontDestroyOnLoad(go);
+            _instance = go.GetComponent<InputVisualizationCanvas>();
+            Debug.Assert(_instance != null, "InputVisualizationCanvas component not found on prefab");
+        }
+
+        // Domain Reload resets _instance but DontDestroyOnLoad objects survive; reclaim one and destroy duplicates.
+        private void ReclaimExistingInstance()
         {
             if (_instance != null)
             {
                 return;
             }
 
-            // Domain Reload resets _instance but DontDestroyOnLoad objects survive; reclaim one and destroy duplicates
+            // Why include inactive: screenshot SetActive(false) would otherwise hide the only canvas
+            // from default FindObjectsByType and make EnsureExists spawn a duplicate.
 #if UNITY_6000_4_OR_NEWER
-            InputVisualizationCanvas[] existing = Object.FindObjectsByType<InputVisualizationCanvas>();
+            InputVisualizationCanvas[] existing = Object.FindObjectsByType<InputVisualizationCanvas>(
+                FindObjectsInactive.Include);
 #else
-            InputVisualizationCanvas[] existing =
-                Object.FindObjectsByType<InputVisualizationCanvas>(FindObjectsSortMode.None);
+            InputVisualizationCanvas[] existing = Object.FindObjectsByType<InputVisualizationCanvas>(
+                FindObjectsInactive.Include,
+                FindObjectsSortMode.None);
 #endif
             for (int i = 0; i < existing.Length; i++)
             {
@@ -55,18 +97,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     Object.DestroyImmediate(existing[i].gameObject);
                 }
             }
-            if (_instance != null)
+        }
+
+        private static void EnsureActive(GameObject overlayRoot)
+        {
+            if (overlayRoot.activeSelf)
             {
                 return;
             }
 
-            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(CANVAS_PREFAB_PATH);
-            Debug.Assert(prefab != null, $"InputVisualizationCanvas prefab not found at {CANVAS_PREFAB_PATH}");
-
-            GameObject go = (GameObject)PrefabUtility.InstantiatePrefab(prefab);
-            Object.DontDestroyOnLoad(go);
-            _instance = go.GetComponent<InputVisualizationCanvas>();
-            Debug.Assert(_instance != null, "InputVisualizationCanvas component not found on prefab");
+            overlayRoot.SetActive(true);
         }
     }
 
@@ -88,6 +128,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static void EnsureExists()
         {
             ServiceValue.EnsureExists();
+        }
+
+        public static GameObject TryGetExisting()
+        {
+            return ServiceValue.TryGetExisting();
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Common/Overlay/OverlayCanvasFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/Overlay/OverlayCanvasFactory.cs
@@ -101,12 +101,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static void EnsureActive(GameObject overlayRoot)
         {
-            if (overlayRoot.activeSelf)
+            // Why Canvas too: screenshot hide disables Canvas.enabled as well as the GameObject.
+            // Recovering only activeSelf leaves badges permanently invisible while looking active.
+            Canvas overlayCanvas = overlayRoot.GetComponent<Canvas>();
+            if (overlayCanvas != null && !overlayCanvas.enabled)
             {
-                return;
+                overlayCanvas.enabled = true;
             }
 
-            overlayRoot.SetActive(true);
+            if (!overlayRoot.activeSelf)
+            {
+                overlayRoot.SetActive(true);
+            }
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -140,22 +140,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Texture2D texture;
             GameRenderingImageInfo captureRenderingInfo;
             bool captureTimedOut;
-            (GameObject inputVisualizationOverlay, bool inputVisualizationWasActive, bool inputVisualizationHideTimedOut) =
-                await BeginHideInputVisualizationOverlayAsync(editorContext, ct).ConfigureAwait(false);
-            if (inputVisualizationHideTimedOut)
-            {
-                RestoreInputVisualizationOverlay(inputVisualizationOverlay, inputVisualizationWasActive, editorContext);
-                return CreateTimedOutResult(
-                    "input visualization overlay hide",
-                    correlationId,
-                    new List<ScreenshotInfo>());
-            }
 
-            // Why: BeginHide is awaited with ConfigureAwait(false), so resume can leave the main thread.
+            // Why SwitchTo before hide: SetActive/Canvas/RT clear are main-thread only. Keep this
+            // await outside try — nothing is hidden yet if cancellation throws here.
             await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+            (GameObject inputVisualizationOverlay, bool inputVisualizationWasActive) =
+                HideInputVisualizationOverlay();
 
             try
             {
+                // Why wait inside try: WaitFramesOrTimeoutAsync / SwitchTo throw OperationCanceledException
+                // on CLI disconnect; finally must still restore the overlay.
+                if (inputVisualizationWasActive)
+                {
+                    bool hideFramesReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+                        ANNOTATION_OVERLAY_RENDER_WAIT_FRAMES,
+                        UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                        ct).ConfigureAwait(false);
+                    if (!hideFramesReady)
+                    {
+                        return CreateTimedOutResult(
+                            "input visualization overlay hide",
+                            correlationId,
+                            new List<ScreenshotInfo>());
+                    }
+
+                    await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+                }
+
                 try
                 {
                     if (request.AnnotateElements || request.AnnotateRaycastGrid)
@@ -339,19 +351,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss_fff");
             List<ScreenshotInfo> screenshots = new();
 
-            (GameObject inputVisualizationOverlay, bool inputVisualizationWasActive, bool inputVisualizationHideTimedOut) =
-                await BeginHideInputVisualizationOverlayAsync(editorContext, ct).ConfigureAwait(false);
-            if (inputVisualizationHideTimedOut)
-            {
-                RestoreInputVisualizationOverlay(inputVisualizationOverlay, inputVisualizationWasActive, editorContext);
-                return CreateTimedOutResult("input visualization overlay hide", correlationId, screenshots);
-            }
-
-            // Why: BeginHide is awaited with ConfigureAwait(false), so resume can leave the main thread.
+            // Why SwitchTo before hide: SetActive/Canvas/RT clear are main-thread only. Keep this
+            // await outside try — nothing is hidden yet if cancellation throws here.
             await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+            (GameObject inputVisualizationOverlay, bool inputVisualizationWasActive) =
+                HideInputVisualizationOverlay();
 
             try
             {
+                // Why wait inside try: WaitFramesOrTimeoutAsync / SwitchTo throw OperationCanceledException
+                // on CLI disconnect; finally must still restore the overlay.
+                if (inputVisualizationWasActive)
+                {
+                    bool hideFramesReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+                        ANNOTATION_OVERLAY_RENDER_WAIT_FRAMES,
+                        UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                        ct).ConfigureAwait(false);
+                    if (!hideFramesReady)
+                    {
+                        return CreateTimedOutResult(
+                            "input visualization overlay hide",
+                            correlationId,
+                            screenshots);
+                    }
+
+                    await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+                }
+
                 for (int i = 0; i < windows.Length; i++)
                 {
                     EditorWindow window = windows[i];
@@ -435,20 +461,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new ScreenshotResponse { Screenshots = screenshots };
         }
 
-        // Why wait after SetActive(false): the Game View RT can still show the previous frame's
-        // overlay badges unless we give rendering the same 2-frame settle used for annotation draw.
-        private static async Task<(GameObject Overlay, bool WasActive, bool TimedOut)> BeginHideInputVisualizationOverlayAsync(
-            SynchronizationContext editorContext,
-            CancellationToken ct)
+        // Hides the input-visualization canvas synchronously. Caller must already be on the editor
+        // main thread, and must run the 2-frame settle wait inside a try/finally that restores.
+        private static (GameObject Overlay, bool WasActive) HideInputVisualizationOverlay()
         {
-            // Why SwitchTo first: capture paths often resume off the main thread after ConfigureAwait(false).
-            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-
             GameObject overlay = OverlayCanvasFactory.TryGetExisting();
             bool wasActive = overlay != null && overlay.activeSelf;
             if (!wasActive)
             {
-                return (overlay, false, false);
+                return (overlay, false);
             }
 
             overlay.SetActive(false);
@@ -461,22 +482,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Canvas.ForceUpdateCanvases();
-            // Why clear then wait: with no camera the Play Mode RT never rewrites itself after a
-            // Screen Space Overlay is hidden, so the last badge composite would stay forever.
-            // With cameras, the following frame wait redraws the scene without the overlay.
+            // Why clear: with no camera the Play Mode RT never rewrites itself after a Screen Space
+            // Overlay is hidden, so the last badge composite would stay forever. With cameras, the
+            // caller's frame wait redraws the scene without the overlay.
             GameViewBridge.ClearMainPlayModeViewRenderTexture();
             GameViewBridge.RepaintMainPlayModeView();
-            bool framesReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
-                ANNOTATION_OVERLAY_RENDER_WAIT_FRAMES,
-                UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                ct).ConfigureAwait(false);
-            if (!framesReady)
-            {
-                return (overlay, true, true);
-            }
-
-            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-            return (overlay, true, false);
+            return (overlay, true);
         }
 
         private static void RestoreInputVisualizationOverlay(
@@ -501,6 +512,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static void RestoreInputVisualizationOverlayOnMainThread(GameObject overlay)
         {
+            // Why: Post may run after Play Mode teardown destroyed the DontDestroyOnLoad overlay.
+            if (overlay == null)
+            {
+                return;
+            }
+
             Canvas overlayCanvas = overlay.GetComponent<Canvas>();
             if (overlayCanvas != null)
             {

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEditor;
 
+using io.github.hatayama.UnityCliLoop.InternalAPIBridge;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -139,50 +140,71 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Texture2D texture;
             GameRenderingImageInfo captureRenderingInfo;
             bool captureTimedOut;
+            (GameObject inputVisualizationOverlay, bool inputVisualizationWasActive, bool inputVisualizationHideTimedOut) =
+                await BeginHideInputVisualizationOverlayAsync(editorContext, ct).ConfigureAwait(false);
+            if (inputVisualizationHideTimedOut)
+            {
+                RestoreInputVisualizationOverlay(inputVisualizationOverlay, inputVisualizationWasActive, editorContext);
+                return CreateTimedOutResult(
+                    "input visualization overlay hide",
+                    correlationId,
+                    new List<ScreenshotInfo>());
+            }
+
+            // Why: BeginHide is awaited with ConfigureAwait(false), so resume can leave the main thread.
+            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+
             try
             {
-                if (request.AnnotateElements || request.AnnotateRaycastGrid)
+                try
                 {
-                    List<UIElementInfo> overlayElements = new(annotatedElements);
-                    overlayElements.AddRange(physicsColliderElements);
-                    annotationOverlay = UIElementAnnotator.CreateAnnotationOverlay(
-                        overlayElements,
-                        request.ResolutionScale);
-                    Canvas.ForceUpdateCanvases();
-                    // Chained CLI calls can read the previous GameView RT before overlay rendering catches up.
-                    bool overlayFramesReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
-                        ANNOTATION_OVERLAY_RENDER_WAIT_FRAMES,
+                    if (request.AnnotateElements || request.AnnotateRaycastGrid)
+                    {
+                        List<UIElementInfo> overlayElements = new(annotatedElements);
+                        overlayElements.AddRange(physicsColliderElements);
+                        annotationOverlay = UIElementAnnotator.CreateAnnotationOverlay(
+                            overlayElements,
+                            request.ResolutionScale);
+                        Canvas.ForceUpdateCanvases();
+                        // Chained CLI calls can read the previous GameView RT before overlay rendering catches up.
+                        bool overlayFramesReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+                            ANNOTATION_OVERLAY_RENDER_WAIT_FRAMES,
+                            UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                            ct).ConfigureAwait(false);
+                        if (!overlayFramesReady)
+                        {
+                            return CreateTimedOutResult(
+                                "annotation overlay render",
+                                correlationId,
+                                new List<ScreenshotInfo>());
+                        }
+
+                        await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+                    }
+
+                    (texture, captureRenderingInfo, captureTimedOut) = await EditorWindowCaptureUtility.CaptureGameRenderingAsync(
+                        request.ResolutionScale,
+                        raycastGridRenderingInfo,
                         UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
                         ct).ConfigureAwait(false);
-                    if (!overlayFramesReady)
+                    if (captureTimedOut)
                     {
                         return CreateTimedOutResult(
-                            "annotation overlay render",
+                            "Play Mode view rendering capture",
                             correlationId,
                             new List<ScreenshotInfo>());
                     }
 
                     await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
                 }
-
-                (texture, captureRenderingInfo, captureTimedOut) = await EditorWindowCaptureUtility.CaptureGameRenderingAsync(
-                    request.ResolutionScale,
-                    raycastGridRenderingInfo,
-                    UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                    ct).ConfigureAwait(false);
-                if (captureTimedOut)
+                finally
                 {
-                    return CreateTimedOutResult(
-                        "Play Mode view rendering capture",
-                        correlationId,
-                        new List<ScreenshotInfo>());
+                    DestroyAnnotationOverlay(annotationOverlay, editorContext);
                 }
-
-                await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
             }
             finally
             {
-                DestroyAnnotationOverlay(annotationOverlay, editorContext);
+                RestoreInputVisualizationOverlay(inputVisualizationOverlay, inputVisualizationWasActive, editorContext);
             }
 
             // Uses the settled capture-time size, not the pre-capture gameViewSize sample, so annotated
@@ -317,66 +339,84 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss_fff");
             List<ScreenshotInfo> screenshots = new();
 
-            for (int i = 0; i < windows.Length; i++)
+            (GameObject inputVisualizationOverlay, bool inputVisualizationWasActive, bool inputVisualizationHideTimedOut) =
+                await BeginHideInputVisualizationOverlayAsync(editorContext, ct).ConfigureAwait(false);
+            if (inputVisualizationHideTimedOut)
             {
-                EditorWindow window = windows[i];
-                (Texture2D texture, bool timedOut) = await EditorWindowCaptureUtility.CaptureWindowAsync(
-                    window,
-                    request.ResolutionScale,
-                    UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                    ct).ConfigureAwait(false);
-                if (timedOut)
+                RestoreInputVisualizationOverlay(inputVisualizationOverlay, inputVisualizationWasActive, editorContext);
+                return CreateTimedOutResult("input visualization overlay hide", correlationId, screenshots);
+            }
+
+            // Why: BeginHide is awaited with ConfigureAwait(false), so resume can leave the main thread.
+            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+
+            try
+            {
+                for (int i = 0; i < windows.Length; i++)
                 {
-                    return CreateTimedOutResult("EditorWindow capture", correlationId, screenshots);
-                }
-
-                await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-                if (texture == null)
-                {
-                    VibeLogger.LogWarning(
-                        "screenshot_failed",
-                        $"Failed to capture window index {i}",
-                        correlationId: correlationId
-                    );
-                    continue;
-                }
-
-                string fileName = windows.Length == 1
-                    ? $"{safeWindowName}_{timestamp}.png"
-                    : $"{safeWindowName}_{i + 1}_{timestamp}.png";
-                string savedPath = Path.Combine(outputDirectory, fileName);
-
-                int width = texture.width;
-                int height = texture.height;
-
-                try
-                {
-                    ScreenshotFileWriter.SaveTextureAsPng(texture, savedPath);
-
-                    FileInfo savedFileInfo = new(savedPath);
-                    ScreenshotInfo info = new()
+                    EditorWindow window = windows[i];
+                    (Texture2D texture, bool timedOut) = await EditorWindowCaptureUtility.CaptureWindowAsync(
+                        window,
+                        request.ResolutionScale,
+                        UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                        ct).ConfigureAwait(false);
+                    if (timedOut)
                     {
-                        ImagePath = savedPath,
-                        FileSizeBytes = savedFileInfo.Length,
-                        Width = width,
-                        Height = height,
-                    };
-                    ApplyWindowCoordinateMetadata(info);
-                    screenshots.Add(info);
+                        return CreateTimedOutResult("EditorWindow capture", correlationId, screenshots);
+                    }
+
+                    await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+                    if (texture == null)
+                    {
+                        VibeLogger.LogWarning(
+                            "screenshot_failed",
+                            $"Failed to capture window index {i}",
+                            correlationId: correlationId
+                        );
+                        continue;
+                    }
+
+                    string fileName = windows.Length == 1
+                        ? $"{safeWindowName}_{timestamp}.png"
+                        : $"{safeWindowName}_{i + 1}_{timestamp}.png";
+                    string savedPath = Path.Combine(outputDirectory, fileName);
+
+                    int width = texture.width;
+                    int height = texture.height;
+
+                    try
+                    {
+                        ScreenshotFileWriter.SaveTextureAsPng(texture, savedPath);
+
+                        FileInfo savedFileInfo = new(savedPath);
+                        ScreenshotInfo info = new()
+                        {
+                            ImagePath = savedPath,
+                            FileSizeBytes = savedFileInfo.Length,
+                            Width = width,
+                            Height = height,
+                        };
+                        ApplyWindowCoordinateMetadata(info);
+                        screenshots.Add(info);
+                    }
+                    catch (Exception ex)
+                    {
+                        // File I/O is external resource access; catch to continue processing remaining windows
+                        VibeLogger.LogWarning(
+                            "screenshot_save_exception",
+                            $"Exception saving window index {i}: {ex.Message}",
+                            correlationId: correlationId
+                        );
+                    }
+                    finally
+                    {
+                        UnityEngine.Object.DestroyImmediate(texture);
+                    }
                 }
-                catch (Exception ex)
-                {
-                    // File I/O is external resource access; catch to continue processing remaining windows
-                    VibeLogger.LogWarning(
-                        "screenshot_save_exception",
-                        $"Exception saving window index {i}: {ex.Message}",
-                        correlationId: correlationId
-                    );
-                }
-                finally
-                {
-                    UnityEngine.Object.DestroyImmediate(texture);
-                }
+            }
+            finally
+            {
+                RestoreInputVisualizationOverlay(inputVisualizationOverlay, inputVisualizationWasActive, editorContext);
             }
 
             // why: only prune the package default Screenshots folder; never delete files in a user-specified OutputDirectory
@@ -393,6 +433,81 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             );
 
             return new ScreenshotResponse { Screenshots = screenshots };
+        }
+
+        // Why wait after SetActive(false): the Game View RT can still show the previous frame's
+        // overlay badges unless we give rendering the same 2-frame settle used for annotation draw.
+        private static async Task<(GameObject Overlay, bool WasActive, bool TimedOut)> BeginHideInputVisualizationOverlayAsync(
+            SynchronizationContext editorContext,
+            CancellationToken ct)
+        {
+            // Why SwitchTo first: capture paths often resume off the main thread after ConfigureAwait(false).
+            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+
+            GameObject overlay = OverlayCanvasFactory.TryGetExisting();
+            bool wasActive = overlay != null && overlay.activeSelf;
+            if (!wasActive)
+            {
+                return (overlay, false, false);
+            }
+
+            overlay.SetActive(false);
+            // Also disable Canvas: Screen Space Overlay can keep compositing into the Play Mode
+            // view RT for a frame after the GameObject alone is deactivated.
+            Canvas overlayCanvas = overlay.GetComponent<Canvas>();
+            if (overlayCanvas != null)
+            {
+                overlayCanvas.enabled = false;
+            }
+
+            Canvas.ForceUpdateCanvases();
+            // Why clear then wait: with no camera the Play Mode RT never rewrites itself after a
+            // Screen Space Overlay is hidden, so the last badge composite would stay forever.
+            // With cameras, the following frame wait redraws the scene without the overlay.
+            GameViewBridge.ClearMainPlayModeViewRenderTexture();
+            GameViewBridge.RepaintMainPlayModeView();
+            bool framesReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+                ANNOTATION_OVERLAY_RENDER_WAIT_FRAMES,
+                UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                ct).ConfigureAwait(false);
+            if (!framesReady)
+            {
+                return (overlay, true, true);
+            }
+
+            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+            return (overlay, true, false);
+        }
+
+        private static void RestoreInputVisualizationOverlay(
+            GameObject overlay,
+            bool wasActive,
+            SynchronizationContext editorContext)
+        {
+            if (!wasActive || overlay == null)
+            {
+                return;
+            }
+
+            if (SynchronizationContext.Current == editorContext)
+            {
+                RestoreInputVisualizationOverlayOnMainThread(overlay);
+                return;
+            }
+
+            // Why post: timeout/error paths may restore from a non-main thread.
+            editorContext.Post(_ => RestoreInputVisualizationOverlayOnMainThread(overlay), null);
+        }
+
+        private static void RestoreInputVisualizationOverlayOnMainThread(GameObject overlay)
+        {
+            Canvas overlayCanvas = overlay.GetComponent<Canvas>();
+            if (overlayCanvas != null)
+            {
+                overlayCanvas.enabled = true;
+            }
+
+            overlay.SetActive(true);
         }
 
         internal static ScreenshotResponse CreateTimedOutResult(

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/UnityCLILoop.FirstPartyTools.Screenshot.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/UnityCLILoop.FirstPartyTools.Screenshot.Editor.asmdef
@@ -7,7 +7,8 @@
         "GUID:a2d87883023de4cf59b7d1962d5dd8aa",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:96b8d4624fb74ea2849fed17e7ad69d3",
-        "GUID:77087b1bb30a415e87a80cbf24e7430a"
+        "GUID:77087b1bb30a415e87a80cbf24e7430a",
+        "GUID:aa7cf56cc5f074e57ba35272b877e116"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/InternalAPIBridge/GameViewBridge.cs
+++ b/Packages/src/Editor/InternalAPIBridge/GameViewBridge.cs
@@ -39,6 +39,42 @@ namespace io.github.hatayama.UnityCliLoop.InternalAPIBridge
         }
 
         /// <summary>
+        /// Requests a Play Mode view redraw so m_TargetTexture drops Screen Space Overlay canvases
+        /// that were just deactivated.
+        /// </summary>
+        public static void RepaintMainPlayModeView()
+        {
+            EnsureMembersResolved();
+
+            EditorWindow playModeView = FindMainPlayModeView();
+            if (playModeView == null)
+            {
+                return;
+            }
+
+            playModeView.Repaint();
+        }
+
+        /// <summary>
+        /// Clears the Play Mode view RT immediately after overlay hide.
+        /// Why: scenes with no camera never rewrite m_TargetTexture, so a deactivated Screen Space
+        /// Overlay leaves its last composite in the RT forever.
+        /// </summary>
+        public static void ClearMainPlayModeViewRenderTexture()
+        {
+            RenderTexture renderTexture = GetRenderTexture();
+            if (renderTexture == null)
+            {
+                return;
+            }
+
+            RenderTexture previousActive = RenderTexture.active;
+            RenderTexture.active = renderTexture;
+            GL.Clear(true, true, Color.black);
+            RenderTexture.active = previousActive;
+        }
+
+        /// <summary>
         /// Resolve m_TargetTexture on the PlayModeView declaring type.
         /// Must not use a derived Type: GetField does not return private fields declared on base types.
         /// </summary>


### PR DESCRIPTION
## Summary

- Screenshot `window` / `rendering` capture temporarily hides the existing `InputVisualizationCanvas` (via new `OverlayCanvasFactory.TryGetExisting()`, no create).
- After `SetActive(false)` (+ Canvas disable), clears `PlayModeView.m_TargetTexture` and waits `ANNOTATION_OVERLAY_RENDER_WAIT_FRAMES` (2) so the composite settles; restores with try-finally on the main thread.
- `EnsureExists` reactivates an inactive canvas and finds inactive instances so hide/restore does not spawn duplicates.

## User Impact

PlayMode screenshots no longer include simulate-* key/mouse visualization badges, so agents stop mistaking overlay chrome for game bugs.

## Live verification (required)

1. `control-play-mode --action Play`
2. `simulate-keyboard --action KeyDown --key W`
3. `screenshot --capture-mode rendering`
4. Inspected PNG: **no W badge** (all black empty scene)
   - Path: `.uloop/outputs/Screenshots/Rendering_20260729_135416_690.png`
   - Pixel check: `nonblack=0`
5. After capture: `InputVisualizationCanvas` `activeSelf=True`, `Canvas.enabled=True`
6. `simulate-keyboard --action ReleaseAll` then Stop PlayMode

Note: this repo’s PlayMode test scene has **zero cameras**, so hiding a Screen Space Overlay alone leaves a stale RT composite; `GameViewBridge.ClearMainPlayModeViewRenderTexture()` is required here. Scenes with cameras redraw after the 2-frame wait.

## Test plan

- [x] `uloop compile` — 0 errors / 0 warnings
- [x] EditMode: `StaticFacadeStateGuardTests` + `OnionAssemblyDependencyTests` — pass
- [x] Full EditMode — 0 failures (7 skipped pre-existing)
- [x] Live KeyDown → rendering screenshot — badge absent; overlay restored

## Notes

Child PR targeting `feat/pause-point-feedback-r13-integration` (round 13–14 feedback series, PR-5).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

