### PR TITLE
feat: report discarded mouse input edges when a pause point interrupts simulation

### DIFF
--- a/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs
@@ -31,7 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         }
 
         /// <summary>
-        /// Verifies interrupted button responses project every Pause Point hit and preserve button coordinates.
+        /// Verifies an interrupted button response when the press never applied reports discarded-edge wording and maps pause evidence plus coordinates.
         /// </summary>
         [Test]
         public void InterruptedButtonResult_WithMultiplePausePointHits_MapsPauseEvidenceAndButtonPosition()
@@ -45,7 +45,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             SimulateMouseInputResponse response = MouseInputSimulationResponseFactory.InterruptedButtonResult(
                 UnityCliLoopMouseInputAction.Click,
                 "Left",
-                inputPosition);
+                inputPosition,
+                pressWasApplied: false);
 
             Assert.That(response.Success, Is.True);
             Assert.That(
@@ -62,6 +63,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             Assert.That(response.PausePointHits, Has.Count.EqualTo(2));
             Assert.That(response.PausePointHits![0].Id, Is.EqualTo("first-hit"));
             Assert.That(response.PausePointHits[1].Id, Is.EqualTo("latest-hit"));
+        }
+
+        /// <summary>
+        /// Verifies an interrupted button response when the press already applied reports delivered-before-pause wording.
+        /// </summary>
+        [Test]
+        public void InterruptedButtonResult_WhenPressWasApplied_ReportsDeliveredBeforePauseMessage()
+        {
+            Vector2 inputPosition = new(12f, 34f);
+
+            SimulateMouseInputResponse response = MouseInputSimulationResponseFactory.InterruptedButtonResult(
+                UnityCliLoopMouseInputAction.LongPress,
+                "Right",
+                inputPosition,
+                pressWasApplied: true);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "Mouse input stopped because Unity paused during Pause Point inspection. Button 'Right' press was already delivered to the game before the pause; Unity CLI Loop released it from bookkeeping, so the game may have registered the press."));
+            Assert.That(response.Action, Is.EqualTo(UnityCliLoopMouseInputAction.LongPress.ToString()));
+            Assert.That(response.Button, Is.EqualTo("Right"));
+            Assert.That(response.PositionX, Is.EqualTo(inputPosition.x));
+            Assert.That(response.PositionY, Is.EqualTo(inputPosition.y));
+            Assert.That(response.InterruptedByPausePoint, Is.True);
         }
 
         /// <summary>

--- a/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs
@@ -51,7 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             Assert.That(
                 response.Message,
                 Is.EqualTo(
-                    "Mouse input stopped because Unity paused during Pause Point inspection. Unity CLI Loop released its held input bookkeeping."));
+                    "Mouse input stopped because Unity paused during Pause Point inspection. Button 'Left' was released from Unity CLI Loop bookkeeping; the queued input edge was discarded."));
             Assert.That(response.Action, Is.EqualTo(UnityCliLoopMouseInputAction.Click.ToString()));
             Assert.That(response.Button, Is.EqualTo("Left"));
             Assert.That(response.PositionX, Is.EqualTo(inputPosition.x));

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputPressActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputPressActionExecutor.cs
@@ -131,7 +131,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return MouseInputSimulationResponseFactory.InterruptedButtonResult(
                     UnityCliLoopMouseInputAction.Click,
                     buttonName,
-                    inputPos);
+                    inputPos,
+                    pressWasApplied);
             }
 
             if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
@@ -261,7 +262,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return MouseInputSimulationResponseFactory.InterruptedButtonResult(
                     UnityCliLoopMouseInputAction.LongPress,
                     buttonName,
-                    inputPos);
+                    inputPos,
+                    pressWasApplied);
             }
 
             if (waitOutcome == InputSimulationWaitOutcome.TimedOut)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs
@@ -42,15 +42,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
+        // Why this wording: keyboard interruptions already tell agents the queued edge was
+        // discarded; the previous generic mouse message left agents guessing whether a click
+        // still landed after resume (false "extra dig" diagnoses).
         internal static SimulateMouseInputResponse InterruptedButtonResult(
             UnityCliLoopMouseInputAction action,
             string buttonName,
             Vector2 inputPos)
         {
-            SimulateMouseInputResponse result = InterruptedActionResult(action);
-            result.Button = buttonName;
-            result.PositionX = inputPos.x;
-            result.PositionY = inputPos.y;
+            SimulateMouseInputResponse result = new()
+            {
+                Success = true,
+                Message =
+                    $"Mouse input stopped because Unity paused during Pause Point inspection. Button '{buttonName}' was released from Unity CLI Loop bookkeeping; the queued input edge was discarded.",
+                Action = action.ToString(),
+                Button = buttonName,
+                PositionX = inputPos.x,
+                PositionY = inputPos.y,
+                InterruptedByPausePoint = true
+            };
+            AttachPausePointHit(result);
             return result;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs
@@ -42,19 +42,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        // Why this wording: keyboard interruptions already tell agents the queued edge was
-        // discarded; the previous generic mouse message left agents guessing whether a click
-        // still landed after resume (false "extra dig" diagnoses).
+        // Why branch on pressWasApplied: Paused has two sources. (a) TryDiscardForPause before
+        // apply leaves pressWasApplied=false — the queued edge never reached the game.
+        // (b) WaitForPressLifetime after a successful apply leaves pressWasApplied=true — the press
+        // already landed (including when that press itself fired the pause point). Claiming
+        // "discarded" in (b) inverts the diagnosis this message exists to prevent.
         internal static SimulateMouseInputResponse InterruptedButtonResult(
             UnityCliLoopMouseInputAction action,
             string buttonName,
-            Vector2 inputPos)
+            Vector2 inputPos,
+            bool pressWasApplied)
         {
+            string message = pressWasApplied
+                ? $"Mouse input stopped because Unity paused during Pause Point inspection. Button '{buttonName}' press was already delivered to the game before the pause; Unity CLI Loop released it from bookkeeping, so the game may have registered the press."
+                : $"Mouse input stopped because Unity paused during Pause Point inspection. Button '{buttonName}' was released from Unity CLI Loop bookkeeping; the queued input edge was discarded.";
             SimulateMouseInputResponse result = new()
             {
                 Success = true,
-                Message =
-                    $"Mouse input stopped because Unity paused during Pause Point inspection. Button '{buttonName}' was released from Unity CLI Loop bookkeeping; the queued input edge was discarded.",
+                Message = message,
                 Action = action.ToString(),
                 Button = buttonName,
                 PositionX = inputPos.x,


### PR DESCRIPTION
## Summary

- Align pause-point interruption messages for mouse button actions with keyboard-style clarity: name the button and state what happened to the queued edge.
- Branch wording on `pressWasApplied`: discarded when pause aborted apply; delivered-before-pause when WaitForPressLifetime saw the pause after a successful press (the common case when the click itself fired the pause point).
- Cover Click and LongPress via `InterruptedButtonResult` (motion/scroll keep the existing non-button message).
- Update PlayMode factory tests for both branches.

## User Impact

- When a pause point interrupts `simulate-mouse-input` Click/LongPress, agents can tell whether the press never reached the game or may already have registered — avoiding both "extra dig" and "click never landed" misreads.

## PressEdgeObserved

Deferred. Keyboard reports `PressEdgeObserved` because `KeyboardInputActionExecutor` already monitors `wasPressedThisFrame` via `InputSystem.onAfterUpdate`. Mouse Click/LongPress only track `pressWasApplied` (device state queued) and have no equivalent edge-observation plumbing. Adding the field would require new wiring; plan says not to invent that in this PR. **PressEdgeObserved parity requires new plumbing; deferred.**

## Test plan

- [x] `uloop compile` → 0 errors / 0 warnings
- [x] PlayMode `MouseInputSimulationResponseFactoryTests` → 3/3 passed
