### PR TITLE
feat: replace unknown-command list with closest-match suggestions

### DIFF
--- a/cli/common/errors/command_suggestions.go
+++ b/cli/common/errors/command_suggestions.go
@@ -1,0 +1,90 @@
+package clierrors
+
+import "sort"
+
+const maxCommandSuggestions = 5
+
+type commandSuggestionCandidate struct {
+	distance int
+	name     string
+}
+
+// suggestCommands returns the closest available command names for an unknown command.
+// Why: listing every available command wastes tokens; a short ranked suggestion list is enough
+// to recover from typos like "compil" -> "compile".
+func suggestCommands(command string, availableCommands []string) []string {
+	if len(availableCommands) == 0 {
+		return []string{}
+	}
+
+	candidates := make([]commandSuggestionCandidate, 0, len(availableCommands))
+	for _, availableCommand := range availableCommands {
+		candidates = append(candidates, commandSuggestionCandidate{
+			distance: levenshteinDistance(command, availableCommand),
+			name:     availableCommand,
+		})
+	}
+
+	sort.Slice(candidates, func(left int, right int) bool {
+		if candidates[left].distance != candidates[right].distance {
+			return candidates[left].distance < candidates[right].distance
+		}
+		return candidates[left].name < candidates[right].name
+	})
+
+	limit := maxCommandSuggestions
+	if len(candidates) < limit {
+		limit = len(candidates)
+	}
+
+	suggestions := make([]string, 0, limit)
+	for index := 0; index < limit; index++ {
+		suggestions = append(suggestions, candidates[index].name)
+	}
+	return suggestions
+}
+
+// levenshteinDistance returns the edit distance between two strings.
+func levenshteinDistance(a string, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+
+	previous := make([]int, len(b)+1)
+	current := make([]int, len(b)+1)
+	for column := 0; column <= len(b); column++ {
+		previous[column] = column
+	}
+
+	for row := 1; row <= len(a); row++ {
+		current[0] = row
+		for column := 1; column <= len(b); column++ {
+			deletionCost := previous[column] + 1
+			insertionCost := current[column-1] + 1
+			substitutionCost := previous[column-1]
+			if a[row-1] != b[column-1] {
+				substitutionCost++
+			}
+			current[column] = minInt(deletionCost, insertionCost, substitutionCost)
+		}
+		previous, current = current, previous
+	}
+
+	return previous[len(b)]
+}
+
+func minInt(values ...int) int {
+	minimum := values[0]
+	for _, value := range values[1:] {
+		if value < minimum {
+			minimum = value
+		}
+	}
+	return minimum
+}

--- a/cli/common/errors/command_suggestions_test.go
+++ b/cli/common/errors/command_suggestions_test.go
@@ -1,0 +1,70 @@
+package clierrors
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Verifies suggestions are ordered by ascending Levenshtein distance.
+func TestSuggestCommandsOrdersByDistance(t *testing.T) {
+	suggestions := suggestCommands("compil", []string{"launch", "compile", "clear-console"})
+
+	if len(suggestions) == 0 || suggestions[0] != "compile" {
+		t.Fatalf("expected compile first, got %#v", suggestions)
+	}
+}
+
+// Verifies equal distances break ties by ascending command name.
+func TestSuggestCommandsBreaksDistanceTiesByName(t *testing.T) {
+	suggestions := suggestCommands("ab", []string{"ac", "ad", "aa"})
+
+	expected := []string{"aa", "ac", "ad"}
+	if !reflect.DeepEqual(suggestions, expected) {
+		t.Fatalf("tie-break order mismatch: got %#v, want %#v", suggestions, expected)
+	}
+}
+
+// Verifies more than five candidates are clipped to maxCommandSuggestions.
+func TestSuggestCommandsCapsAtFive(t *testing.T) {
+	available := []string{"a", "b", "c", "d", "e", "f", "g"}
+	suggestions := suggestCommands("z", available)
+
+	if len(suggestions) != maxCommandSuggestions {
+		t.Fatalf("expected %d suggestions, got %#v", maxCommandSuggestions, suggestions)
+	}
+}
+
+// Verifies fewer than five candidates returns the full sorted list.
+func TestSuggestCommandsReturnsAllWhenFewerThanCap(t *testing.T) {
+	available := []string{"compile", "launch"}
+	suggestions := suggestCommands("compil", available)
+
+	if len(suggestions) != 2 {
+		t.Fatalf("expected both candidates, got %#v", suggestions)
+	}
+	if suggestions[0] != "compile" {
+		t.Fatalf("expected compile first, got %#v", suggestions)
+	}
+}
+
+// Verifies an empty available-command list yields an empty suggestion list.
+func TestSuggestCommandsReturnsEmptyForEmptyAvailableList(t *testing.T) {
+	suggestions := suggestCommands("compile", nil)
+
+	if len(suggestions) != 0 {
+		t.Fatalf("expected empty suggestions, got %#v", suggestions)
+	}
+}
+
+// Verifies identical strings have distance zero and single-char edits distance one.
+func TestLevenshteinDistanceBasicCases(t *testing.T) {
+	if distance := levenshteinDistance("compile", "compile"); distance != 0 {
+		t.Fatalf("identical distance: got %d", distance)
+	}
+	if distance := levenshteinDistance("compil", "compile"); distance != 1 {
+		t.Fatalf("one-edit distance: got %d", distance)
+	}
+	if distance := levenshteinDistance("", "abc"); distance != 3 {
+		t.Fatalf("empty-to-string distance: got %d", distance)
+	}
+}

--- a/cli/common/errors/error_envelope.go
+++ b/cli/common/errors/error_envelope.go
@@ -272,7 +272,7 @@ func UnknownCommandError(command string, availableCommands []string, context Err
 			"Run `uloop sync` if the local tool cache may be stale.",
 		},
 		Details: map[string]any{
-			"AvailableCommands": availableCommands,
+			"SuggestedCommands": suggestCommands(command, availableCommands),
 		},
 	}
 }

--- a/cli/common/errors/error_envelope_test.go
+++ b/cli/common/errors/error_envelope_test.go
@@ -469,22 +469,44 @@ func TestWriteToolFailureClassifiesAcceptedResponseTimeout(t *testing.T) {
 	}
 }
 
-func TestUnknownCommandErrorIncludesAvailableCommands(t *testing.T) {
+// Verifies unknown-command details expose at most five closest suggestions, with typos ranked first.
+func TestUnknownCommandErrorIncludesSuggestedCommands(t *testing.T) {
+	available := []string{
+		"clear-console",
+		"compile",
+		"control-play-mode",
+		"execute-dynamic-code",
+		"find-game-objects",
+		"focus-window",
+		"get-hierarchy",
+		"get-logs",
+		"launch",
+		"list",
+		"run-tests",
+		"screenshot",
+		"sync",
+	}
 	cliErr := UnknownCommandError(
-		"missing",
-		[]string{"launch", "compile"},
+		"compil",
+		available,
 		ErrorContext{ProjectRoot: "/tmp/MyProject"},
 	)
 
 	if cliErr.ErrorCode != ErrorCodeUnknownCommand {
 		t.Fatalf("error code mismatch: %#v", cliErr)
 	}
-	available, ok := cliErr.Details["AvailableCommands"].([]string)
+	suggested, ok := cliErr.Details["SuggestedCommands"].([]string)
 	if !ok {
-		t.Fatalf("available commands missing: %#v", cliErr.Details)
+		t.Fatalf("suggested commands missing: %#v", cliErr.Details)
 	}
-	if len(available) == 0 || available[len(available)-1] != "compile" {
-		t.Fatalf("available commands mismatch: %#v", available)
+	if len(suggested) == 0 || len(suggested) > maxCommandSuggestions {
+		t.Fatalf("suggested commands length out of range: %#v", suggested)
+	}
+	if suggested[0] != "compile" {
+		t.Fatalf("expected compile first for typo compil, got %#v", suggested)
+	}
+	if _, hasAvailable := cliErr.Details["AvailableCommands"]; hasAvailable {
+		t.Fatalf("AvailableCommands should be removed: %#v", cliErr.Details)
 	}
 }
 

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "7561c6f3a56f2300725d6411b772978e3a31f009"
+  "sharedInputsHash": "df1d138a23c8d7606d29408c17393cd9bb32afa8"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "a94f640d4d0d70a5379786fadf7c5fb2335ca28d"
+  "sharedInputsHash": "7561c6f3a56f2300725d6411b772978e3a31f009"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "e2a4495ac68e04f0639d86e638cf672282590684"
+  "sharedInputsHash": "a55a34f9ce070418cbd86f238bd56098359f3aaa"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "a55a34f9ce070418cbd86f238bd56098359f3aaa"
+  "sharedInputsHash": "ca5858203a19887e7d0793869b75c3af20b4a4cc"
 }


### PR DESCRIPTION
## Summary

- Unknown-command error details now return up to five closest `SuggestedCommands` (Levenshtein distance, name tie-break) instead of the full `AvailableCommands` list.
- Shared release input stamps updated for the `cli/common` change.

## User Impact

Typo recovery stays useful without dumping every command name into the error envelope.

## Test plan

- [x] `scripts/check-go-cli.sh` → exit 0
- [x] `scripts/stamp-release-inputs.sh` twice → content-idempotent
- [x] Live typo check:

```json
{
  "ErrorCode": "UNKNOWN_COMMAND",
  "Command": "compil",
  "Details": {
    "SuggestedCommands": [
      "compile",
      "completion",
      "install",
      "launch",
      "list"
    ]
  }
}
```

- [ ] Repo CI may not fire for integration-branch PRs (`pull_request.branches: [main, v3-beta]`); full CI on the final PR to `v3-beta`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

