### PR TITLE
test: cover TriggerResult embedding in expired pause point responses

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -172,7 +172,7 @@ If a `simulate-*` command instead returns a failure whose message says PlayMode 
 
 ## Timeout Checks
 
-If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
+If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. When `--trigger` was passed, the expired envelope also carries `Error.Details.TriggerResult` (with `Completed: false` and no `Error` field when the trigger's outcome was still unknown at expiry). The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
 
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -172,7 +172,7 @@ If a `simulate-*` command instead returns a failure whose message says PlayMode 
 
 ## Timeout Checks
 
-If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
+If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. When `--trigger` was passed, the expired envelope also carries `Error.Details.TriggerResult` (with `Completed: false` and no `Error` field when the trigger's outcome was still unknown at expiry). The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
 
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -172,7 +172,7 @@ If a `simulate-*` command instead returns a failure whose message says PlayMode 
 
 ## Timeout Checks
 
-If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
+If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. When `--trigger` was passed, the expired envelope also carries `Error.Details.TriggerResult` (with `Completed: false` and no `Error` field when the trigger's outcome was still unknown at expiry). The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
 
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 

--- a/cli/project-runner/internal/projectrunner/pause_point_trigger_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_trigger_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
@@ -462,6 +463,98 @@ func TestRunWaitForPausePointEmbedsTriggerResultOnTimeout(t *testing.T) {
 	}
 	if triggerResult["Completed"] != true {
 		t.Fatalf("TriggerResult should report Completed=true: %#v", triggerResult)
+	}
+}
+
+// Verifies a --trigger result is embedded in the expired error envelope's Details after the
+// trigger was actually dispatched (arm confirmed Enabled first; later polls return Expired).
+func TestRunWaitForPausePointEmbedsTriggerResultOnExpired(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	originalClear := clearPausePointStatus
+	originalDispatch := dispatchPausePointTriggerCommand
+	originalPoll := pausePointStatusPoll
+	pausePointStatusPoll = time.Millisecond
+	defer func() {
+		queryPausePointStatus = originalQuery
+		clearPausePointStatus = originalClear
+		dispatchPausePointTriggerCommand = originalDispatch
+		pausePointStatusPoll = originalPoll
+	}()
+
+	// Why stateful: an unconditional Expired on the first query makes arm confirmation fail, so
+	// the trigger is never dispatched and only a "not dispatched" placeholder TriggerResult appears.
+	statusQueryCount := 0
+	queryPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		statusQueryCount++
+		if statusQueryCount == 1 {
+			return pausePointStatusResponse{
+				Id:          id,
+				Status:      pausePointStatusEnabled,
+				IsEnabled:   true,
+				EditorState: pausePointEditorState{IsPlaying: true, CapturedAt: "Current"},
+			}, nil
+		}
+		return pausePointStatusResponse{
+			Id:          id,
+			Status:      pausePointStatusExpired,
+			Expired:     true,
+			IsEnabled:   false,
+			EditorState: pausePointEditorState{IsPlaying: true, CapturedAt: "Current"},
+		}, nil
+	}
+	clearPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{Id: id, Status: pausePointStatusCleared}, nil
+	}
+	dispatchPausePointTriggerCommand = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		command string,
+		commandArgs []string,
+		startPath string,
+		stdout io.Writer,
+		stderr io.Writer,
+	) int {
+		_, _ = stdout.Write([]byte(`{"Success":true}`))
+		return 0
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runWaitForPausePoint(context.Background(), unityipc.Connection{}, waitForPausePointOptions{
+		id:             "jump",
+		timeoutSeconds: 1,
+		timeout:        50 * time.Millisecond,
+		triggerCommand: "simulate-keyboard",
+		triggerArgs:    []string{"--action", "Press"},
+	}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("expected expired failure, got %d with stdout %s stderr %s", code, stdout.String(), stderr.String())
+	}
+	envelope := parsePausePointErrorEnvelope(t, stderr.Bytes())
+	if envelope.Error.ErrorCode != clierrors.ErrorCodePausePointExpired {
+		t.Fatalf("error code mismatch: %#v", envelope.Error)
+	}
+	triggerResult, ok := envelope.Error.Details["TriggerResult"].(map[string]any)
+	if !ok {
+		t.Fatalf("TriggerResult detail missing or wrong shape: %#v", envelope.Error.Details)
+	}
+	if triggerResult["Command"] != "simulate-keyboard --action Press" {
+		t.Fatalf("TriggerResult command mismatch: %#v", triggerResult)
+	}
+	if triggerResult["Completed"] != true {
+		t.Fatalf("TriggerResult should report Completed=true after dispatch: %#v", triggerResult)
+	}
+	if errorText, _ := triggerResult["Error"].(string); errorText != "" {
+		t.Fatalf("TriggerResult Error should be empty after a successful dispatch: %#v", triggerResult)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a stateful regression test that expired pause-point waits with `--trigger` embed a dispatched `TriggerResult` (`Completed: true`, empty `Error`) under `PAUSE_POINT_EXPIRED`.
- Documents the expired-envelope `TriggerResult` field in the pause-point skill.

## User Impact

Agents can rely on expired `--trigger` waits still reporting what the trigger command did, without guessing from a missing field.

## Test plan

- [x] `go test ./internal/projectrunner -run TestRunWaitForPausePointEmbedsTriggerResultOnExpired` → pass
- [x] `scripts/check-go-cli.sh` → exit 0
- [ ] Repo CI may not fire for integration-branch PRs; full CI on the final PR to `v3-beta`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

