### PR TITLE
fix: reference System.Security.Cryptography.Primitives when building the Roslyn worker

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -58,6 +59,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(
                 startInfo.EnvironmentVariables[SharedRoslynCompilerWorkerAssemblyBuilder.DotnetMultilevelLookupEnvironmentVariableName],
                 Is.EqualTo(SharedRoslynCompilerWorkerAssemblyBuilder.DotnetMultilevelLookupDisabledValue));
+        }
+
+        /// <summary>
+        /// Verifies the worker reference set includes System.Security.Cryptography.Primitives when that assembly exists in the Unity runtime.
+        /// </summary>
+        [Test]
+        public void BuildWorkerReferenceSet_WhenPrimitivesAssemblyExists_ShouldIncludePrimitivesReference()
+        {
+            ExternalCompilerPaths externalCompilerPaths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(externalCompilerPaths, Is.Not.Null, "Unity external compiler layout should be available.");
+
+            string primitivesAssemblyPath = Path.Combine(
+                externalCompilerPaths.NetCoreRuntimeSharedDirectoryPath,
+                "System.Security.Cryptography.Primitives.dll");
+            if (!File.Exists(primitivesAssemblyPath))
+            {
+                Assert.Ignore(
+                    "System.Security.Cryptography.Primitives.dll is not present in this Unity NetCoreRuntime shared directory.");
+            }
+
+            List<string> references =
+                SharedRoslynCompilerWorkerAssemblyBuilder.BuildWorkerReferenceSet(externalCompilerPaths);
+
+            Assert.That(references, Does.Contain(primitivesAssemblyPath));
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
@@ -179,7 +179,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        private static List<string> BuildWorkerReferenceSet(ExternalCompilerPaths externalCompilerPaths)
+        internal static List<string> BuildWorkerReferenceSet(ExternalCompilerPaths externalCompilerPaths)
         {
             string sharedRuntimeDirectoryPath = externalCompilerPaths.NetCoreRuntimeSharedDirectoryPath;
             List<string> references = new()            {
@@ -203,6 +203,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             AddIfExists(references, Path.Combine(sharedRuntimeDirectoryPath, "System.Memory.dll"));
             AddIfExists(references, Path.Combine(sharedRuntimeDirectoryPath, "System.Buffers.dll"));
             AddIfExists(references, Path.Combine(sharedRuntimeDirectoryPath, "System.Threading.Tasks.Extensions.dll"));
+            // Why: the CodeAnalysis Emit API surface references HashAlgorithmName from
+            // System.Security.Cryptography.Primitives; without this reference the worker build itself
+            // fails with CS0012 whenever the worker assembly has to be rebuilt.
+            AddIfExists(references, Path.Combine(sharedRuntimeDirectoryPath, "System.Security.Cryptography.Primitives.dll"));
 
             return references;
         }


### PR DESCRIPTION
## Summary

- Shared Roslyn worker rebuilds no longer fail with CS0012 on `HashAlgorithmName` when the Unity NetCoreRuntime ships `System.Security.Cryptography.Primitives.dll`.
- That rebuild failure previously logged as an Unhandled error and failed `WatchExpressionCompilerTests` during EditMode runs after other tests shut down the shared worker.
- Adds a regression test that asserts the worker reference set includes Primitives when the assembly exists on disk.

## Root cause

Rebuilding the shared worker compiles `RoslynCompilerWorker.cs` against Microsoft.CodeAnalysis. The `Emit` API surface requires `HashAlgorithmName` from `System.Security.Cryptography.Primitives`, but `BuildWorkerReferenceSet` did not reference that assembly. After `ExternalCompilerPathResolverTests` deleted the worker DLL / cleared health-monitor once-flags, Watch expression compilation rebuilt the worker, hit CS0012, and `ReportSharedWorkerFailure` emitted `Debug.LogError`.

## Test plan

- [x] `uloop compile` → 0 errors / 0 warnings
- [x] Deleted `$TMPDIR/UnityCliLoopCompilation/RoslynWorker-<pid>/`, then EditMode regex `ExternalCompilerPathResolverTests|WatchExpressionCompilerTests` → 18/18 passed (pre-fix: 1 failure on ValidExpression)
- [x] Worker DLL regenerated; rsp includes `System.Security.Cryptography.Primitives.dll`
- [x] No new CS0012 in today's VibeLogger after the verification run (only expected synthetic `worker_build_failed` from path-resolver fallback smoke)
- [x] Solo exact filter for `BuildWorkerReferenceSet_WhenPrimitivesAssemblyExists_ShouldIncludePrimitivesReference` → passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

