### PR TITLE
feat: install the Unity package from the terminal with uloop package install

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,17 @@ https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 
 ## Via OpenUPM (Recommended)
 
-## Using Scoped registry in Unity Package Manager
+After the global `uloop` CLI is on PATH, install the Unity package from a terminal at the project root (or pass `--project-path`):
+
+```bash
+uloop package install
+uloop package status
+```
+
+`uloop package install` writes the OpenUPM scoped registry and the `io.github.hatayama.uloopmcp` dependency into `Packages/manifest.json`. Pass `--version <x.y.z>` to pin a specific package version instead of OpenUPM `dist-tags.latest`. Use `uloop package status` to confirm the registry and dependency are present.
+
+### Manual setup in Unity Package Manager
+
 1. Open Project Settings window and go to Package Manager page
 2. Add the following entry to the Scoped Registries list:
 ```text

--- a/README_ja.md
+++ b/README_ja.md
@@ -61,7 +61,17 @@ https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 
 ## OpenUPM経由（推奨）
 
-## Unity Package ManagerでScoped registryを使用
+グローバルな `uloop` CLI が PATH に入った状態で、プロジェクトルートのターミナルから（または `--project-path` を指定して）Unity パッケージを導入できます。
+
+```bash
+uloop package install
+uloop package status
+```
+
+`uloop package install` は OpenUPM の scoped registry と `io.github.hatayama.uloopmcp` 依存を `Packages/manifest.json` に書き込みます。OpenUPM の `dist-tags.latest` ではなく特定バージョンを入れたいときは `--version <x.y.z>` を付けます。導入状態の確認には `uloop package status` を使います。
+
+### 手動で設定する場合（Unity Package Manager）
+
 1. Project Settingsウィンドウを開き、Package Managerページに移動
 2. Scoped Registriesリストに以下のエントリを追加：
 ```text

--- a/cli/common/clicore/command_errors_test.go
+++ b/cli/common/clicore/command_errors_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestAvailableCommandNamesIncludesBuiltIns(t *testing.T) {
 	// Verifies unknown-command suggestions include built-in CLI commands before cached tools.
 	names := availableCommandNames(ToolsCache{})
-	expectedBuiltIns := []string{"launch", "list", "sync", "focus-window", "await-pause-point", "pause-point-status", "skills", "completion", "install", "update", "uninstall"}
+	expectedBuiltIns := []string{"launch", "list", "sync", "focus-window", "await-pause-point", "pause-point-status", "skills", "package", "completion", "install", "update", "uninstall"}
 	for index, expected := range expectedBuiltIns {
 		if names[index] != expected {
 			t.Fatalf("built-in command mismatch: %#v", names)

--- a/cli/common/clicore/command_registry.go
+++ b/cli/common/clicore/command_registry.go
@@ -7,6 +7,7 @@ const (
 	UninstallCommandName            = "uninstall"
 	VersionCommandName              = "version"
 	SkillsCommandName               = "skills"
+	PackageCommandName              = "package"
 	CompileCommandName              = "compile"
 	ExecuteDynamicCodeCommandName   = "execute-dynamic-code"
 	PausePointAwaitCommandName      = "await-pause-point"
@@ -36,6 +37,7 @@ var NativeCommands = []NativeCommandEntry{
 	{Name: PausePointAwaitCommandName, Description: "Wait until a named UloopPausePoint.Pause marker pauses Unity", Owner: RunnerOwned},
 	{Name: PausePointStatusUserCommandName, Description: "Show the state of a named UloopPausePoint.Pause marker", Owner: RunnerOwned},
 	{Name: SkillsCommandName, Description: "List, install, or uninstall agent skills", Owner: DispatcherOwned},
+	{Name: PackageCommandName, Description: "Install or inspect the Unity CLI Loop package in a project", Owner: DispatcherOwned},
 	{Name: CompletionCommand, Description: "Deprecated: shell completion has been removed; this command is now a no-op", Owner: DispatcherOwned},
 	{Name: InstallCommandName, Description: "Configure the global uloop dispatcher binary", Owner: DispatcherOwned},
 	{Name: UpdateCommandName, Description: "Update the global uloop dispatcher binary", Owner: DispatcherOwned},

--- a/cli/common/clicore/command_registry_test.go
+++ b/cli/common/clicore/command_registry_test.go
@@ -11,6 +11,7 @@ func TestNativeCommandEntriesDeclareOwners(t *testing.T) {
 		UninstallCommandName:            DispatcherOwned,
 		VersionCommandName:              DispatcherOwned,
 		SkillsCommandName:               DispatcherOwned,
+		PackageCommandName:              DispatcherOwned,
 		CompletionCommand:               DispatcherOwned,
 		"list":                          RunnerOwned,
 		"sync":                          RunnerOwned,
@@ -41,6 +42,7 @@ func TestIsDispatcherOwnedCommandName(t *testing.T) {
 		UninstallCommandName,
 		VersionCommandName,
 		SkillsCommandName,
+		PackageCommandName,
 		CompletionCommand,
 	} {
 		if !IsDispatcherOwnedCommandName(command) {
@@ -81,6 +83,7 @@ func TestIsRunnerOwnedCommandName(t *testing.T) {
 		UninstallCommandName,
 		VersionCommandName,
 		SkillsCommandName,
+		PackageCommandName,
 		CompletionCommand,
 		CompileCommandName,
 		"",

--- a/cli/common/errors/error_envelope.go
+++ b/cli/common/errors/error_envelope.go
@@ -34,7 +34,11 @@ const (
 	ErrorCodePausePointExpired               = "PAUSE_POINT_EXPIRED"
 	ErrorCodePausePointCleared               = "PAUSE_POINT_CLEARED"
 	ErrorCodePausePointTriggerFailed         = "PAUSE_POINT_TRIGGER_FAILED"
-	ErrorCodeInternalError                   = "INTERNAL_ERROR"
+	// ErrorCodePackageManifestInvalid is returned when Packages/manifest.json is missing or not valid JSON.
+	ErrorCodePackageManifestInvalid = "PACKAGE_MANIFEST_INVALID"
+	// ErrorCodePackageRegistryUnavailable is returned when the OpenUPM registry HTTP lookup fails.
+	ErrorCodePackageRegistryUnavailable = "PACKAGE_REGISTRY_UNAVAILABLE"
+	ErrorCodeInternalError              = "INTERNAL_ERROR"
 
 	ErrorPhaseArgumentParsing = "argument_parsing"
 	ErrorPhaseProjectResolve  = "project_resolution"

--- a/cli/dispatcher/internal/dispatcher/dispatcher_process.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_process.go
@@ -73,6 +73,9 @@ func tryHandlePreConnectionRequestWithDeps(
 	if handled, code := tryHandleSkillsRequest(remainingArgs, startPath, projectPath, stdout, stderr); handled {
 		return true, code
 	}
+	if handled, code := tryHandlePackageRequest(ctx, remainingArgs, startPath, projectPath, stdout, stderr); handled {
+		return true, code
+	}
 	if handled, code := tryHandleVersionRequest(remainingArgs, stdout, stderr); handled {
 		return true, code
 	}

--- a/cli/dispatcher/internal/dispatcher/help_test.go
+++ b/cli/dispatcher/internal/dispatcher/help_test.go
@@ -27,6 +27,7 @@ func TestPrintDispatcherHelpListsNativeCommandsAndLiveToolGuidance(t *testing.T)
 		"  focus-window",
 		"  list",
 		"  skills",
+		"  package",
 		"  uninstall",
 		"  version",
 		"Unity tool commands are project-specific.",

--- a/cli/dispatcher/internal/dispatcher/package.go
+++ b/cli/dispatcher/internal/dispatcher/package.go
@@ -1,0 +1,405 @@
+package dispatcher
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/project"
+)
+
+const packageVersionFlagName = "version"
+
+type packageInstallOptions struct {
+	version string
+}
+
+func tryHandlePackageRequest(
+	ctx context.Context,
+	args []string,
+	startPath string,
+	globalProjectPath string,
+	stdout io.Writer,
+	stderr io.Writer,
+) (bool, int) {
+	if len(args) == 0 || args[0] != clicore.PackageCommandName {
+		return false, 0
+	}
+	if len(args) == 1 || clicore.IsHelpRequest(args[1:]) {
+		printPackageHelp(stdout)
+		return true, 0
+	}
+
+	subcommand := args[1]
+	if !isKnownPackageSubcommand(subcommand) {
+		clierrors.WriteErrorEnvelope(stderr, unknownPackageSubcommandError(subcommand, clierrors.ErrorContext{Command: clicore.PackageCommandName}))
+		return true, 1
+	}
+	if clicore.ContainsHelpRequest(args[2:]) {
+		printPackageHelp(stdout)
+		return true, 0
+	}
+
+	switch subcommand {
+	case "install":
+		return true, runPackageInstall(ctx, args[2:], startPath, globalProjectPath, stdout, stderr)
+	case "status":
+		return true, runPackageStatus(args[2:], startPath, globalProjectPath, stdout, stderr)
+	default:
+		return true, 1
+	}
+}
+
+func isKnownPackageSubcommand(subcommand string) bool {
+	switch subcommand {
+	case "install", "status":
+		return true
+	default:
+		return false
+	}
+}
+
+func unknownPackageSubcommandError(subcommand string, context clierrors.ErrorContext) clierrors.CLIError {
+	return (&clierrors.ArgumentError{
+		Message:     "Unknown package command: " + subcommand,
+		Received:    subcommand,
+		Command:     clicore.PackageCommandName,
+		NextActions: []string{"Use `uloop package install` or `uloop package status`."},
+	}).ToCLIError(context)
+}
+
+func parsePackageInstallOptions(args []string) (packageInstallOptions, error) {
+	options := packageInstallOptions{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		name, value, consumedNext, err := clicore.ParseFlagValue(arg, args, index)
+		if err != nil {
+			return packageInstallOptions{}, err
+		}
+		if name != packageVersionFlagName {
+			return packageInstallOptions{}, &clierrors.ArgumentError{
+				Message:     "Unknown package install option: --" + name,
+				Option:      "--" + name,
+				Command:     clicore.PackageCommandName,
+				NextActions: []string{"Run `uloop package install --help` to inspect supported options."},
+			}
+		}
+		if value == "" {
+			return packageInstallOptions{}, &clierrors.ArgumentError{
+				Message:     "Empty value for --version",
+				Option:      "--version",
+				Command:     clicore.PackageCommandName,
+				NextActions: []string{"Pass a non-empty package version with `--version <x.y.z>`."},
+			}
+		}
+		if options.version != "" {
+			return packageInstallOptions{}, &clierrors.ArgumentError{
+				Message:     "Duplicate package install option: --version",
+				Option:      "--version",
+				Command:     clicore.PackageCommandName,
+				NextActions: []string{"Pass --version only once."},
+			}
+		}
+		options.version = value
+		if consumedNext {
+			index++
+		}
+	}
+	return options, nil
+}
+
+func parsePackageStatusOptions(args []string) error {
+	for _, arg := range args {
+		return &clierrors.ArgumentError{
+			Message:     "Unknown package status option: " + arg,
+			Option:      arg,
+			Command:     clicore.PackageCommandName,
+			NextActions: []string{"Run `uloop package status` with no options, or pass `--project-path` as a global flag."},
+		}
+	}
+	return nil
+}
+
+func resolvePackageProjectRoot(startPath string, explicitProjectPath string) (string, error) {
+	if explicitProjectPath != "" {
+		return project.ResolveExplicitProjectRoot(explicitProjectPath)
+	}
+	return project.FindUnityProjectRoot(startPath)
+}
+
+func runPackageInstall(
+	ctx context.Context,
+	args []string,
+	startPath string,
+	explicitProjectPath string,
+	stdout io.Writer,
+	stderr io.Writer,
+) int {
+	options, err := parsePackageInstallOptions(args)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: clicore.PackageCommandName})
+		return 1
+	}
+
+	projectRoot, err := resolvePackageProjectRoot(startPath, explicitProjectPath)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: clicore.PackageCommandName})
+		return 1
+	}
+
+	manifestPath := filepath.Join(projectRoot, filepath.FromSlash(dispatcherPackagesManifestRelativePath))
+	content, err := os.ReadFile(manifestPath)
+	if err != nil {
+		clierrors.WriteErrorEnvelope(stderr, packageManifestInvalidError(projectRoot, err))
+		return 1
+	}
+
+	version := options.version
+	if version == "" {
+		version, err = resolveLatestPackageVersion(ctx)
+		if err != nil {
+			clierrors.WriteErrorEnvelope(stderr, packageRegistryUnavailableError(projectRoot, err))
+			return 1
+		}
+	}
+
+	result, err := mergePackageManifest(content, version)
+	if err != nil {
+		clierrors.WriteErrorEnvelope(stderr, packageManifestInvalidError(projectRoot, err))
+		return 1
+	}
+
+	if !result.Changed {
+		clicore.WriteFormat(stdout, "%s %s is already installed. Nothing to do.\n", dispatcherUnityPackageName, version)
+		return 0
+	}
+
+	if err := writePackageManifestAtomically(manifestPath, result.Content); err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{ProjectRoot: projectRoot, Command: clicore.PackageCommandName})
+		return 1
+	}
+
+	writePackageInstallSuccess(stdout, result, version)
+	return 0
+}
+
+func runPackageStatus(
+	args []string,
+	startPath string,
+	explicitProjectPath string,
+	stdout io.Writer,
+	stderr io.Writer,
+) int {
+	if err := parsePackageStatusOptions(args); err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: clicore.PackageCommandName})
+		return 1
+	}
+
+	projectRoot, err := resolvePackageProjectRoot(startPath, explicitProjectPath)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: clicore.PackageCommandName})
+		return 1
+	}
+
+	manifestPath := filepath.Join(projectRoot, filepath.FromSlash(dispatcherPackagesManifestRelativePath))
+	content, err := os.ReadFile(manifestPath)
+	if err != nil {
+		clierrors.WriteErrorEnvelope(stderr, packageManifestInvalidError(projectRoot, err))
+		return 1
+	}
+
+	status, err := inspectPackageManifestStatus(content)
+	if err != nil {
+		clierrors.WriteErrorEnvelope(stderr, packageManifestInvalidError(projectRoot, err))
+		return 1
+	}
+
+	clicore.WriteFormat(stdout, "Package: %s\n", dispatcherUnityPackageName)
+	if status.registryInstalled {
+		clicore.WriteFormat(stdout, "Scoped registry: installed (%s)\n", openUPMRegistryURL)
+	} else {
+		clicore.WriteLine(stdout, "Scoped registry: not installed")
+	}
+	if status.dependencyInstalled {
+		clicore.WriteFormat(stdout, "Dependency: installed (%s)\n", status.dependencyVersion)
+	} else {
+		clicore.WriteLine(stdout, "Dependency: not installed")
+	}
+	return 0
+}
+
+type packageManifestStatus struct {
+	registryInstalled   bool
+	dependencyInstalled bool
+	dependencyVersion   string
+}
+
+func inspectPackageManifestStatus(content []byte) (packageManifestStatus, error) {
+	normalized := bytesReplaceCRLF(content)
+	root, err := parseOrderedJSONObjectBytes(normalized)
+	if err != nil {
+		return packageManifestStatus{}, err
+	}
+
+	status := packageManifestStatus{}
+	if rawDependencies, ok := root.values["dependencies"]; ok {
+		dependencies, depErr := parseOrderedJSONObjectBytes(rawDependencies)
+		if depErr != nil {
+			return packageManifestStatus{}, depErr
+		}
+		if rawVersion, found := dependencies.values[dispatcherUnityPackageName]; found {
+			var version string
+			if unmarshalErr := json.Unmarshal(rawVersion, &version); unmarshalErr != nil {
+				return packageManifestStatus{}, unmarshalErr
+			}
+			status.dependencyInstalled = true
+			status.dependencyVersion = version
+		}
+	}
+
+	if rawRegistries, ok := root.values["scopedRegistries"]; ok {
+		elements, arrayErr := parseJSONRawArray(rawRegistries)
+		if arrayErr != nil {
+			return packageManifestStatus{}, arrayErr
+		}
+		for _, element := range elements {
+			entry, parseErr := parseOrderedJSONObjectBytes(element)
+			if parseErr != nil {
+				return packageManifestStatus{}, parseErr
+			}
+			urlRaw, hasURL := entry.values["url"]
+			if !hasURL {
+				continue
+			}
+			var url string
+			if unmarshalErr := json.Unmarshal(urlRaw, &url); unmarshalErr != nil {
+				return packageManifestStatus{}, unmarshalErr
+			}
+			if url != openUPMRegistryURL {
+				continue
+			}
+			rawScopes, hasScopes := entry.values["scopes"]
+			if !hasScopes {
+				continue
+			}
+			var scopes []string
+			if unmarshalErr := json.Unmarshal(rawScopes, &scopes); unmarshalErr != nil {
+				return packageManifestStatus{}, unmarshalErr
+			}
+			for _, scope := range scopes {
+				if scope == dispatcherUnityPackageName {
+					status.registryInstalled = true
+					break
+				}
+			}
+		}
+	}
+	return status, nil
+}
+
+func writePackageManifestAtomically(manifestPath string, content []byte) error {
+	temporaryPath := manifestPath + ".tmp"
+	if err := os.WriteFile(temporaryPath, content, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, manifestPath); err != nil {
+		_ = os.Remove(temporaryPath)
+		return err
+	}
+	return nil
+}
+
+func writePackageInstallSuccess(stdout io.Writer, result packageManifestMergeResult, version string) {
+	if result.RegistryAdded || result.ScopeAdded {
+		clicore.WriteFormat(
+			stdout,
+			"Added scoped registry %s (scope %s)\n",
+			openUPMRegistryURL,
+			dispatcherUnityPackageName,
+		)
+	}
+	if result.PreviousVersion != "" {
+		clicore.WriteFormat(
+			stdout,
+			"Updated %s %s -> %s in %s\n",
+			dispatcherUnityPackageName,
+			result.PreviousVersion,
+			version,
+			dispatcherPackagesManifestRelativePath,
+		)
+	} else {
+		clicore.WriteFormat(
+			stdout,
+			"Added %s %s to %s\n",
+			dispatcherUnityPackageName,
+			version,
+			dispatcherPackagesManifestRelativePath,
+		)
+	}
+	clicore.WriteLine(stdout, "If the Unity Editor is open, it applies the change when the window regains focus; otherwise the next launch applies it.")
+}
+
+func packageManifestInvalidError(projectRoot string, cause error) clierrors.CLIError {
+	return clierrors.CLIError{
+		ErrorCode:   clierrors.ErrorCodePackageManifestInvalid,
+		Phase:       clierrors.ErrorPhaseExecution,
+		Message:     "Packages/manifest.json is missing or invalid",
+		Retryable:   false,
+		SafeToRetry: false,
+		Command:     clicore.PackageCommandName,
+		NextActions: []string{
+			"Confirm the path is a Unity project root that contains Packages/manifest.json.",
+			"Repair Packages/manifest.json so it is valid JSON, then retry.",
+		},
+		Details: map[string]any{
+			"ProjectRoot": projectRoot,
+			"Cause":       cause.Error(),
+		},
+	}
+}
+
+func packageRegistryUnavailableError(projectRoot string, cause error) clierrors.CLIError {
+	return clierrors.CLIError{
+		ErrorCode:   clierrors.ErrorCodePackageRegistryUnavailable,
+		Phase:       clierrors.ErrorPhaseExecution,
+		Message:     "OpenUPM registry lookup failed",
+		Retryable:   true,
+		SafeToRetry: true,
+		Command:     clicore.PackageCommandName,
+		NextActions: []string{
+			"Retry after the network is available.",
+			"Pin a version with `uloop package install --version <x.y.z>` to skip the registry lookup.",
+		},
+		Details: map[string]any{
+			"ProjectRoot": projectRoot,
+			"Cause":       cause.Error(),
+		},
+	}
+}
+
+func printPackageHelp(stdout io.Writer) {
+	clicore.WriteLine(stdout, "Usage:")
+	clicore.WriteLine(stdout, "  uloop package install [--version <x.y.z>]")
+	clicore.WriteLine(stdout, "  uloop package status")
+	clicore.WriteLine(stdout, "")
+	clicore.WriteLine(stdout, "Install or inspect the Unity CLI Loop package in a Unity project's Packages/manifest.json.")
+	clicore.WriteLine(stdout, "")
+	clicore.WriteLine(stdout, "Subcommands:")
+	clicore.WriteLine(stdout, "  install   Add the OpenUPM scoped registry and package dependency")
+	clicore.WriteLine(stdout, "  status    Report whether the registry and dependency are present")
+	clicore.WriteLine(stdout, "")
+	clicore.WriteLine(stdout, "Options:")
+	clicore.WriteLine(stdout, "  --version <x.y.z>   Install a specific package version instead of dist-tags.latest")
+	clicore.WriteLine(stdout, "")
+	printGlobalOptionsHelp(stdout)
+}
+
+func bytesReplaceCRLF(content []byte) []byte {
+	return bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
+}

--- a/cli/dispatcher/internal/dispatcher/package_manifest.go
+++ b/cli/dispatcher/internal/dispatcher/package_manifest.go
@@ -1,0 +1,275 @@
+package dispatcher
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	openUPMRegistryURL  = "https://package.openupm.com"
+	openUPMRegistryName = "package.openupm.com"
+)
+
+// packageManifestMergeResult reports how Packages/manifest.json changed.
+type packageManifestMergeResult struct {
+	Content         []byte
+	Changed         bool
+	RegistryAdded   bool
+	ScopeAdded      bool
+	DependencyAdded bool
+	PreviousVersion string
+}
+
+func mergePackageManifest(content []byte, version string) (packageManifestMergeResult, error) {
+	hadCRLF := bytes.Contains(content, []byte("\r\n"))
+	hadTrailingNewline := len(content) > 0 && (content[len(content)-1] == '\n')
+	normalized := bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
+
+	root, err := parseOrderedJSONObjectBytes(normalized)
+	if err != nil {
+		return packageManifestMergeResult{}, err
+	}
+
+	result := packageManifestMergeResult{}
+	if err := updatePackageManifestDependencies(&root, version, &result); err != nil {
+		return packageManifestMergeResult{}, err
+	}
+	if err := updatePackageManifestScopedRegistries(&root, &result); err != nil {
+		return packageManifestMergeResult{}, err
+	}
+
+	if !result.Changed {
+		result.Content = append([]byte{}, content...)
+		return result, nil
+	}
+
+	emitted, err := emitOrderedJSONObject(root, 0)
+	if err != nil {
+		return packageManifestMergeResult{}, err
+	}
+	if hadCRLF {
+		emitted = bytes.ReplaceAll(emitted, []byte("\n"), []byte("\r\n"))
+	}
+	if hadTrailingNewline {
+		if hadCRLF {
+			if !bytes.HasSuffix(emitted, []byte("\r\n")) {
+				emitted = append(emitted, '\r', '\n')
+			}
+		} else if !bytes.HasSuffix(emitted, []byte("\n")) {
+			emitted = append(emitted, '\n')
+		}
+	} else {
+		emitted = bytes.TrimSuffix(emitted, []byte("\r\n"))
+		emitted = bytes.TrimSuffix(emitted, []byte("\n"))
+	}
+	result.Content = emitted
+	return result, nil
+}
+
+func updatePackageManifestDependencies(root *orderedJSONObject, version string, result *packageManifestMergeResult) error {
+	rawDependencies, ok := root.values["dependencies"]
+	if !ok {
+		dependencies := orderedJSONObject{
+			keys:   []string{},
+			values: map[string]json.RawMessage{},
+		}
+		insertDependencyAlphabetically(&dependencies, dispatcherUnityPackageName, version)
+		encoded, err := emitOrderedJSONObject(dependencies, 1)
+		if err != nil {
+			return err
+		}
+		root.insertAfter("dependencies", encoded, "")
+		result.Changed = true
+		result.DependencyAdded = true
+		return nil
+	}
+
+	dependencies, err := parseOrderedJSONObjectBytes(rawDependencies)
+	if err != nil {
+		return fmt.Errorf("dependencies: %w", err)
+	}
+
+	versionJSON, err := json.Marshal(version)
+	if err != nil {
+		return err
+	}
+	existing, exists := dependencies.values[dispatcherUnityPackageName]
+	if exists {
+		var previous string
+		if err := json.Unmarshal(existing, &previous); err != nil {
+			return fmt.Errorf("dependency %s: %w", dispatcherUnityPackageName, err)
+		}
+		if previous == version {
+			return nil
+		}
+		dependencies.values[dispatcherUnityPackageName] = json.RawMessage(versionJSON)
+		result.Changed = true
+		result.PreviousVersion = previous
+	} else {
+		insertDependencyAlphabetically(&dependencies, dispatcherUnityPackageName, version)
+		result.Changed = true
+		result.DependencyAdded = true
+	}
+
+	encoded, err := emitOrderedJSONObject(dependencies, 1)
+	if err != nil {
+		return err
+	}
+	root.values["dependencies"] = encoded
+	return nil
+}
+
+func insertDependencyAlphabetically(dependencies *orderedJSONObject, name string, version string) {
+	versionJSON, err := json.Marshal(version)
+	if err != nil {
+		panic(err)
+	}
+	insertAt := len(dependencies.keys)
+	for index, key := range dependencies.keys {
+		if key > name {
+			insertAt = index
+			break
+		}
+	}
+	dependencies.keys = append(dependencies.keys, "")
+	copy(dependencies.keys[insertAt+1:], dependencies.keys[insertAt:])
+	dependencies.keys[insertAt] = name
+	if dependencies.values == nil {
+		dependencies.values = map[string]json.RawMessage{}
+	}
+	dependencies.values[name] = json.RawMessage(versionJSON)
+}
+
+func updatePackageManifestScopedRegistries(root *orderedJSONObject, result *packageManifestMergeResult) error {
+	rawRegistries, hasRegistries := root.values["scopedRegistries"]
+	if !hasRegistries {
+		encoded, err := emitOpenUPMScopedRegistriesArray(1)
+		if err != nil {
+			return err
+		}
+		root.insertAfter("scopedRegistries", encoded, "dependencies")
+		result.Changed = true
+		result.RegistryAdded = true
+		result.ScopeAdded = true
+		return nil
+	}
+
+	elements, err := parseJSONRawArray(rawRegistries)
+	if err != nil {
+		return fmt.Errorf("scopedRegistries: %w", err)
+	}
+
+	openUPMIndex := -1
+	parsedEntries := make([]orderedJSONObject, len(elements))
+	for index, element := range elements {
+		entry, parseErr := parseOrderedJSONObjectBytes(element)
+		if parseErr != nil {
+			return fmt.Errorf("scopedRegistries[%d]: %w", index, parseErr)
+		}
+		parsedEntries[index] = entry
+		urlRaw, ok := entry.values["url"]
+		if !ok {
+			continue
+		}
+		var url string
+		if err := json.Unmarshal(urlRaw, &url); err != nil {
+			return fmt.Errorf("scopedRegistries[%d].url: %w", index, err)
+		}
+		if url == openUPMRegistryURL {
+			openUPMIndex = index
+		}
+	}
+
+	if openUPMIndex < 0 {
+		newEntry, err := buildOpenUPMRegistryEntry()
+		if err != nil {
+			return err
+		}
+		elements = append(elements, newEntry)
+		encoded, err := emitJSONRawArray(elements, 1)
+		if err != nil {
+			return err
+		}
+		root.values["scopedRegistries"] = encoded
+		result.Changed = true
+		result.RegistryAdded = true
+		result.ScopeAdded = true
+		return nil
+	}
+
+	entry := parsedEntries[openUPMIndex]
+	scopesChanged, err := ensureOpenUPMScope(&entry)
+	if err != nil {
+		return err
+	}
+	if !scopesChanged {
+		return nil
+	}
+	encodedEntry, err := emitOrderedJSONObject(entry, 2)
+	if err != nil {
+		return err
+	}
+	elements[openUPMIndex] = encodedEntry
+	encoded, err := emitJSONRawArray(elements, 1)
+	if err != nil {
+		return err
+	}
+	root.values["scopedRegistries"] = encoded
+	result.Changed = true
+	result.ScopeAdded = true
+	return nil
+}
+
+func ensureOpenUPMScope(entry *orderedJSONObject) (bool, error) {
+	rawScopes, ok := entry.values["scopes"]
+	if !ok {
+		scopesJSON, err := json.Marshal([]string{dispatcherUnityPackageName})
+		if err != nil {
+			return false, err
+		}
+		entry.values["scopes"] = json.RawMessage(scopesJSON)
+		if !entry.hasKey("scopes") {
+			entry.keys = append(entry.keys, "scopes")
+		}
+		return true, nil
+	}
+
+	var scopes []string
+	if err := json.Unmarshal(rawScopes, &scopes); err != nil {
+		return false, fmt.Errorf("scopes: %w", err)
+	}
+	for _, scope := range scopes {
+		if scope == dispatcherUnityPackageName {
+			return false, nil
+		}
+	}
+	scopes = append(scopes, dispatcherUnityPackageName)
+	sortStringsByteOrder(scopes)
+	scopesJSON, err := json.Marshal(scopes)
+	if err != nil {
+		return false, err
+	}
+	entry.values["scopes"] = json.RawMessage(scopesJSON)
+	return true, nil
+}
+
+func buildOpenUPMRegistryEntry() (json.RawMessage, error) {
+	entry := orderedJSONObject{
+		keys: []string{"name", "url", "scopes"},
+		values: map[string]json.RawMessage{
+			"name":   mustMarshalJSON(openUPMRegistryName),
+			"url":    mustMarshalJSON(openUPMRegistryURL),
+			"scopes": mustMarshalJSON([]string{dispatcherUnityPackageName}),
+		},
+	}
+	return emitOrderedJSONObject(entry, 2)
+}
+
+func emitOpenUPMScopedRegistriesArray(depth int) (json.RawMessage, error) {
+	entry, err := buildOpenUPMRegistryEntry()
+	if err != nil {
+		return nil, err
+	}
+	return emitJSONRawArray([]json.RawMessage{entry}, depth)
+}

--- a/cli/dispatcher/internal/dispatcher/package_manifest_json.go
+++ b/cli/dispatcher/internal/dispatcher/package_manifest_json.go
@@ -1,0 +1,246 @@
+package dispatcher
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// orderedJSONObject preserves the original key order of a JSON object so a
+// rewrite of Packages/manifest.json produces a minimal diff.
+type orderedJSONObject struct {
+	keys   []string
+	values map[string]json.RawMessage
+}
+
+func parseOrderedJSONObjectBytes(data []byte) (orderedJSONObject, error) {
+	trimmed := bytes.TrimSpace(data)
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	token, err := dec.Token()
+	if err != nil {
+		return orderedJSONObject{}, err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return orderedJSONObject{}, fmt.Errorf("expected JSON object")
+	}
+
+	object := orderedJSONObject{
+		keys:   []string{},
+		values: map[string]json.RawMessage{},
+	}
+	for dec.More() {
+		keyToken, keyErr := dec.Token()
+		if keyErr != nil {
+			return orderedJSONObject{}, keyErr
+		}
+		key, keyOK := keyToken.(string)
+		if !keyOK {
+			return orderedJSONObject{}, fmt.Errorf("expected object key")
+		}
+		var raw json.RawMessage
+		if decodeErr := dec.Decode(&raw); decodeErr != nil {
+			return orderedJSONObject{}, decodeErr
+		}
+		object.keys = append(object.keys, key)
+		object.values[key] = raw
+	}
+	closing, err := dec.Token()
+	if err != nil {
+		return orderedJSONObject{}, err
+	}
+	if closingDelim, ok := closing.(json.Delim); !ok || closingDelim != '}' {
+		return orderedJSONObject{}, fmt.Errorf("expected end of JSON object")
+	}
+	return object, nil
+}
+
+func parseJSONRawArray(data []byte) ([]json.RawMessage, error) {
+	trimmed := bytes.TrimSpace(data)
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	token, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '[' {
+		return nil, fmt.Errorf("expected JSON array")
+	}
+	elements := []json.RawMessage{}
+	for dec.More() {
+		var raw json.RawMessage
+		if decodeErr := dec.Decode(&raw); decodeErr != nil {
+			return nil, decodeErr
+		}
+		elements = append(elements, raw)
+	}
+	closing, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if closingDelim, ok := closing.(json.Delim); !ok || closingDelim != ']' {
+		return nil, fmt.Errorf("expected end of JSON array")
+	}
+	return elements, nil
+}
+
+func emitOrderedJSONObject(object orderedJSONObject, depth int) (json.RawMessage, error) {
+	indent := strings.Repeat("  ", depth)
+	innerIndent := strings.Repeat("  ", depth+1)
+	var builder strings.Builder
+	builder.WriteString("{\n")
+	for index, key := range object.keys {
+		raw, ok := object.values[key]
+		if !ok {
+			return nil, fmt.Errorf("missing value for key %q", key)
+		}
+		encodedKey, err := json.Marshal(key)
+		if err != nil {
+			return nil, err
+		}
+		formattedValue, err := formatJSONRawForEmit(raw, depth+1)
+		if err != nil {
+			return nil, err
+		}
+		builder.WriteString(innerIndent)
+		builder.Write(encodedKey)
+		builder.WriteString(": ")
+		builder.WriteString(formattedValue)
+		if index < len(object.keys)-1 {
+			builder.WriteString(",")
+		}
+		builder.WriteString("\n")
+	}
+	builder.WriteString(indent)
+	builder.WriteString("}")
+	return json.RawMessage(builder.String()), nil
+}
+
+func emitJSONRawArray(elements []json.RawMessage, depth int) (json.RawMessage, error) {
+	indent := strings.Repeat("  ", depth)
+	innerIndent := strings.Repeat("  ", depth+1)
+	var builder strings.Builder
+	builder.WriteString("[\n")
+	for index, element := range elements {
+		formatted, err := formatJSONRawForEmit(element, depth+1)
+		if err != nil {
+			return nil, err
+		}
+		builder.WriteString(innerIndent)
+		builder.WriteString(formatted)
+		if index < len(elements)-1 {
+			builder.WriteString(",")
+		}
+		builder.WriteString("\n")
+	}
+	builder.WriteString(indent)
+	builder.WriteString("]")
+	return json.RawMessage(builder.String()), nil
+}
+
+func formatJSONRawForEmit(raw json.RawMessage, depth int) (string, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return "", fmt.Errorf("empty JSON value")
+	}
+	switch trimmed[0] {
+	case '{':
+		object, err := parseOrderedJSONObjectBytes(trimmed)
+		if err != nil {
+			return "", err
+		}
+		emitted, err := emitOrderedJSONObject(object, depth)
+		if err != nil {
+			return "", err
+		}
+		return string(emitted), nil
+	case '[':
+		// Pretty-print arrays (including scopes) with stable formatting.
+		var values []json.RawMessage
+		if err := json.Unmarshal(trimmed, &values); err != nil {
+			return "", err
+		}
+		// Distinguish object-array (scopedRegistries elements) from string-array (scopes).
+		if len(values) > 0 {
+			first := bytes.TrimSpace(values[0])
+			if len(first) > 0 && first[0] == '{' {
+				emitted, err := emitJSONRawArray(values, depth)
+				if err != nil {
+					return "", err
+				}
+				return string(emitted), nil
+			}
+		}
+		indent := strings.Repeat("  ", depth)
+		innerIndent := strings.Repeat("  ", depth+1)
+		var builder strings.Builder
+		builder.WriteString("[\n")
+		for index, value := range values {
+			builder.WriteString(innerIndent)
+			builder.Write(bytes.TrimSpace(value))
+			if index < len(values)-1 {
+				builder.WriteString(",")
+			}
+			builder.WriteString("\n")
+		}
+		builder.WriteString(indent)
+		builder.WriteString("]")
+		return builder.String(), nil
+	default:
+		return string(trimmed), nil
+	}
+}
+
+func (object *orderedJSONObject) hasKey(key string) bool {
+	for _, existing := range object.keys {
+		if existing == key {
+			return true
+		}
+	}
+	return false
+}
+
+// insertAfter inserts key/value immediately after afterKey, or at the end when afterKey is empty/missing.
+func (object *orderedJSONObject) insertAfter(key string, value json.RawMessage, afterKey string) {
+	if object.values == nil {
+		object.values = map[string]json.RawMessage{}
+	}
+	if object.hasKey(key) {
+		object.values[key] = value
+		return
+	}
+	insertAt := len(object.keys)
+	if afterKey != "" {
+		for index, existing := range object.keys {
+			if existing == afterKey {
+				insertAt = index + 1
+				break
+			}
+		}
+	}
+	object.keys = append(object.keys, "")
+	copy(object.keys[insertAt+1:], object.keys[insertAt:])
+	object.keys[insertAt] = key
+	object.values[key] = value
+}
+
+func mustMarshalJSON(value any) json.RawMessage {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return json.RawMessage(encoded)
+}
+
+func sortStringsByteOrder(values []string) {
+	for index := 1; index < len(values); index++ {
+		current := values[index]
+		previous := index - 1
+		for previous >= 0 && values[previous] > current {
+			values[previous+1] = values[previous]
+			previous--
+		}
+		values[previous+1] = current
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/package_manifest_json.go
+++ b/cli/dispatcher/internal/dispatcher/package_manifest_json.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -53,6 +54,9 @@ func parseOrderedJSONObjectBytes(data []byte) (orderedJSONObject, error) {
 	if closingDelim, ok := closing.(json.Delim); !ok || closingDelim != '}' {
 		return orderedJSONObject{}, fmt.Errorf("expected end of JSON object")
 	}
+	if err := ensureJSONDecoderFullyConsumed(dec); err != nil {
+		return orderedJSONObject{}, err
+	}
 	return object, nil
 }
 
@@ -82,7 +86,24 @@ func parseJSONRawArray(data []byte) ([]json.RawMessage, error) {
 	if closingDelim, ok := closing.(json.Delim); !ok || closingDelim != ']' {
 		return nil, fmt.Errorf("expected end of JSON array")
 	}
+	if err := ensureJSONDecoderFullyConsumed(dec); err != nil {
+		return nil, err
+	}
 	return elements, nil
+}
+
+// ensureJSONDecoderFullyConsumed rejects trailing tokens after a complete JSON
+// value so malformed manifests with garbage after the closing delimiter fail
+// instead of being silently rewritten without that garbage.
+func ensureJSONDecoderFullyConsumed(dec *json.Decoder) error {
+	token, err := dec.Token()
+	if err == io.EOF {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("unexpected trailing JSON token: %v", token)
 }
 
 func emitOrderedJSONObject(object orderedJSONObject, depth int) (json.RawMessage, error) {

--- a/cli/dispatcher/internal/dispatcher/package_manifest_test.go
+++ b/cli/dispatcher/internal/dispatcher/package_manifest_test.go
@@ -1,0 +1,339 @@
+package dispatcher
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Verifies a bare dependencies-only manifest gains the OpenUPM registry and package dependency.
+func TestMergePackageManifestAddsRegistryAndDependencyToBareManifest(t *testing.T) {
+	input := []byte(`{
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0"
+  }
+}
+`)
+
+	result, err := mergePackageManifest(input, "1.2.3")
+	if err != nil {
+		t.Fatalf("mergePackageManifest failed: %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("expected Changed=true")
+	}
+	if !result.RegistryAdded || !result.DependencyAdded {
+		t.Fatalf("flags mismatch: %#v", result)
+	}
+
+	assertManifestHasDependency(t, result.Content, dispatcherUnityPackageName, "1.2.3")
+	assertManifestHasOpenUPMRegistry(t, result.Content)
+}
+
+// Verifies foreign scopedRegistries entries stay intact while OpenUPM is appended.
+func TestMergePackageManifestKeepsExistingForeignRegistry(t *testing.T) {
+	input := []byte(`{
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0"
+  },
+  "scopedRegistries": [
+    {
+      "name": "Other",
+      "url": "https://example.invalid/registry",
+      "scopes": [
+        "com.other.package"
+      ]
+    }
+  ]
+}
+`)
+
+	result, err := mergePackageManifest(input, "1.2.3")
+	if err != nil {
+		t.Fatalf("mergePackageManifest failed: %v", err)
+	}
+
+	content := string(result.Content)
+	if !strings.Contains(content, `"url": "https://example.invalid/registry"`) {
+		t.Fatalf("foreign registry was altered:\n%s", content)
+	}
+	if !strings.Contains(content, `"com.other.package"`) {
+		t.Fatalf("foreign scope was altered:\n%s", content)
+	}
+	assertManifestHasOpenUPMRegistry(t, result.Content)
+	assertManifestHasDependency(t, result.Content, dispatcherUnityPackageName, "1.2.3")
+}
+
+// Verifies an existing OpenUPM registry entry gets the scope appended without a duplicate entry.
+func TestMergePackageManifestAppendsScopeToExistingOpenUPMRegistry(t *testing.T) {
+	input := []byte(`{
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0"
+  },
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.com",
+      "url": "https://package.openupm.com",
+      "scopes": [
+        "com.other.openupm"
+      ]
+    }
+  ]
+}
+`)
+
+	result, err := mergePackageManifest(input, "1.2.3")
+	if err != nil {
+		t.Fatalf("mergePackageManifest failed: %v", err)
+	}
+	if !result.ScopeAdded {
+		t.Fatal("expected ScopeAdded=true")
+	}
+	if result.RegistryAdded {
+		t.Fatal("expected RegistryAdded=false when OpenUPM already exists")
+	}
+
+	openUPMCount := strings.Count(string(result.Content), `"url": "https://package.openupm.com"`)
+	if openUPMCount != 1 {
+		t.Fatalf("expected one OpenUPM registry entry, got %d:\n%s", openUPMCount, result.Content)
+	}
+	if !strings.Contains(string(result.Content), `"com.other.openupm"`) {
+		t.Fatalf("existing scope missing:\n%s", result.Content)
+	}
+	if !strings.Contains(string(result.Content), `"`+dispatcherUnityPackageName+`"`) {
+		t.Fatalf("package scope missing:\n%s", result.Content)
+	}
+	assertManifestHasDependency(t, result.Content, dispatcherUnityPackageName, "1.2.3")
+}
+
+// Verifies no rewrite when registry, scope, and the same dependency version are already present.
+func TestMergePackageManifestNoChangeWhenAlreadyInstalled(t *testing.T) {
+	input := []byte(`{
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0",
+    "io.github.hatayama.uloopmcp": "1.2.3"
+  },
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.com",
+      "url": "https://package.openupm.com",
+      "scopes": [
+        "io.github.hatayama.uloopmcp"
+      ]
+    }
+  ]
+}
+`)
+
+	result, err := mergePackageManifest(input, "1.2.3")
+	if err != nil {
+		t.Fatalf("mergePackageManifest failed: %v", err)
+	}
+	if result.Changed {
+		t.Fatalf("expected Changed=false, got content:\n%s", result.Content)
+	}
+	if !bytes.Equal(result.Content, input) {
+		t.Fatalf("content changed unexpectedly:\n%s", result.Content)
+	}
+}
+
+// Verifies an existing dependency version is updated in place without reordering keys.
+func TestMergePackageManifestUpdatesDependencyVersionInPlace(t *testing.T) {
+	input := []byte(`{
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0",
+    "io.github.hatayama.uloopmcp": "1.2.2",
+    "com.unity.modules.animation": "1.0.0"
+  }
+}
+`)
+
+	result, err := mergePackageManifest(input, "1.2.3")
+	if err != nil {
+		t.Fatalf("mergePackageManifest failed: %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("expected Changed=true")
+	}
+	if result.PreviousVersion != "1.2.2" {
+		t.Fatalf("PreviousVersion mismatch: %q", result.PreviousVersion)
+	}
+	if result.DependencyAdded {
+		t.Fatal("expected DependencyAdded=false for version update")
+	}
+
+	deps := decodeOrderedObjectField(t, result.Content, "dependencies")
+	keys := deps.keys
+	expectedKeys := []string{"com.unity.modules.ai", "io.github.hatayama.uloopmcp", "com.unity.modules.animation"}
+	if len(keys) != len(expectedKeys) {
+		t.Fatalf("dependency key count mismatch: %#v", keys)
+	}
+	for index, expected := range expectedKeys {
+		if keys[index] != expected {
+			t.Fatalf("dependency key order mismatch at %d: %#v", index, keys)
+		}
+	}
+	assertManifestHasDependency(t, result.Content, dispatcherUnityPackageName, "1.2.3")
+}
+
+// Verifies non-alphabetical top-level key order is preserved across a rewrite.
+func TestMergePackageManifestPreservesTopLevelKeyOrder(t *testing.T) {
+	input := []byte(`{
+  "testables": [
+    "com.unity.testtools.codecoverage"
+  ],
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0"
+  }
+}
+`)
+
+	result, err := mergePackageManifest(input, "1.2.3")
+	if err != nil {
+		t.Fatalf("mergePackageManifest failed: %v", err)
+	}
+
+	top := parseOrderedJSONObject(t, result.Content)
+	if len(top.keys) < 2 || top.keys[0] != "testables" {
+		t.Fatalf("top-level key order not preserved: %#v", top.keys)
+	}
+	if top.keys[1] != "dependencies" {
+		t.Fatalf("dependencies should remain second: %#v", top.keys)
+	}
+}
+
+// Verifies CRLF input is rewritten with CRLF line endings (Windows regression).
+func TestMergePackageManifestPreservesCRLFLineEndings(t *testing.T) {
+	input := []byte("{\r\n  \"dependencies\": {\r\n    \"com.unity.modules.ai\": \"1.0.0\"\r\n  }\r\n}\r\n")
+
+	result, err := mergePackageManifest(input, "1.2.3")
+	if err != nil {
+		t.Fatalf("mergePackageManifest failed: %v", err)
+	}
+	if !bytes.Contains(result.Content, []byte("\r\n")) {
+		t.Fatalf("expected CRLF output:\n%q", result.Content)
+	}
+	if bytes.Contains(bytes.ReplaceAll(result.Content, []byte("\r\n"), nil), []byte("\n")) {
+		t.Fatalf("found bare LF in CRLF output:\n%q", result.Content)
+	}
+}
+
+// Verifies trailing-newline presence or absence matches the input.
+func TestMergePackageManifestPreservesMissingTrailingNewline(t *testing.T) {
+	withoutNewline := []byte(`{
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0"
+  }
+}`)
+	withNewline := append(append([]byte{}, withoutNewline...), '\n')
+
+	resultWithout, err := mergePackageManifest(withoutNewline, "1.2.3")
+	if err != nil {
+		t.Fatalf("merge without newline failed: %v", err)
+	}
+	if bytes.HasSuffix(resultWithout.Content, []byte("\n")) {
+		t.Fatalf("unexpected trailing newline:\n%q", resultWithout.Content)
+	}
+
+	resultWith, err := mergePackageManifest(withNewline, "1.2.3")
+	if err != nil {
+		t.Fatalf("merge with newline failed: %v", err)
+	}
+	if !bytes.HasSuffix(resultWith.Content, []byte("\n")) {
+		t.Fatalf("expected trailing newline:\n%q", resultWith.Content)
+	}
+}
+
+// Verifies malformed JSON is rejected.
+func TestMergePackageManifestRejectsMalformedJSON(t *testing.T) {
+	_, err := mergePackageManifest([]byte(`{not json`), "1.2.3")
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+// Verifies scopedRegistries is inserted immediately after dependencies when absent.
+func TestMergePackageManifestInsertsScopedRegistriesAfterDependencies(t *testing.T) {
+	input := []byte(`{
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0"
+  },
+  "testables": [
+    "com.unity.testtools.codecoverage"
+  ]
+}
+`)
+
+	result, err := mergePackageManifest(input, "1.2.3")
+	if err != nil {
+		t.Fatalf("mergePackageManifest failed: %v", err)
+	}
+
+	top := parseOrderedJSONObject(t, result.Content)
+	dependenciesIndex := -1
+	scopedIndex := -1
+	for index, key := range top.keys {
+		if key == "dependencies" {
+			dependenciesIndex = index
+		}
+		if key == "scopedRegistries" {
+			scopedIndex = index
+		}
+	}
+	if dependenciesIndex < 0 || scopedIndex < 0 {
+		t.Fatalf("missing keys: %#v", top.keys)
+	}
+	if scopedIndex != dependenciesIndex+1 {
+		t.Fatalf("scopedRegistries not after dependencies: %#v", top.keys)
+	}
+}
+
+func assertManifestHasDependency(t *testing.T, content []byte, name string, version string) {
+	t.Helper()
+	deps := decodeOrderedObjectField(t, content, "dependencies")
+	raw, ok := deps.values[name]
+	if !ok {
+		t.Fatalf("dependency %s missing from:\n%s", name, content)
+	}
+	var decoded string
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("dependency value decode failed: %v", err)
+	}
+	if decoded != version {
+		t.Fatalf("dependency version mismatch: got %q want %q", decoded, version)
+	}
+}
+
+func assertManifestHasOpenUPMRegistry(t *testing.T, content []byte) {
+	t.Helper()
+	if !strings.Contains(string(content), `"url": "https://package.openupm.com"`) {
+		t.Fatalf("OpenUPM registry missing:\n%s", content)
+	}
+	if !strings.Contains(string(content), `"`+dispatcherUnityPackageName+`"`) {
+		t.Fatalf("OpenUPM scope missing:\n%s", content)
+	}
+}
+
+func decodeOrderedObjectField(t *testing.T, content []byte, field string) orderedJSONObject {
+	t.Helper()
+	top := parseOrderedJSONObject(t, content)
+	raw, ok := top.values[field]
+	if !ok {
+		t.Fatalf("field %s missing from:\n%s", field, content)
+	}
+	object, err := parseOrderedJSONObjectBytes(raw)
+	if err != nil {
+		t.Fatalf("parse field %s failed: %v", field, err)
+	}
+	return object
+}
+
+func parseOrderedJSONObject(t *testing.T, content []byte) orderedJSONObject {
+	t.Helper()
+	object, err := parseOrderedJSONObjectBytes(content)
+	if err != nil {
+		t.Fatalf("parseOrderedJSONObjectBytes failed: %v", err)
+	}
+	return object
+}

--- a/cli/dispatcher/internal/dispatcher/package_manifest_test.go
+++ b/cli/dispatcher/internal/dispatcher/package_manifest_test.go
@@ -101,9 +101,7 @@ func TestMergePackageManifestAppendsScopeToExistingOpenUPMRegistry(t *testing.T)
 	if !strings.Contains(string(result.Content), `"com.other.openupm"`) {
 		t.Fatalf("existing scope missing:\n%s", result.Content)
 	}
-	if !strings.Contains(string(result.Content), `"`+dispatcherUnityPackageName+`"`) {
-		t.Fatalf("package scope missing:\n%s", result.Content)
-	}
+	assertManifestHasOpenUPMRegistry(t, result.Content)
 	assertManifestHasDependency(t, result.Content, dispatcherUnityPackageName, "1.2.3")
 }
 
@@ -253,6 +251,14 @@ func TestMergePackageManifestRejectsMalformedJSON(t *testing.T) {
 	}
 }
 
+// Verifies trailing garbage after a complete JSON object is rejected.
+func TestMergePackageManifestRejectsTrailingGarbage(t *testing.T) {
+	_, err := mergePackageManifest([]byte("{\n  \"dependencies\": {}\n}\n trailing"), "1.2.3")
+	if err == nil {
+		t.Fatal("expected error for trailing garbage after JSON object")
+	}
+}
+
 // Verifies scopedRegistries is inserted immediately after dependencies when absent.
 func TestMergePackageManifestInsertsScopedRegistriesAfterDependencies(t *testing.T) {
 	input := []byte(`{
@@ -307,12 +313,47 @@ func assertManifestHasDependency(t *testing.T, content []byte, name string, vers
 
 func assertManifestHasOpenUPMRegistry(t *testing.T, content []byte) {
 	t.Helper()
-	if !strings.Contains(string(content), `"url": "https://package.openupm.com"`) {
-		t.Fatalf("OpenUPM registry missing:\n%s", content)
+	top := parseOrderedJSONObject(t, content)
+	rawRegistries, ok := top.values["scopedRegistries"]
+	if !ok {
+		t.Fatalf("scopedRegistries missing:\n%s", content)
 	}
-	if !strings.Contains(string(content), `"`+dispatcherUnityPackageName+`"`) {
-		t.Fatalf("OpenUPM scope missing:\n%s", content)
+	elements, err := parseJSONRawArray(rawRegistries)
+	if err != nil {
+		t.Fatalf("parse scopedRegistries failed: %v", err)
 	}
+	for _, element := range elements {
+		entry, parseErr := parseOrderedJSONObjectBytes(element)
+		if parseErr != nil {
+			t.Fatalf("parse registry entry failed: %v", parseErr)
+		}
+		urlRaw, hasURL := entry.values["url"]
+		if !hasURL {
+			continue
+		}
+		var url string
+		if unmarshalErr := json.Unmarshal(urlRaw, &url); unmarshalErr != nil {
+			t.Fatalf("url decode failed: %v", unmarshalErr)
+		}
+		if url != openUPMRegistryURL {
+			continue
+		}
+		rawScopes, hasScopes := entry.values["scopes"]
+		if !hasScopes {
+			t.Fatalf("OpenUPM registry missing scopes:\n%s", content)
+		}
+		var scopes []string
+		if unmarshalErr := json.Unmarshal(rawScopes, &scopes); unmarshalErr != nil {
+			t.Fatalf("scopes decode failed: %v", unmarshalErr)
+		}
+		for _, scope := range scopes {
+			if scope == dispatcherUnityPackageName {
+				return
+			}
+		}
+		t.Fatalf("OpenUPM scopes missing %s: %#v\n%s", dispatcherUnityPackageName, scopes, content)
+	}
+	t.Fatalf("OpenUPM registry missing:\n%s", content)
 }
 
 func decodeOrderedObjectField(t *testing.T, content []byte, field string) orderedJSONObject {

--- a/cli/dispatcher/internal/dispatcher/package_registry.go
+++ b/cli/dispatcher/internal/dispatcher/package_registry.go
@@ -1,0 +1,47 @@
+package dispatcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Overridable in tests (httptest): see attestation/fetcher.go for the same pattern.
+var (
+	packageRegistryHTTPClient = &http.Client{Timeout: 30 * time.Second}
+	openUPMRegistryBaseURL    = openUPMRegistryURL
+)
+
+func resolveLatestPackageVersion(ctx context.Context) (string, error) {
+	requestURL := strings.TrimRight(openUPMRegistryBaseURL, "/") + "/" + dispatcherUnityPackageName
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	response, err := packageRegistryHTTPClient.Do(request)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return "", fmt.Errorf("OpenUPM registry returned HTTP %d", response.StatusCode)
+	}
+
+	var payload struct {
+		DistTags struct {
+			Latest string `json:"latest"`
+		} `json:"dist-tags"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode OpenUPM registry response: %w", err)
+	}
+	if payload.DistTags.Latest == "" {
+		return "", fmt.Errorf("OpenUPM registry response missing dist-tags.latest")
+	}
+	return payload.DistTags.Latest, nil
+}

--- a/cli/dispatcher/internal/dispatcher/package_registry_test.go
+++ b/cli/dispatcher/internal/dispatcher/package_registry_test.go
@@ -1,0 +1,82 @@
+package dispatcher
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Verifies dist-tags.latest is returned from the OpenUPM package metadata endpoint.
+func TestResolveLatestPackageVersionReadsDistTags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/"+dispatcherUnityPackageName {
+			t.Fatalf("unexpected path: %s", request.URL.Path)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"dist-tags":{"latest":"9.8.7"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	previousURL := openUPMRegistryBaseURL
+	previousClient := packageRegistryHTTPClient
+	openUPMRegistryBaseURL = server.URL
+	packageRegistryHTTPClient = server.Client()
+	t.Cleanup(func() {
+		openUPMRegistryBaseURL = previousURL
+		packageRegistryHTTPClient = previousClient
+	})
+
+	version, err := resolveLatestPackageVersion(context.Background())
+	if err != nil {
+		t.Fatalf("resolveLatestPackageVersion failed: %v", err)
+	}
+	if version != "9.8.7" {
+		t.Fatalf("version mismatch: %s", version)
+	}
+}
+
+// Verifies non-2xx registry responses surface as errors.
+func TestResolveLatestPackageVersionReportsHTTPFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	previousURL := openUPMRegistryBaseURL
+	previousClient := packageRegistryHTTPClient
+	openUPMRegistryBaseURL = server.URL
+	packageRegistryHTTPClient = server.Client()
+	t.Cleanup(func() {
+		openUPMRegistryBaseURL = previousURL
+		packageRegistryHTTPClient = previousClient
+	})
+
+	_, err := resolveLatestPackageVersion(context.Background())
+	if err == nil {
+		t.Fatal("expected HTTP failure error")
+	}
+}
+
+// Verifies an empty dist-tags.latest value is rejected.
+func TestResolveLatestPackageVersionRejectsEmptyLatest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"dist-tags":{}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	previousURL := openUPMRegistryBaseURL
+	previousClient := packageRegistryHTTPClient
+	openUPMRegistryBaseURL = server.URL
+	packageRegistryHTTPClient = server.Client()
+	t.Cleanup(func() {
+		openUPMRegistryBaseURL = previousURL
+		packageRegistryHTTPClient = previousClient
+	})
+
+	_, err := resolveLatestPackageVersion(context.Background())
+	if err == nil {
+		t.Fatal("expected empty latest error")
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/package_test.go
+++ b/cli/dispatcher/internal/dispatcher/package_test.go
@@ -99,6 +99,51 @@ func TestPackageInstallWithVersionSkipsRegistryLookup(t *testing.T) {
 	}
 }
 
+// Verifies install appends the package scope to an existing OpenUPM registry without duplicating it.
+func TestPackageInstallAppendsScopeToExistingOpenUPMRegistry(t *testing.T) {
+	manifest := `{
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0"
+  },
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.com",
+      "url": "https://package.openupm.com",
+      "scopes": [
+        "com.other.openupm"
+      ]
+    }
+  ]
+}
+`
+	projectRoot := createPackageTestProject(t, manifest)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(
+		context.Background(),
+		[]string{"package", "install", "--version", "1.2.3", "--project-path", projectRoot},
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("package install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	content := readPackageManifest(t, projectRoot)
+	if strings.Count(content, `"url": "https://package.openupm.com"`) != 1 {
+		t.Fatalf("expected one OpenUPM registry entry:\n%s", content)
+	}
+	if !strings.Contains(content, `"com.other.openupm"`) {
+		t.Fatalf("existing scope missing:\n%s", content)
+	}
+	assertManifestHasOpenUPMRegistry(t, []byte(content))
+	if !strings.Contains(content, `"`+dispatcherUnityPackageName+`": "1.2.3"`) {
+		t.Fatalf("dependency missing from manifest:\n%s", content)
+	}
+	if !strings.Contains(stdout.String(), "Added scoped registry") {
+		t.Fatalf("expected scoped registry message:\n%s", stdout.String())
+	}
+}
+
 // Verifies a second install reports already installed and leaves the manifest unchanged.
 func TestPackageInstallIsIdempotent(t *testing.T) {
 	projectRoot := createPackageTestProject(t, barePackageManifest())

--- a/cli/dispatcher/internal/dispatcher/package_test.go
+++ b/cli/dispatcher/internal/dispatcher/package_test.go
@@ -1,0 +1,301 @@
+package dispatcher
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Verifies package help lists install, status, and --version.
+func TestPackageHelpListsSubcommands(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := RunDispatcher(context.Background(), []string{"package", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("package help failed: code=%d stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, expected := range []string{"install", "status", "--version", "--project-path"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("package help missing %q:\n%s", expected, output)
+		}
+	}
+}
+
+// Verifies install writes registry and dependency using dist-tags.latest from the registry.
+func TestPackageInstallWritesManifestUsingRegistryLatest(t *testing.T) {
+	projectRoot := createPackageTestProject(t, barePackageManifest())
+	restore := stubOpenUPMRegistry(t, `{"dist-tags":{"latest":"1.2.3"}}`)
+	defer restore()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(
+		context.Background(),
+		[]string{"package", "install", "--project-path", projectRoot},
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("package install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, expected := range []string{
+		"Added scoped registry https://package.openupm.com",
+		"Added " + dispatcherUnityPackageName + " 1.2.3",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("install output missing %q:\n%s", expected, output)
+		}
+	}
+
+	content := readPackageManifest(t, projectRoot)
+	if !strings.Contains(content, `"url": "https://package.openupm.com"`) {
+		t.Fatalf("registry missing from manifest:\n%s", content)
+	}
+	if !strings.Contains(content, `"`+dispatcherUnityPackageName+`": "1.2.3"`) {
+		t.Fatalf("dependency missing from manifest:\n%s", content)
+	}
+}
+
+// Verifies --version skips the registry HTTP lookup entirely.
+func TestPackageInstallWithVersionSkipsRegistryLookup(t *testing.T) {
+	projectRoot := createPackageTestProject(t, barePackageManifest())
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("registry must not be contacted when --version is set")
+	}))
+	t.Cleanup(server.Close)
+
+	previousURL := openUPMRegistryBaseURL
+	previousClient := packageRegistryHTTPClient
+	openUPMRegistryBaseURL = server.URL
+	packageRegistryHTTPClient = server.Client()
+	t.Cleanup(func() {
+		openUPMRegistryBaseURL = previousURL
+		packageRegistryHTTPClient = previousClient
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(
+		context.Background(),
+		[]string{"package", "install", "--version", "1.2.3", "--project-path", projectRoot},
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("package install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	content := readPackageManifest(t, projectRoot)
+	if !strings.Contains(content, `"`+dispatcherUnityPackageName+`": "1.2.3"`) {
+		t.Fatalf("dependency missing from manifest:\n%s", content)
+	}
+}
+
+// Verifies a second install reports already installed and leaves the manifest unchanged.
+func TestPackageInstallIsIdempotent(t *testing.T) {
+	projectRoot := createPackageTestProject(t, barePackageManifest())
+	restore := stubOpenUPMRegistry(t, `{"dist-tags":{"latest":"1.2.3"}}`)
+	defer restore()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	firstCode := RunDispatcher(
+		context.Background(),
+		[]string{"package", "install", "--project-path", projectRoot},
+		&stdout,
+		&stderr,
+	)
+	if firstCode != 0 {
+		t.Fatalf("first install failed: code=%d stderr=%s", firstCode, stderr.String())
+	}
+	before := readPackageManifest(t, projectRoot)
+
+	stdout.Reset()
+	stderr.Reset()
+	secondCode := RunDispatcher(
+		context.Background(),
+		[]string{"package", "install", "--project-path", projectRoot},
+		&stdout,
+		&stderr,
+	)
+	if secondCode != 0 {
+		t.Fatalf("second install failed: code=%d stderr=%s", secondCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "already installed") {
+		t.Fatalf("expected already installed message:\n%s", stdout.String())
+	}
+	after := readPackageManifest(t, projectRoot)
+	if before != after {
+		t.Fatalf("manifest changed on idempotent install:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+// Verifies a project without Packages/manifest.json returns PACKAGE_MANIFEST_INVALID.
+func TestPackageInstallFailsWithoutManifest(t *testing.T) {
+	projectRoot := t.TempDir()
+	for _, directory := range []string{"Assets", "ProjectSettings", "Packages"} {
+		if err := os.MkdirAll(filepath.Join(projectRoot, directory), 0o755); err != nil {
+			t.Fatalf("mkdir failed: %v", err)
+		}
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(
+		context.Background(),
+		[]string{"package", "install", "--version", "1.2.3", "--project-path", projectRoot},
+		&stdout,
+		&stderr,
+	)
+	if code == 0 {
+		t.Fatal("expected failure without manifest")
+	}
+	if !strings.Contains(stderr.String(), "PACKAGE_MANIFEST_INVALID") {
+		t.Fatalf("expected PACKAGE_MANIFEST_INVALID:\n%s", stderr.String())
+	}
+}
+
+// Verifies status reports not installed when the package is absent.
+func TestPackageStatusReportsNotInstalled(t *testing.T) {
+	projectRoot := createPackageTestProject(t, barePackageManifest())
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(
+		context.Background(),
+		[]string{"package", "status", "--project-path", projectRoot},
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("status failed: code=%d stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, expected := range []string{
+		"Package: " + dispatcherUnityPackageName,
+		"Scoped registry: not installed",
+		"Dependency: not installed",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("status output missing %q:\n%s", expected, output)
+		}
+	}
+}
+
+// Verifies status reports the installed dependency version and registry.
+func TestPackageStatusReportsInstalledVersion(t *testing.T) {
+	projectRoot := createPackageTestProject(t, installedPackageManifest("1.2.3"))
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(
+		context.Background(),
+		[]string{"package", "status", "--project-path", projectRoot},
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("status failed: code=%d stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, expected := range []string{
+		"Scoped registry: installed (https://package.openupm.com)",
+		"Dependency: installed (1.2.3)",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("status output missing %q:\n%s", expected, output)
+		}
+	}
+}
+
+// Verifies an unknown package subcommand fails with guidance for valid subcommands.
+func TestPackageUnknownSubcommandFails(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(context.Background(), []string{"package", "bogus"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected exit 1, got %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "uloop package install") || !strings.Contains(stderr.String(), "uloop package status") {
+		t.Fatalf("expected valid subcommand guidance:\n%s", stderr.String())
+	}
+}
+
+func createPackageTestProject(t *testing.T, manifest string) string {
+	t.Helper()
+	projectRoot := t.TempDir()
+	for _, directory := range []string{"Assets", "ProjectSettings", "Packages"} {
+		if err := os.MkdirAll(filepath.Join(projectRoot, directory), 0o755); err != nil {
+			t.Fatalf("failed to create %s: %v", directory, err)
+		}
+	}
+	manifestPath := filepath.Join(projectRoot, "Packages", "manifest.json")
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+	return projectRoot
+}
+
+func barePackageManifest() string {
+	return `{
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0"
+  }
+}
+`
+}
+
+func installedPackageManifest(version string) string {
+	return `{
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0",
+    "io.github.hatayama.uloopmcp": "` + version + `"
+  },
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.com",
+      "url": "https://package.openupm.com",
+      "scopes": [
+        "io.github.hatayama.uloopmcp"
+      ]
+    }
+  ]
+}
+`
+}
+
+func readPackageManifest(t *testing.T, projectRoot string) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(projectRoot, "Packages", "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest failed: %v", err)
+	}
+	return string(content)
+}
+
+func stubOpenUPMRegistry(t *testing.T, body string) func() {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/"+dispatcherUnityPackageName {
+			t.Fatalf("unexpected path: %s", request.URL.Path)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(body))
+	}))
+	previousURL := openUPMRegistryBaseURL
+	previousClient := packageRegistryHTTPClient
+	openUPMRegistryBaseURL = server.URL
+	packageRegistryHTTPClient = server.Client()
+	return func() {
+		server.Close()
+		openUPMRegistryBaseURL = previousURL
+		packageRegistryHTTPClient = previousClient
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -178,7 +178,7 @@ func shouldKeepDispatcherProcessCommand(args []string) bool {
 		return true
 	}
 	switch args[0] {
-	case clicore.InstallCommandName, clicore.UpdateCommandName, clicore.UninstallCommandName, clicore.LaunchCommandName, clicore.CompletionCommand:
+	case clicore.InstallCommandName, clicore.UpdateCommandName, clicore.UninstallCommandName, clicore.LaunchCommandName, clicore.CompletionCommand, clicore.PackageCommandName:
 		return true
 	default:
 		return false

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "7d1b8798dc431bb9af2a7c041d813f98e9cf69c5"
+  "sharedInputsHash": "a766d75f22284a30478ed17847ae3f8e99fd36a5"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "65ea078fb375813bc25aa1fa561c626db40700f7"
+  "sharedInputsHash": "d429ad0bf002a8f7cccbc2d58fdfd707d281f42f"
 }


### PR DESCRIPTION
## Summary

- Add dispatcher-owned `uloop package install` / `uloop package status` so agents and CI can bootstrap the Unity package from a terminal without Package Manager UI.
- `install` writes the OpenUPM scoped registry and `io.github.hatayama.uloopmcp` into `Packages/manifest.json` (latest from OpenUPM, or `--version`), preserving key order / CRLF / trailing newlines and using an atomic rewrite.
- `status` reports registry and dependency state with exit 0; README documents the terminal path while keeping the manual OpenUPM steps.

Closes #2077

## User Impact

AI agents and CI can run `uloop package install` (optionally `--project-path` / `--version`) and `uloop package status` to add or inspect the Unity CLI Loop package without opening Unity Package Manager.

## Test plan

- [x] `cd cli/common && go test ./clicore/`
- [x] `cd cli/dispatcher && go test ./...`
- [x] `scripts/check-go-cli.sh`
- [x] `cd cli/release-automation && go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD`
- [x] Manual: `dist/darwin-arm64/uloop package install --project-path <temp>` against live OpenUPM, then `package status` shows installed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

