### PR TITLE
fix: terminal install works with curl alone by trusting the repository pin

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -165,6 +165,7 @@ jobs:
           $null = [scriptblock]::Create((Get-Content -Raw -Encoding UTF8 scripts/test-simulate-mouse-demo.ps1))
           $null = [scriptblock]::Create((Get-Content -Raw -Encoding UTF8 Assets/Tests/Demo/scripts/verify-replay-via-cli.ps1))
           $null = [scriptblock]::Create((Get-Content -Raw -Encoding UTF8 scripts/test-powershell51-native-argument-escaping.ps1))
+          $null = [scriptblock]::Create((Get-Content -Raw -Encoding UTF8 scripts/test-install-pin-resolution.ps1))
 
       - name: Test release installer smoke helper
         shell: powershell
@@ -173,6 +174,10 @@ jobs:
       - name: Test Windows PowerShell native argument escaping
         shell: powershell
         run: .\scripts\test-powershell51-native-argument-escaping.ps1
+
+      - name: Test install pin resolution in Windows PowerShell
+        shell: powershell
+        run: .\scripts\test-install-pin-resolution.ps1
 
   test-unity-package:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,6 +52,9 @@ jobs:
           scripts/test-dispatcher-publish-workflow.sh
           scripts/test-distribute-attestation-bundles.sh
           scripts/test-install-release-filter.sh
+          scripts/test-install-pin-manifest.sh
+          scripts/test-install-archive-manifest.sh
+          scripts/test-install-version-format.sh
           scripts/test-bootstrap-manifest-from-bundle.sh
 
       - name: Check IPC protocol reminder

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ V2 delegation requires Node.js 22 or later, including npm for the first command 
 <summary>CLI-only terminal install</summary>
 
 Use this only when you want to install the standalone global CLI without opening Unity package setup.
+The installer verifies the downloaded archive against the digest list in
+`Packages/src/project-runner-pin.json` (same pin Unity's **Install CLI** button uses).
+Optional env: `ULOOP_REF` (git ref for the pin; default `main`), `ULOOP_INSTALL_DIR`.
+`ULOOP_VERSION` is accepted only when it matches the pin's `dispatcherReleaseTag`.
+
+On macOS or Windows Git Bash:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/install.sh | sh
+```
+
+On Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/install.ps1 | iex
+```
+
+#### Manual attestation-verified install (choose your own release tag)
 
 Install `gh` and `jq` through your operating-system or package channel first. The bootstrap does not install
 or fall back from `gh`. Select the immutable dispatcher Release tag and its source branch; use

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ On Windows PowerShell:
 irm https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/install.ps1 | iex
 ```
 
-#### Manual attestation-verified install (choose your own release tag)
+### Manual attestation-verified install (choose your own release tag)
 
 Install `gh` and `jq` through your operating-system or package channel first. The bootstrap does not install
 or fall back from `gh`. Select the immutable dispatcher Release tag and its source branch; use

--- a/README_ja.md
+++ b/README_ja.md
@@ -109,11 +109,27 @@ v2への委譲には、初回コマンドでcacheを作成するnpmを含むNode
 <summary>CLIだけをterminalからinstallする場合はこちら</summary>
 
 Unity Package の setup を開かず、standalone の global CLI だけを入れたい場合に使ってください。
+インストーラは `Packages/src/project-runner-pin.json` の digest 一覧でアーカイブを検証します（Unity の **Install CLI** ボタンと同じ pin）。
+任意の環境変数: `ULOOP_REF`（pin を取る git ref。既定は `main`）、`ULOOP_INSTALL_DIR`。
+`ULOOP_VERSION` は pin の `dispatcherReleaseTag` と一致する場合のみ有効です。
 
 > [!NOTE]
-> このコマンドが冗長なのはセキュリティのためです。ダウンロードしたインストーラと成果物が、このリポジトリのCIが実際にビルドしたものと一致することをsigstore attestationで検証してから実行します。UnityのGUI（**Install CLI** ボタン）も同じ検証済みdigestとの照合を行っていますが、そちらはCIがリリース時に検証した結果をパッケージ内に持っているため、`gh` や `jq` は不要です。
->
-> 冗長ですが、下記のブロックはコピペしてそのまま一気に実行できます。
+> terminal install も Unity GUI と同じ repository pin を信頼源にします。明示的に
+> `ULOOP_ARCHIVE_MANIFEST`（Sigstore 検証由来）を渡す手動フローは、任意の release tag を選ぶ hardened option として残っています。
+
+macOS、Windows Git Bash の場合:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/install.sh | sh
+```
+
+Windows PowerShell の場合:
+
+```powershell
+irm https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/install.ps1 | iex
+```
+
+#### 手動の attestation 検証付き install（release tag を自分で選ぶ）
 
 最初にOSまたはパッケージ管理経由で`gh`（ログイン済み）と`jq`を導入してください。以下のコマンドはこの2つを自動では導入せず、代替手段にもフォールバックしません。最新のdispatcher Release tagは自動で解決されます。特定のバージョンを入れたい場合は、`RELEASE_TAG`にimmutableなタグ（例: `dispatcher-v3.0.0`）を直接指定してください。
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -129,7 +129,7 @@ Windows PowerShell の場合:
 irm https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/install.ps1 | iex
 ```
 
-#### 手動の attestation 検証付き install（release tag を自分で選ぶ）
+### 手動の attestation 検証付き install（release tag を自分で選ぶ）
 
 最初にOSまたはパッケージ管理経由で`gh`（ログイン済み）と`jq`を導入してください。以下のコマンドはこの2つを自動では導入せず、代替手段にもフォールバックしません。最新のdispatcher Release tagは自動で解決されます。特定のバージョンを入れたい場合は、`RELEASE_TAG`にimmutableなタグ（例: `dispatcher-v3.0.0`）を直接指定してください。
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,33 +17,30 @@ When reporting a vulnerability, please include:
 
 ### First-install provenance decision
 
-The repository owner approved the following first-install trust model.
+The repository owner approved the following first-install trust model
+(issue #2080 replaces the earlier decision that CLI-only install required `gh`
+and forbade a mutable-branch `curl | sh` / `irm | iex` path).
 
-- CLI-only installation requires a preinstalled GitHub CLI (`gh`) obtained
-  through the user's operating-system or package channel. The installer never
-  downloads or bootstraps `gh`. The README bootstrap downloads the installer
-  script and its Sigstore bundle from an immutable dispatcher Release, verifies
-  the script with `gh attestation verify`, and only then executes it. The
-  verified installer verifies the selected archive and its bundle before
-  extraction or execution. A missing `gh` is a hard failure.
-- Unity installation treats the already-installed Unity package as its trust
-  root. Package-release automation verifies the dispatcher Release attestation
-  and stamps its verified subject digests into the package pin. The device
-  enforces those digests by SHA-256 pinning before it executes a downloaded
-  installer script, so Unity installation does not require external `gh` or an
-  embedded verifier.
-- CLI-only verification enforces the exact repository, signer workflow
-  `.github/workflows/dispatcher-publish.yml`, an allowed source ref of
-  `refs/heads/main` or `refs/heads/v3-beta`, an attested source digest equal to
-  the resolved immutable Release tag commit, and a subject digest equal to the
-  downloaded installer or archive. Package-release automation verifies that
-  same policy before it stamps Unity's pinned subject digests. A same-origin
-  checksum provides integrity only and is never authentication.
-- Offline first installation is unsupported. Network or GitHub API failure,
-  missing verifier, missing or malformed bundle, identity mismatch, tag
-  mismatch, and digest mismatch all fail closed before script or binary
-  execution. There is no checksum-only fallback and no mutable-branch
-  `curl | sh` or `irm | iex` path.
+- The default CLI-only install trusts the repository pin
+  (`Packages/src/project-runner-pin.json` → `dispatcherArchiveManifest`).
+  Release automation stamps that digest list after verifying the published
+  release's attestation subjects, and CI requires an exact match. The
+  installer fetches the pin over TLS from `raw.githubusercontent.com` on a
+  protected branch (default `main`; override with `ULOOP_REF`) and enforces
+  those digests by SHA-256 before extraction.
+- An explicit `ULOOP_ARCHIVE_MANIFEST` (typically from a Sigstore-verified
+  attestation) always takes precedence over the pin. The README's
+  `gh attestation verify` + `jq` flow remains available as a hardened option
+  when choosing a release tag other than the pin.
+- Unity installation uses the same pin fields from the already-installed
+  package, so terminal and GUI share one trust root. Remaining gaps (Sigstore
+  chains to the signing workflow; repository trust chains to branch
+  protection) are identical across those paths — this change introduces no
+  new regression relative to the Unity GUI install.
+- Offline first installation is unsupported. Network failure, a missing or
+  malformed pin, an invalid `ULOOP_REF`, a tag/`ULOOP_VERSION` mismatch, and
+  digest mismatch all fail closed before script or binary execution. There is
+  no checksum-only fallback.
 
 OS-native signing remains a later defense-in-depth release improvement; it is
 not a prerequisite for this bootstrap verification work.

--- a/cli/dispatcher/internal/dispatcher/update.go
+++ b/cli/dispatcher/internal/dispatcher/update.go
@@ -112,6 +112,10 @@ func runUpdateCommand(ctx context.Context, updateCommand update.Command, stdout 
 	command.Stdout = stdout
 	command.Stderr = stderr
 	env := append(os.Environ(), updateCommand.Env...)
+	// Why: installer scripts now fall back to the repository pin when this env
+	// var is absent; self-update MUST keep passing the Sigstore-derived
+	// manifest explicitly so the update installs the requested release tag
+	// rather than the pinned one.
 	env = append(env, updateArchiveManifestEnvName+"="+manifest)
 	command.Env = env
 	return command.Run()

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d04c153e18a833271be907e3c20db213f9488652"
+  "sharedInputsHash": "b2ac9823a3c47b5fec9ec4fb5104c119d393e7fb"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "a766d75f22284a30478ed17847ae3f8e99fd36a5"
+  "sharedInputsHash": "d04c153e18a833271be907e3c20db213f9488652"
 }

--- a/docs/project-runner-pin.md
+++ b/docs/project-runner-pin.md
@@ -15,7 +15,11 @@ for cross-component version requirements. Its required fields:
   release used for first installation and its verified asset hashes. Stamped by automation
   against a published release; never edit by hand — `VerifyDispatcherPinSubjects` requires the
   manifest to match the published release's verified subjects exactly, so a hand-written value
-  cannot pass CI (see `docs/dispatcher-pin-release-order.md`).
+  cannot pass CI (see `docs/dispatcher-pin-release-order.md`). Consumers: Unity's **Install CLI**
+  path (via `CliPinReader` / `NativeCliCommandBuilder`) and the terminal installers
+  (`scripts/install.sh` / `scripts/install.ps1`) when `ULOOP_ARCHIVE_MANIFEST` is unset — they
+  fetch this pin and use `dispatcherReleaseTag` as the install target plus
+  `dispatcherArchiveManifest` as the attestation digest list.
 
 There is no dispatcher⇄package integer contract generation; the pin's semver
 floor is the only dispatcher gate. The IPC `protocolVersion` pair (see

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4,6 +4,9 @@ $Repository = "hatayama/unity-cli-loop"
 $Version = if ($env:ULOOP_VERSION) { $env:ULOOP_VERSION } else { "latest" }
 $LatestVersion = "latest"
 $LatestBetaVersion = "latest-beta"
+$DefaultPinRef = "main"
+$PinRef = if ($env:ULOOP_REF) { $env:ULOOP_REF } else { $DefaultPinRef }
+$ResolvedArchiveManifest = $null
 $InstallDir = if ($env:ULOOP_INSTALL_DIR) {
     $env:ULOOP_INSTALL_DIR
 } else {
@@ -72,6 +75,110 @@ function Find-LatestAssetUrl {
         $Page += 1
     }
 }
+
+# Why: ULOOP_REF is interpolated into a raw.githubusercontent.com URL. Reject
+# empty values, path traversal (`..`), and characters outside the ref alphabet
+# so a hostile env cannot break out of the intended pin path.
+function Test-UloopRefFormat {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Candidate
+    )
+
+    if ([string]::IsNullOrEmpty($Candidate) -or $Candidate.Contains("..") -or ($Candidate -notmatch '^[0-9A-Za-z._/-]+$')) {
+        throw "Invalid ULOOP_REF: $Candidate. Expected a git ref such as 'main' or 'v3-beta'."
+    }
+}
+
+function Get-UloopPinJson {
+    $PinUrl = "https://raw.githubusercontent.com/$Repository/$PinRef/Packages/src/project-runner-pin.json"
+    return (Invoke-WebRequest -UseBasicParsing -Uri $PinUrl).Content
+}
+
+function ConvertFrom-UloopPinDocument {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$JsonText
+    )
+
+    return ($JsonText | ConvertFrom-Json)
+}
+
+# Why: ConvertFrom-Json already expands JSON escapes, so fail-closed validation
+# of the expanded manifest is the PowerShell-side counterpart to install.sh's
+# unescape + validate pair. Accept A-F to stay symmetric with CliPinReaderService.
+function Test-UloopPinManifestFormat {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Manifest
+    )
+
+    if ($Manifest.Contains("`r")) {
+        throw "project-runner pin dispatcherArchiveManifest must not contain CR"
+    }
+
+    $Seen = @{}
+    $Count = 0
+    foreach ($Line in ($Manifest -split "`n")) {
+        if ([string]::IsNullOrEmpty($Line)) {
+            continue
+        }
+        if ($Line -notmatch '^[0-9a-fA-F]{64}  \S+$') {
+            throw "project-runner pin dispatcherArchiveManifest has an invalid line"
+        }
+        $Name = ($Line -split "  ", 2)[1]
+        if ($Seen.ContainsKey($Name)) {
+            throw "project-runner pin dispatcherArchiveManifest has a duplicate filename"
+        }
+        $Seen[$Name] = $true
+        $Count += 1
+    }
+    if ($Count -eq 0) {
+        throw "project-runner pin dispatcherArchiveManifest is empty"
+    }
+}
+
+function Resolve-UloopManifestFromPin {
+    $ExistingManifest = [Environment]::GetEnvironmentVariable("ULOOP_ARCHIVE_MANIFEST")
+    if (-not [string]::IsNullOrEmpty($ExistingManifest)) {
+        return
+    }
+
+    Test-UloopRefFormat -Candidate $PinRef
+
+    $PinUrl = "https://raw.githubusercontent.com/$Repository/$PinRef/Packages/src/project-runner-pin.json"
+    try {
+        $PinJsonText = Get-UloopPinJson
+    } catch {
+        throw "Could not fetch project-runner pin from $PinUrl. Set ULOOP_ARCHIVE_MANIFEST from a verified attestation (see README), or fix ULOOP_REF."
+    }
+
+    $PinDocument = ConvertFrom-UloopPinDocument -JsonText $PinJsonText
+    if ([string]::IsNullOrEmpty([string]$PinDocument.dispatcherReleaseTag)) {
+        throw "project-runner pin is missing dispatcherReleaseTag"
+    }
+    if ([string]::IsNullOrEmpty([string]$PinDocument.dispatcherArchiveManifest)) {
+        throw "project-runner pin is missing dispatcherArchiveManifest"
+    }
+
+    $PinTag = [string]$PinDocument.dispatcherReleaseTag
+    $PinManifest = [string]$PinDocument.dispatcherArchiveManifest
+    Test-UloopPinManifestFormat -Manifest $PinManifest
+    Test-UloopVersionFormat -Candidate $PinTag
+
+    if ($Version -eq $LatestVersion -or $Version -eq $LatestBetaVersion) {
+        $script:Version = $PinTag
+        Write-Host "Using dispatcher release $($script:Version) pinned at $PinRef"
+    } elseif ($Version -ne $PinTag) {
+        throw "ULOOP_VERSION ($Version) does not match the pin dispatcherReleaseTag ($PinTag) at $PinRef. Unset ULOOP_VERSION, or supply ULOOP_ARCHIVE_MANIFEST from a verified attestation (see README)."
+    }
+
+    $script:ResolvedArchiveManifest = $PinManifest
+}
+
+Resolve-UloopManifestFromPin
 
 if ($Version -eq $LatestVersion -or $Version -eq $LatestBetaVersion) {
     $ReleaseChannel = if ($Version -eq $LatestBetaVersion) { "beta" } else { "stable" }
@@ -517,7 +624,10 @@ try {
     # Enforcing the manifest entry stops a swapped archive from being blessed by
     # a compromised same-origin .sha256. Missing env must fail before archive
     # extraction because same-origin checksums are not authentication.
-    $Manifest = [Environment]::GetEnvironmentVariable("ULOOP_ARCHIVE_MANIFEST")
+    $Manifest = $ResolvedArchiveManifest
+    if ([string]::IsNullOrEmpty($Manifest)) {
+        $Manifest = [Environment]::GetEnvironmentVariable("ULOOP_ARCHIVE_MANIFEST")
+    }
     if ([string]::IsNullOrEmpty($Manifest)) {
         throw "Attestation manifest is required"
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,8 @@ INSTALL_DIR="${ULOOP_INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${ULOOP_VERSION:-latest}"
 LATEST_VERSION="latest"
 LATEST_BETA_VERSION="latest-beta"
+DEFAULT_PIN_REF="main"
+PIN_REF="${ULOOP_REF:-$DEFAULT_PIN_REF}"
 
 # Why: install.sh interpolates $VERSION into
 # "https://github.com/$REPOSITORY/releases/download/$VERSION/..." without
@@ -359,6 +361,122 @@ set_download_urls() {
   checksum_url="$download_url.sha256"
 }
 
+# Why: ULOOP_REF is interpolated into a raw.githubusercontent.com URL. Reject
+# empty values, path traversal (`..`), and any character outside the ref
+# alphabet so a hostile env cannot break out of the intended pin path.
+validate_uloop_ref() {
+  candidate=$1
+  case $candidate in
+    ''|*..*|*[!0-9A-Za-z._/-]*)
+      echo "Invalid ULOOP_REF: $candidate" >&2
+      echo "Expected a git ref such as 'main' or 'v3-beta'." >&2
+      exit 1
+      ;;
+  esac
+}
+
+fetch_pin_json() {
+  curl -fsSL "https://raw.githubusercontent.com/$REPOSITORY/$PIN_REF/Packages/src/project-runner-pin.json"
+}
+
+# Why: the pin is pretty-printed with one key per physical line and the
+# manifest value keeps JSON `\n` escapes. Extract the raw (still-escaped)
+# string so unescape_pin_manifest can fail closed on unexpected escapes.
+extract_pin_string_field() {
+  printf '%s\n' "$pin_json" | awk -v key="$1" '
+    {
+      prefix = "\"" key "\": \""
+      i = index($0, prefix)
+      if (i == 0) next
+      value = substr($0, i + length(prefix))
+      if (value !~ /",?[[:space:]]*$/) exit 1
+      sub(/",?[[:space:]]*$/, "", value)
+      print value
+      found = 1
+      exit
+    }
+    END { if (!found) exit 1 }
+  '
+}
+
+# Why: only `\n` is a legitimate escape in dispatcherArchiveManifest. Any
+# other backslash residue means the pin shape drifted or was tampered with.
+unescape_pin_manifest() {
+  printf '%s\n' "$1" | awk '
+    {
+      residue = $0
+      gsub(/\\n/, "", residue)
+      if (residue ~ /\\/) exit 1
+      line = $0
+      gsub(/\\n/, "\n", line)
+      print line
+    }
+  '
+}
+
+# Why: keep the installer symmetric with CliPinReaderService — 64 hex digits
+# (A-F accepted), exactly two spaces, no whitespace in the filename, no CR,
+# no duplicates, and at least one line.
+validate_pin_manifest() {
+  printf '%s\n' "$1" | awk '
+    BEGIN { count = 0 }
+    {
+      if ($0 ~ /\r/) exit 1
+      if ($0 == "") next
+      if ($0 !~ /^[0-9a-fA-F]{64}  [^ \t]+$/) exit 1
+      name = $2
+      if (seen[name]++) exit 1
+      count++
+    }
+    END { if (count == 0) exit 1 }
+  '
+}
+
+resolve_manifest_from_pin_if_needed() {
+  if [ -n "${ULOOP_ARCHIVE_MANIFEST:-}" ]; then
+    return 0
+  fi
+
+  validate_uloop_ref "$PIN_REF"
+
+  pin_json=$(fetch_pin_json) || {
+    echo "Could not fetch project-runner pin from https://raw.githubusercontent.com/$REPOSITORY/$PIN_REF/Packages/src/project-runner-pin.json" >&2
+    echo "Set ULOOP_ARCHIVE_MANIFEST from a verified attestation (see README), or fix ULOOP_REF." >&2
+    exit 1
+  }
+
+  pin_tag=$(extract_pin_string_field dispatcherReleaseTag) || {
+    echo "project-runner pin is missing dispatcherReleaseTag" >&2
+    exit 1
+  }
+  raw=$(extract_pin_string_field dispatcherArchiveManifest) || {
+    echo "project-runner pin is missing dispatcherArchiveManifest" >&2
+    exit 1
+  }
+  pin_manifest=$(unescape_pin_manifest "$raw") || {
+    echo "project-runner pin dispatcherArchiveManifest has an unexpected escape sequence" >&2
+    exit 1
+  }
+  validate_pin_manifest "$pin_manifest" || {
+    echo "project-runner pin dispatcherArchiveManifest failed format validation" >&2
+    exit 1
+  }
+  validate_uloop_version "$pin_tag"
+
+  if [ "$VERSION" = "$LATEST_VERSION" ] || [ "$VERSION" = "$LATEST_BETA_VERSION" ]; then
+    VERSION=$pin_tag
+    echo "Using dispatcher release $VERSION pinned at $PIN_REF"
+  elif [ "$VERSION" = "$pin_tag" ]; then
+    :
+  else
+    echo "ULOOP_VERSION ($VERSION) does not match the pin dispatcherReleaseTag ($pin_tag) at $PIN_REF." >&2
+    echo "Unset ULOOP_VERSION, or supply ULOOP_ARCHIVE_MANIFEST from a verified attestation (see README)." >&2
+    exit 1
+  fi
+
+  ULOOP_ARCHIVE_MANIFEST=$pin_manifest
+}
+
 extract_asset() {
   case "$asset_name" in
     *.zip)
@@ -447,6 +565,7 @@ if is_legacy_npm_uloop_path "$legacy_uloop_before_install"; then
 fi
 download_url=""
 checksum_url=""
+resolve_manifest_from_pin_if_needed
 set_download_urls
 
 tmp_dir=$(mktemp -d)

--- a/scripts/test-install-pin-manifest.sh
+++ b/scripts/test-install-pin-manifest.sh
@@ -1,0 +1,146 @@
+#!/bin/sh
+# Verifies install.sh pin-manifest helpers: field extraction, \n-only unescape,
+# fail-closed manifest validation, and ULOOP_REF format checks. Extracts the
+# real functions from install.sh so a later refactor cannot silently drift.
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+INSTALL_SCRIPT="$ROOT_DIR/scripts/install.sh"
+
+if ! command -v awk >/dev/null 2>&1; then
+  echo "awk is required for this test" >&2
+  exit 1
+fi
+
+extract_function() {
+  name=$1
+  awk -v want="$name" '
+    $0 ~ ("^" want "\\(\\)") { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { exit }
+  ' "$INSTALL_SCRIPT"
+}
+
+expect_pass() {
+  label=$1
+  shift
+  if ! ("$@") 2>/dev/null; then
+    echo "FAIL: $label — expected pass but got failure" >&2
+    exit 1
+  fi
+}
+
+expect_fail() {
+  label=$1
+  shift
+  if ("$@") 2>/dev/null; then
+    echo "FAIL: $label — expected failure but got pass" >&2
+    exit 1
+  fi
+}
+
+eval "$(extract_function extract_pin_string_field)"
+eval "$(extract_function unescape_pin_manifest)"
+eval "$(extract_function validate_pin_manifest)"
+eval "$(extract_function validate_uloop_ref)"
+
+HEX64_LOWER="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+HEX64_UPPER="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+HEX63="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+# Pretty-print fixture matches the real pin shape: each key on its own line.
+# \\n in the unquoted heredoc becomes the two-character JSON escape \n.
+pin_json=$(cat <<PIN
+{
+  "dispatcherArchiveManifest": "${HEX64_LOWER}  uloop-dispatcher-darwin-arm64.tar.gz\\n${HEX64_LOWER}  install.sh",
+  "dispatcherReleaseTag": "dispatcher-v3.1.0-beta.16",
+  "minimumDispatcherVersion": "3.0.0-beta.19",
+  "projectRunnerVersion": "3.0.0-beta.64"
+}
+PIN
+)
+
+tag=$(extract_pin_string_field dispatcherReleaseTag) || {
+  echo "FAIL: extract dispatcherReleaseTag from fixture" >&2
+  exit 1
+}
+if [ "$tag" != "dispatcher-v3.1.0-beta.16" ]; then
+  echo "FAIL: unexpected dispatcherReleaseTag: $tag" >&2
+  exit 1
+fi
+
+raw=$(extract_pin_string_field dispatcherArchiveManifest) || {
+  echo "FAIL: extract dispatcherArchiveManifest from fixture" >&2
+  exit 1
+}
+expected_raw="${HEX64_LOWER}  uloop-dispatcher-darwin-arm64.tar.gz\\n${HEX64_LOWER}  install.sh"
+if [ "$raw" != "$expected_raw" ]; then
+  echo "FAIL: unexpected raw dispatcherArchiveManifest: $raw" >&2
+  exit 1
+fi
+
+# Missing keys must fail closed.
+pin_json=$(cat <<PIN
+{
+  "dispatcherReleaseTag": "dispatcher-v3.1.0-beta.16",
+  "minimumDispatcherVersion": "3.0.0-beta.19",
+  "projectRunnerVersion": "3.0.0-beta.64"
+}
+PIN
+)
+expect_fail "missing dispatcherArchiveManifest" extract_pin_string_field dispatcherArchiveManifest
+
+pin_json=$(cat <<PIN
+{
+  "dispatcherArchiveManifest": "${HEX64_LOWER}  install.sh",
+  "minimumDispatcherVersion": "3.0.0-beta.19",
+  "projectRunnerVersion": "3.0.0-beta.64"
+}
+PIN
+)
+expect_fail "missing dispatcherReleaseTag" extract_pin_string_field dispatcherReleaseTag
+
+# \n expands to real newlines; line count and contents must match.
+unescaped=$(unescape_pin_manifest "$expected_raw") || {
+  echo "FAIL: unescape of \\n-only value" >&2
+  exit 1
+}
+line_count=$(printf '%s\n' "$unescaped" | awk 'END { print NR }')
+if [ "$line_count" != "2" ]; then
+  echo "FAIL: expected 2 unescaped lines, got $line_count" >&2
+  exit 1
+fi
+assert_line=$(printf '%s\n' "$unescaped" | awk 'NR==1 { print }')
+if [ "$assert_line" != "${HEX64_LOWER}  uloop-dispatcher-darwin-arm64.tar.gz" ]; then
+  echo "FAIL: unexpected first unescaped line: $assert_line" >&2
+  exit 1
+fi
+assert_line=$(printf '%s\n' "$unescaped" | awk 'NR==2 { print }')
+if [ "$assert_line" != "${HEX64_LOWER}  install.sh" ]; then
+  echo "FAIL: unexpected second unescaped line: $assert_line" >&2
+  exit 1
+fi
+
+# Fail-closed on unexpected escapes.
+expect_fail "reject CR escape" unescape_pin_manifest "${HEX64_LOWER}  install.sh\\r"
+expect_fail "reject quote escape" unescape_pin_manifest "${HEX64_LOWER}  \\\"evil\\\""
+expect_fail "reject backslash escape" unescape_pin_manifest "${HEX64_LOWER}  install\\\\.sh"
+
+# Manifest validation: length/spacing fail; uppercase hex passes (C# symmetry).
+expect_fail "reject 63-digit digest" validate_pin_manifest "${HEX63}  install.sh"
+expect_fail "reject single-space separator" validate_pin_manifest "${HEX64_LOWER} install.sh"
+expect_pass "accept uppercase hex digest" validate_pin_manifest "${HEX64_UPPER}  install.sh"
+expect_fail "reject duplicate filenames" validate_pin_manifest "${HEX64_LOWER}  install.sh
+${HEX64_UPPER}  install.sh"
+expect_fail "reject empty manifest" validate_pin_manifest ""
+expect_fail "reject CR in expanded manifest" validate_pin_manifest "${HEX64_LOWER}  install.sh$(printf '\r')"
+
+# Ref validation takes the candidate as $1 (same interface as validate_uloop_version).
+expect_pass "accept v3-beta ref" validate_uloop_ref "v3-beta"
+expect_pass "accept main ref" validate_uloop_ref "main"
+expect_pass "accept release/1.0 ref" validate_uloop_ref "release/1.0"
+expect_fail "reject empty ref" validate_uloop_ref ""
+expect_fail "reject path traversal ref" validate_uloop_ref "../evil"
+expect_fail "reject space in ref" validate_uloop_ref "a b"
+
+echo "OK"

--- a/scripts/test-install-pin-resolution.ps1
+++ b/scripts/test-install-pin-resolution.ps1
@@ -163,6 +163,28 @@ function Get-UloopPinJson {
 $env:ULOOP_ARCHIVE_MANIFEST = $null
 Remove-Item Env:ULOOP_ARCHIVE_MANIFEST -ErrorAction SilentlyContinue
 
+# Explicit manifest: early return without fetching pin or rewriting Version.
+# Why: Windows self-update must keep the requested tag (via env manifest) and
+# must not replace it with the repository pin. MockPinFetchFail=true would throw
+# if Resolve incorrectly called Get-UloopPinJson.
+$script:MockPinFetchFail = $true
+$script:MockPinJsonText = $PinJson
+$Version = "latest"
+$ResolvedArchiveManifest = $null
+$PinRef = "main"
+$env:ULOOP_ARCHIVE_MANIFEST = "$Hex64Lower  uloop-dispatcher-windows-amd64.zip"
+try {
+    Resolve-UloopManifestFromPin
+    if ($Version -ne "latest") {
+        throw "FAIL: explicit manifest must leave Version unchanged, got $Version"
+    }
+    if ($null -ne $ResolvedArchiveManifest) {
+        throw "FAIL: explicit manifest must leave ResolvedArchiveManifest null"
+    }
+} finally {
+    Remove-Item Env:ULOOP_ARCHIVE_MANIFEST -ErrorAction SilentlyContinue
+}
+
 # Success: latest -> pin tag, ResolvedArchiveManifest populated.
 $script:MockPinFetchFail = $false
 $script:MockPinJsonText = $PinJson

--- a/scripts/test-install-pin-resolution.ps1
+++ b/scripts/test-install-pin-resolution.ps1
@@ -1,0 +1,196 @@
+<#
+Verifies install.ps1 pin-manifest helpers via AST extraction: document parse,
+manifest format (including uppercase hex), ref format, and Resolve-UloopManifestFromPin
+with Get-UloopPinJson shadowed for success / fetch-failure / version-mismatch.
+Windows PowerShell 5.1 compatible — no ternary, null-coalescing, or ForEach -Parallel.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$InstallScriptPath = Join-Path $PSScriptRoot "install.ps1"
+$Hex64Lower = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+$Hex64Upper = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+$Hex63 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+function Get-InstallScriptFunction {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FunctionName
+    )
+
+    $Tokens = $null
+    $Errors = $null
+    $Ast = [System.Management.Automation.Language.Parser]::ParseFile(
+        $InstallScriptPath,
+        [ref]$Tokens,
+        [ref]$Errors
+    )
+    if ($Errors -and $Errors.Count -gt 0) {
+        throw "Failed to parse install.ps1: $($Errors[0].Message)"
+    }
+
+    $FunctionAst = $Ast.FindAll(
+        {
+            param($Node)
+            return (
+                $Node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $Node.Name -eq $FunctionName
+            )
+        },
+        $true
+    ) | Select-Object -First 1
+
+    if ($null -eq $FunctionAst) {
+        throw "install.ps1 does not define function $FunctionName"
+    }
+
+    return $FunctionAst.Extent.Text
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Label,
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Script
+    )
+
+    & $Script
+    if (-not $?) {
+        throw "FAIL: $Label — expected success"
+    }
+}
+
+function Assert-Throws {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Label,
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Script
+    )
+
+    $Threw = $false
+    try {
+        & $Script
+    } catch {
+        $Threw = $true
+    }
+    if (-not $Threw) {
+        throw "FAIL: $Label — expected failure"
+    }
+}
+
+# Script-scope values the extracted helpers close over / read.
+$Repository = "hatayama/unity-cli-loop"
+$LatestVersion = "latest"
+$LatestBetaVersion = "latest-beta"
+$DefaultPinRef = "main"
+$PinRef = $DefaultPinRef
+$Version = "latest"
+$ResolvedArchiveManifest = $null
+
+. ([scriptblock]::Create((Get-InstallScriptFunction -FunctionName "Test-UloopVersionFormat")))
+. ([scriptblock]::Create((Get-InstallScriptFunction -FunctionName "Test-UloopRefFormat")))
+. ([scriptblock]::Create((Get-InstallScriptFunction -FunctionName "ConvertFrom-UloopPinDocument")))
+. ([scriptblock]::Create((Get-InstallScriptFunction -FunctionName "Test-UloopPinManifestFormat")))
+. ([scriptblock]::Create((Get-InstallScriptFunction -FunctionName "Resolve-UloopManifestFromPin")))
+
+$PinJson = @"
+{
+  "dispatcherArchiveManifest": "$Hex64Lower  uloop-dispatcher-windows-amd64.zip\n$Hex64Lower  install.ps1",
+  "dispatcherReleaseTag": "dispatcher-v3.1.0-beta.16",
+  "minimumDispatcherVersion": "3.0.0-beta.19",
+  "projectRunnerVersion": "3.0.0-beta.64"
+}
+"@
+
+$Document = ConvertFrom-UloopPinDocument -JsonText $PinJson
+if ($Document.dispatcherReleaseTag -ne "dispatcher-v3.1.0-beta.16") {
+    throw "FAIL: unexpected dispatcherReleaseTag: $($Document.dispatcherReleaseTag)"
+}
+$Expanded = [string]$Document.dispatcherArchiveManifest
+$Lines = @($Expanded -split "`n" | Where-Object { -not [string]::IsNullOrEmpty($_) })
+if ($Lines.Count -ne 2) {
+    throw "FAIL: expected 2 expanded manifest lines, got $($Lines.Count)"
+}
+if ($Lines[0] -ne "$Hex64Lower  uloop-dispatcher-windows-amd64.zip") {
+    throw "FAIL: unexpected first expanded line: $($Lines[0])"
+}
+
+Assert-Throws "missing dispatcherArchiveManifest" {
+    $Missing = '{"dispatcherReleaseTag":"dispatcher-v3.1.0-beta.16"}'
+    $Parsed = ConvertFrom-UloopPinDocument -JsonText $Missing
+    if ([string]::IsNullOrEmpty([string]$Parsed.dispatcherArchiveManifest)) {
+        throw "missing dispatcherArchiveManifest"
+    }
+}
+
+Assert-Throws "reject 63-digit digest" {
+    Test-UloopPinManifestFormat -Manifest "$Hex63  install.ps1"
+}
+Assert-Throws "reject single-space separator" {
+    Test-UloopPinManifestFormat -Manifest "$Hex64Lower install.ps1"
+}
+Assert-True "accept uppercase hex digest" {
+    Test-UloopPinManifestFormat -Manifest "$Hex64Upper  install.ps1"
+}
+Assert-Throws "reject duplicate filenames" {
+    Test-UloopPinManifestFormat -Manifest "$Hex64Lower  install.ps1`n$Hex64Upper  install.ps1"
+}
+Assert-Throws "reject empty manifest" {
+    Test-UloopPinManifestFormat -Manifest ""
+}
+Assert-Throws "reject CR in expanded manifest" {
+    Test-UloopPinManifestFormat -Manifest ("$Hex64Lower  install.ps1" + "`r")
+}
+
+Assert-True "accept v3-beta ref" { Test-UloopRefFormat -Candidate "v3-beta" }
+Assert-True "accept main ref" { Test-UloopRefFormat -Candidate "main" }
+Assert-True "accept release/1.0 ref" { Test-UloopRefFormat -Candidate "release/1.0" }
+Assert-Throws "reject empty ref" { Test-UloopRefFormat -Candidate "" }
+Assert-Throws "reject path traversal ref" { Test-UloopRefFormat -Candidate "../evil" }
+Assert-Throws "reject space in ref" { Test-UloopRefFormat -Candidate "a b" }
+
+# Shadow Get-UloopPinJson for Resolve-UloopManifestFromPin cases.
+function Get-UloopPinJson {
+    if ($script:MockPinFetchFail) {
+        throw "mock pin fetch failure"
+    }
+    return $script:MockPinJsonText
+}
+
+$env:ULOOP_ARCHIVE_MANIFEST = $null
+Remove-Item Env:ULOOP_ARCHIVE_MANIFEST -ErrorAction SilentlyContinue
+
+# Success: latest → pin tag, ResolvedArchiveManifest populated.
+$script:MockPinFetchFail = $false
+$script:MockPinJsonText = $PinJson
+$Version = "latest"
+$ResolvedArchiveManifest = $null
+$PinRef = "main"
+Resolve-UloopManifestFromPin
+if ($Version -ne "dispatcher-v3.1.0-beta.16") {
+    throw "FAIL: expected Version to become pin tag, got $Version"
+}
+if ([string]::IsNullOrEmpty($ResolvedArchiveManifest)) {
+    throw "FAIL: expected ResolvedArchiveManifest to be set"
+}
+
+# Fetch failure mentions ULOOP_ARCHIVE_MANIFEST.
+$script:MockPinFetchFail = $true
+$Version = "latest"
+$ResolvedArchiveManifest = $null
+Assert-Throws "pin fetch failure" {
+    Resolve-UloopManifestFromPin
+}
+
+# Version mismatch against pin tag.
+$script:MockPinFetchFail = $false
+$Version = "dispatcher-v9.9.9"
+$ResolvedArchiveManifest = $null
+Assert-Throws "pin version mismatch" {
+    Resolve-UloopManifestFromPin
+}
+
+Write-Host "OK"

--- a/scripts/test-install-pin-resolution.ps1
+++ b/scripts/test-install-pin-resolution.ps1
@@ -2,7 +2,7 @@
 Verifies install.ps1 pin-manifest helpers via AST extraction: document parse,
 manifest format (including uppercase hex), ref format, and Resolve-UloopManifestFromPin
 with Get-UloopPinJson shadowed for success / fetch-failure / version-mismatch.
-Windows PowerShell 5.1 compatible — no ternary, null-coalescing, or ForEach -Parallel.
+Windows PowerShell 5.1 compatible - no ternary, null-coalescing, or ForEach -Parallel.
 #>
 
 Set-StrictMode -Version Latest
@@ -58,7 +58,7 @@ function Assert-True {
 
     & $Script
     if (-not $?) {
-        throw "FAIL: $Label — expected success"
+        throw "FAIL: $Label - expected success"
     }
 }
 
@@ -77,7 +77,7 @@ function Assert-Throws {
         $Threw = $true
     }
     if (-not $Threw) {
-        throw "FAIL: $Label — expected failure"
+        throw "FAIL: $Label - expected failure"
     }
 }
 
@@ -163,7 +163,7 @@ function Get-UloopPinJson {
 $env:ULOOP_ARCHIVE_MANIFEST = $null
 Remove-Item Env:ULOOP_ARCHIVE_MANIFEST -ErrorAction SilentlyContinue
 
-# Success: latest → pin tag, ResolvedArchiveManifest populated.
+# Success: latest -> pin tag, ResolvedArchiveManifest populated.
 $script:MockPinFetchFail = $false
 $script:MockPinJsonText = $PinJson
 $Version = "latest"

--- a/scripts/test-install-release-filter.sh
+++ b/scripts/test-install-release-filter.sh
@@ -932,6 +932,10 @@ test_powershell_latest_skips_prerelease_assets() {
   assert_contains "$ROOT_DIR/scripts/install.ps1" 'Invoke-UloopNativeInstall -UloopPath $FinalUloopPath -Directory $InstallDir'
   assert_contains "$ROOT_DIR/scripts/install.ps1" 'Set-CurrentPathWithInstallDirectoryFirst -Directory $InstallDir'
   assert_contains "$ROOT_DIR/scripts/install.ps1" 'Invoke-CompatibilityWindowsInstall -Directory $InstallDir -ExpectedUloopPath $FinalUloopPath'
+  assert_contains "$ROOT_DIR/scripts/install.ps1" 'function Resolve-UloopManifestFromPin'
+  assert_contains "$ROOT_DIR/scripts/install.ps1" 'function Test-UloopPinManifestFormat'
+  assert_contains "$ROOT_DIR/scripts/install.ps1" 'raw.githubusercontent.com/$Repository/$PinRef/Packages/src/project-runner-pin.json'
+  assert_contains "$ROOT_DIR/scripts/install.ps1" '$DefaultPinRef = "main"'
   assert_not_contains "$ROOT_DIR/scripts/install.ps1" "ULOOP_REMOVE_LEGACY"
 }
 

--- a/scripts/test-install-release-filter.sh
+++ b/scripts/test-install-release-filter.sh
@@ -139,17 +139,27 @@ esac
 printf '%s\n' "$url" >> "$CURL_LOG"
 
 case "$url" in
+  */Packages/src/project-runner-pin.json)
+    # Why: pin URL handling must sit after CURL_LOG recording so tests can
+    # assert whether the pin fallback path was taken. Returning before the
+    # log (like the releases API case) would make "pin URL absent" vacuous.
+    if [ "${MOCK_PIN_FETCH_FAIL:-0}" = "1" ]; then
+      exit 22
+    fi
+    cat "$PIN_JSON"
+    exit 0
+    ;;
   *dispatcher-v2.0.0/uloop-dispatcher-darwin-arm64.tar.gz)
     : > "$output_file"
     ;;
   *dispatcher-v2.0.0/uloop-dispatcher-darwin-arm64.tar.gz.sha256)
-    printf 'fakehash  uloop-dispatcher-darwin-arm64.tar.gz\n' > "$output_file"
+    printf '%s  uloop-dispatcher-darwin-arm64.tar.gz\n' "${MOCK_ASSET_DIGEST:-fakehash}" > "$output_file"
     ;;
   *dispatcher-v2.0.0/uloop-dispatcher-windows-amd64.zip)
     : > "$output_file"
     ;;
   *dispatcher-v2.0.0/uloop-dispatcher-windows-amd64.zip.sha256)
-    printf 'fakehash  uloop-dispatcher-windows-amd64.zip\n' > "$output_file"
+    printf '%s  uloop-dispatcher-windows-amd64.zip\n' "${MOCK_ASSET_DIGEST:-fakehash}" > "$output_file"
     ;;
   *dispatcher-v3.0.0-beta.2/uloop-dispatcher-darwin-arm64.tar.gz)
     if [ "${ULOOP_VERSION:-}" != "latest-beta" ]; then
@@ -163,7 +173,7 @@ case "$url" in
       echo "Prerelease checksum should not be downloaded: $url" >&2
       exit 1
     fi
-    printf 'fakehash  uloop-dispatcher-darwin-arm64.tar.gz\n' > "$output_file"
+    printf '%s  uloop-dispatcher-darwin-arm64.tar.gz\n' "${MOCK_ASSET_DIGEST:-fakehash}" > "$output_file"
     ;;
   *dispatcher-v3.0.0-beta.2/uloop-dispatcher-windows-amd64.zip)
     if [ "${ULOOP_VERSION:-}" != "latest-beta" ]; then
@@ -177,7 +187,7 @@ case "$url" in
       echo "Prerelease checksum should not be downloaded: $url" >&2
       exit 1
     fi
-    printf 'fakehash  uloop-dispatcher-windows-amd64.zip\n' > "$output_file"
+    printf '%s  uloop-dispatcher-windows-amd64.zip\n' "${MOCK_ASSET_DIGEST:-fakehash}" > "$output_file"
     ;;
   *)
     echo "unexpected curl url: $url" >&2
@@ -196,12 +206,11 @@ fi
 
 # install.sh now computes the digest with `sha256sum <path>` and compares
 # against the parsed .sha256 file so the same hash string is available for
-# both the same-origin check and the attestation-manifest cross-check. The
-# .sha256 fixtures written above use the literal "fakehash", so emit that
-# whenever a single-file digest is requested. Any other invocation shape is
-# unexpected and should fail loud.
+# both the same-origin check and the attestation-manifest cross-check. Default
+# digest stays "fakehash" for existing fixtures; pin-fallback cases override
+# MOCK_ASSET_DIGEST to a 64-digit hex that validate_pin_manifest accepts.
 if [ "$#" -ge 1 ] && [ -f "$1" ]; then
-  printf 'fakehash  %s\n' "$1"
+  printf '%s  %s\n' "${MOCK_ASSET_DIGEST:-fakehash}" "$1"
   exit 0
 fi
 
@@ -327,6 +336,24 @@ exit 1
 MOCK_NPM
 
   chmod +x "$mock_bin/uname" "$mock_bin/curl" "$mock_bin/sha256sum" "$mock_bin/tar" "$mock_bin/unzip" "$mock_bin/npm"
+}
+
+# Builds a pretty-print pin JSON whose dispatcherArchiveManifest digests come
+# from PIN_ASSET_DIGEST (or MOCK_ASSET_DIGEST). Tag is always dispatcher-v2.0.0
+# so pin-driven installs hit the mocked stable asset URLs.
+write_pin_json() {
+  output_path=$1
+  digest=${PIN_ASSET_DIGEST:-${MOCK_ASSET_DIGEST:-fakehash}}
+  asset_name=${PIN_ASSET_NAME:-uloop-dispatcher-darwin-arm64.tar.gz}
+
+  cat > "$output_path" <<PIN
+{
+  "dispatcherArchiveManifest": "${digest}  ${asset_name}\\n${digest}  install.sh",
+  "dispatcherReleaseTag": "dispatcher-v2.0.0",
+  "minimumDispatcherVersion": "3.0.0-beta.19",
+  "projectRunnerVersion": "3.0.0-beta.64"
+}
+PIN
 }
 
 write_legacy_npm_uloop_shim() {
@@ -974,6 +1001,236 @@ test_powershell_reports_persisted_path_shadowing() {
   assert_not_contains "$ROOT_DIR/scripts/install.ps1" '$RemovedAll'
 }
 
+PIN_TEST_DIGEST="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+PIN_MISMATCH_DIGEST="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+# (a) Explicit ULOOP_ARCHIVE_MANIFEST must not fetch the repository pin.
+test_posix_explicit_manifest_skips_pin_fetch() {
+  work_dir="$TMP_DIR/posix-explicit-manifest-skips-pin"
+  mock_bin="$work_dir/bin"
+  install_dir="$work_dir/install"
+  releases_json="$work_dir/releases.json"
+  pin_json="$work_dir/pin.json"
+  curl_log="$work_dir/curl.log"
+  npm_log="$work_dir/npm.log"
+  mkdir -p "$work_dir"
+  : > "$curl_log"
+  : > "$npm_log"
+  write_releases_json "$releases_json"
+  write_pin_json "$pin_json"
+  write_mock_commands "$mock_bin"
+
+  PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    ULOOP_VERSION=latest \
+    ULOOP_INSTALL_DIR="$install_dir" \
+    RELEASES_JSON="$releases_json" \
+    PIN_JSON="$pin_json" \
+    CURL_LOG="$curl_log" \
+    NPM_LOG="$npm_log" \
+    MOCK_NATIVE_INSTALL_UNSUPPORTED=1 \
+    LEGACY_ULOOP="" \
+    "$ROOT_DIR/scripts/install.sh" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt"
+
+  assert_not_contains "$curl_log" "Packages/src/project-runner-pin.json"
+}
+
+# (b) Empty env + pin → install succeeds via pin tag and pin URL.
+test_posix_pin_fallback_installs_pinned_release() {
+  work_dir="$TMP_DIR/posix-pin-fallback-success"
+  mock_bin="$work_dir/bin"
+  install_dir="$work_dir/install"
+  releases_json="$work_dir/releases.json"
+  pin_json="$work_dir/pin.json"
+  curl_log="$work_dir/curl.log"
+  npm_log="$work_dir/npm.log"
+  mkdir -p "$work_dir"
+  : > "$curl_log"
+  : > "$npm_log"
+  write_releases_json "$releases_json"
+  MOCK_ASSET_DIGEST="$PIN_TEST_DIGEST" write_pin_json "$pin_json"
+  write_mock_commands "$mock_bin"
+
+  set +e
+  PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    env -u ULOOP_ARCHIVE_MANIFEST \
+    ULOOP_VERSION=latest \
+    ULOOP_INSTALL_DIR="$install_dir" \
+    RELEASES_JSON="$releases_json" \
+    PIN_JSON="$pin_json" \
+    CURL_LOG="$curl_log" \
+    NPM_LOG="$npm_log" \
+    MOCK_ASSET_DIGEST="$PIN_TEST_DIGEST" \
+    MOCK_NATIVE_INSTALL_UNSUPPORTED=1 \
+    LEGACY_ULOOP="" \
+    "$ROOT_DIR/scripts/install.sh" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    echo "Expected pin-fallback install to succeed" >&2
+    cat "$work_dir/stderr.txt" >&2
+    exit 1
+  fi
+
+  assert_contains "$curl_log" "Packages/src/project-runner-pin.json"
+  assert_contains "$curl_log" "dispatcher-v2.0.0/uloop-dispatcher-darwin-arm64.tar.gz"
+  assert_contains "$work_dir/output.txt" "pinned at"
+}
+
+# (c) Pin fetch failure must mention ULOOP_ARCHIVE_MANIFEST.
+test_posix_pin_fetch_failure_mentions_manifest_env() {
+  work_dir="$TMP_DIR/posix-pin-fetch-fail"
+  mock_bin="$work_dir/bin"
+  install_dir="$work_dir/install"
+  releases_json="$work_dir/releases.json"
+  pin_json="$work_dir/pin.json"
+  curl_log="$work_dir/curl.log"
+  npm_log="$work_dir/npm.log"
+  mkdir -p "$work_dir"
+  : > "$curl_log"
+  : > "$npm_log"
+  write_releases_json "$releases_json"
+  MOCK_ASSET_DIGEST="$PIN_TEST_DIGEST" write_pin_json "$pin_json"
+  write_mock_commands "$mock_bin"
+
+  set +e
+  PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    env -u ULOOP_ARCHIVE_MANIFEST \
+    ULOOP_VERSION=latest \
+    ULOOP_INSTALL_DIR="$install_dir" \
+    RELEASES_JSON="$releases_json" \
+    PIN_JSON="$pin_json" \
+    CURL_LOG="$curl_log" \
+    NPM_LOG="$npm_log" \
+    MOCK_PIN_FETCH_FAIL=1 \
+    MOCK_ASSET_DIGEST="$PIN_TEST_DIGEST" \
+    MOCK_NATIVE_INSTALL_UNSUPPORTED=1 \
+    LEGACY_ULOOP="" \
+    "$ROOT_DIR/scripts/install.sh" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt"
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    echo "Expected pin fetch failure to abort install" >&2
+    exit 1
+  fi
+  assert_contains "$work_dir/stderr.txt" "ULOOP_ARCHIVE_MANIFEST"
+}
+
+# (d) Pin digest that does not match the computed archive hash must fail.
+test_posix_pin_digest_mismatch_fails() {
+  work_dir="$TMP_DIR/posix-pin-digest-mismatch"
+  mock_bin="$work_dir/bin"
+  install_dir="$work_dir/install"
+  releases_json="$work_dir/releases.json"
+  pin_json="$work_dir/pin.json"
+  curl_log="$work_dir/curl.log"
+  npm_log="$work_dir/npm.log"
+  mkdir -p "$work_dir"
+  : > "$curl_log"
+  : > "$npm_log"
+  write_releases_json "$releases_json"
+  PIN_ASSET_DIGEST="$PIN_MISMATCH_DIGEST" MOCK_ASSET_DIGEST="$PIN_TEST_DIGEST" write_pin_json "$pin_json"
+  write_mock_commands "$mock_bin"
+
+  set +e
+  PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    env -u ULOOP_ARCHIVE_MANIFEST \
+    ULOOP_VERSION=latest \
+    ULOOP_INSTALL_DIR="$install_dir" \
+    RELEASES_JSON="$releases_json" \
+    PIN_JSON="$pin_json" \
+    CURL_LOG="$curl_log" \
+    NPM_LOG="$npm_log" \
+    MOCK_ASSET_DIGEST="$PIN_TEST_DIGEST" \
+    MOCK_NATIVE_INSTALL_UNSUPPORTED=1 \
+    LEGACY_ULOOP="" \
+    "$ROOT_DIR/scripts/install.sh" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt"
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    echo "Expected pin digest mismatch to abort install" >&2
+    exit 1
+  fi
+}
+
+# (e) Explicit ULOOP_VERSION that disagrees with the pin tag must fail.
+test_posix_pin_version_mismatch_fails() {
+  work_dir="$TMP_DIR/posix-pin-version-mismatch"
+  mock_bin="$work_dir/bin"
+  install_dir="$work_dir/install"
+  releases_json="$work_dir/releases.json"
+  pin_json="$work_dir/pin.json"
+  curl_log="$work_dir/curl.log"
+  npm_log="$work_dir/npm.log"
+  mkdir -p "$work_dir"
+  : > "$curl_log"
+  : > "$npm_log"
+  write_releases_json "$releases_json"
+  MOCK_ASSET_DIGEST="$PIN_TEST_DIGEST" write_pin_json "$pin_json"
+  write_mock_commands "$mock_bin"
+
+  set +e
+  PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    env -u ULOOP_ARCHIVE_MANIFEST \
+    ULOOP_VERSION=dispatcher-v9.9.9 \
+    ULOOP_INSTALL_DIR="$install_dir" \
+    RELEASES_JSON="$releases_json" \
+    PIN_JSON="$pin_json" \
+    CURL_LOG="$curl_log" \
+    NPM_LOG="$npm_log" \
+    MOCK_ASSET_DIGEST="$PIN_TEST_DIGEST" \
+    MOCK_NATIVE_INSTALL_UNSUPPORTED=1 \
+    LEGACY_ULOOP="" \
+    "$ROOT_DIR/scripts/install.sh" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt"
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    echo "Expected pin tag mismatch to abort install" >&2
+    exit 1
+  fi
+  assert_contains "$work_dir/stderr.txt" "ULOOP_VERSION"
+  assert_contains "$work_dir/stderr.txt" "ULOOP_ARCHIVE_MANIFEST"
+}
+
+# (f) ULOOP_REF must appear in the pin raw URL.
+test_posix_uloop_ref_appears_in_pin_url() {
+  work_dir="$TMP_DIR/posix-uloop-ref-in-pin-url"
+  mock_bin="$work_dir/bin"
+  install_dir="$work_dir/install"
+  releases_json="$work_dir/releases.json"
+  pin_json="$work_dir/pin.json"
+  curl_log="$work_dir/curl.log"
+  npm_log="$work_dir/npm.log"
+  mkdir -p "$work_dir"
+  : > "$curl_log"
+  : > "$npm_log"
+  write_releases_json "$releases_json"
+  MOCK_ASSET_DIGEST="$PIN_TEST_DIGEST" write_pin_json "$pin_json"
+  write_mock_commands "$mock_bin"
+
+  set +e
+  PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    env -u ULOOP_ARCHIVE_MANIFEST \
+    ULOOP_VERSION=latest \
+    ULOOP_REF=custom-ref \
+    ULOOP_INSTALL_DIR="$install_dir" \
+    RELEASES_JSON="$releases_json" \
+    PIN_JSON="$pin_json" \
+    CURL_LOG="$curl_log" \
+    NPM_LOG="$npm_log" \
+    MOCK_ASSET_DIGEST="$PIN_TEST_DIGEST" \
+    MOCK_NATIVE_INSTALL_UNSUPPORTED=1 \
+    LEGACY_ULOOP="" \
+    "$ROOT_DIR/scripts/install.sh" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    echo "Expected custom-ref pin-fallback install to succeed" >&2
+    cat "$work_dir/stderr.txt" >&2
+    exit 1
+  fi
+  assert_contains "$curl_log" "raw.githubusercontent.com/hatayama/unity-cli-loop/custom-ref/Packages/src/project-runner-pin.json"
+}
+
 test_posix_latest_skips_prerelease_assets
 test_posix_latest_beta_selects_prerelease_assets
 test_posix_invokes_native_install_setup
@@ -995,3 +1252,9 @@ test_powershell_installer_avoids_optional_archive_cmdlets
 test_powershell_installer_uses_non_installer_staged_executable_name
 test_powershell_native_probe_restores_error_action_preference
 test_powershell_reports_persisted_path_shadowing
+test_posix_explicit_manifest_skips_pin_fetch
+test_posix_pin_fallback_installs_pinned_release
+test_posix_pin_fetch_failure_mentions_manifest_env
+test_posix_pin_digest_mismatch_fails
+test_posix_pin_version_mismatch_fails
+test_posix_uloop_ref_appears_in_pin_url


### PR DESCRIPTION
## Summary

- Terminal install (`curl | sh` / `irm | iex`) now falls back to `Packages/src/project-runner-pin.json` when `ULOOP_ARCHIVE_MANIFEST` is unset, so first-time CLI install no longer requires `gh` + `jq`.
- Explicit `ULOOP_ARCHIVE_MANIFEST` (Unity GUI / dispatcher self-update / manual attestation) still wins; pin fetch is skipped in that case.
- New env `ULOOP_REF` (default `main`) selects the pin ref; pin parsing is fail-closed (escape residues, digest format, duplicates, CR).

Closes #2080

## Design

1. Non-empty `ULOOP_ARCHIVE_MANIFEST` → use it (no pin fetch).
2. Empty → fetch pin at `raw.githubusercontent.com/$REPOSITORY/$ULOOP_REF/Packages/src/project-runner-pin.json`, take `dispatcherArchiveManifest` + `dispatcherReleaseTag`.
3. `ULOOP_VERSION` of `latest` / `latest-beta` (or unset) is replaced by the pin tag; an explicit tag must match the pin or the install fails.
4. Fetch/parse/validation failure exits with a message that mentions both the pin URL and `ULOOP_ARCHIVE_MANIFEST`.

## Test plan

- [x] `sh scripts/test-install-pin-manifest.sh` (exit 0)
- [x] `sh scripts/test-install-archive-manifest.sh` (exit 0)
- [x] `sh scripts/test-install-version-format.sh` (exit 0)
- [x] `sh scripts/test-install-release-filter.sh` (exit 0, including new pin-fallback e2e cases)
- [x] `scripts/check-go-cli.sh` (exit 0)
- [x] Live smoke: `ULOOP_REF=v3-beta ULOOP_INSTALL_DIR=$(mktemp -d) sh scripts/install.sh` → `Using dispatcher release dispatcher-v3.1.0-beta.16 pinned at v3-beta`, install succeeded, `--version` printed `3.1.0-beta.16`
- [ ] Windows PowerShell steps in CI (`scripts/test-install-pin-resolution.ps1` + parse check) — no local `pwsh`/`powershell` on this machine
- [ ] Full PR CI green (`check-release-triggers`, Linux shell tests, Git Bash release-filter, Windows PowerShell)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

