### PR TITLE
docs: hot reload feasibility spike findings and design notes

### DIFF
--- a/Assets/Tests/Editor/HotReload.meta
+++ b/Assets/Tests/Editor/HotReload.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b96d98133a76845609cc4c62a15c256a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs
@@ -38,7 +38,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
     /// </summary>
     public class HotReloadSpikeS1PublicizedAccessTests
     {
-        private const string HarmonyId = "io.github.hatayama.uloop.hot-reload";
+        // Test-scoped id: sharing the production hot reload id would let this suite's
+        // UnpatchAll remove real hot reload patches from the Editor domain.
+        private const string HarmonyId = "io.github.hatayama.uloop.hot-reload-spike-s1";
         private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
         private const string FixtureTypeFullName =
             "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikePrivateAccessFixture";
@@ -144,9 +146,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
 
         // The runtime would match IgnoresAccessChecksToAttribute by full name if it supported
         // it, so the snippet declares it locally; a pinned test below shows this Mono ignores it.
-        private const string IgnoresAccessChecksToPreamble = @"using System.Runtime.CompilerServices;
+        private static readonly string IgnoresAccessChecksToPreamble = @"using System.Runtime.CompilerServices;
 
-[assembly: IgnoresAccessChecksTo(""UnityCLILoop.Tests.Editor.HotReload"")]
+[assembly: IgnoresAccessChecksTo(""" + TestAssemblyName + @""")]
 
 namespace System.Runtime.CompilerServices
 {

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs
@@ -1,0 +1,537 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
+using System.Threading.Tasks;
+using HarmonyLib;
+using Mono.Cecil;
+using NUnit.Framework;
+using UnityEditor.Compilation;
+using UnityEngine;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using Assembly = System.Reflection.Assembly;
+using CecilFieldAttributes = Mono.Cecil.FieldAttributes;
+using CecilMethodAttributes = Mono.Cecil.MethodAttributes;
+using CecilTypeAttributes = Mono.Cecil.TypeAttributes;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
+{
+    /// <summary>
+    /// Spike S1 for hot reload: establishes how generated shims can access private/internal
+    /// members of other assemblies on the Editor Mono runtime. Compile time: shims compile
+    /// against a publicized reference copy of the target assembly (same assembly name, all
+    /// members public). Runtime: this Mono enforces IL accessibility when a method is
+    /// JIT-compiled — invoking a private-poking snippet throws FieldAccessException,
+    /// IgnoresAccessChecksToAttribute is ignored, and even Harmony-patching such a method
+    /// throws at patch time because Harmony must JIT-compile the patch target to detour it
+    /// (all pinned by tests below). Shim IL containing inaccessible references must therefore
+    /// only ever run inside skip-visibility DynamicMethods. Two mechanisms achieve that and
+    /// are proven here: (1) transplanting the shim method's IL into the original method's
+    /// Harmony replacement via a transpiler, so the shim itself is never JIT-compiled, and
+    /// (2) rewriting private accesses to Harmony AccessTools accessor delegates, which keeps
+    /// the shim IL JIT-legal — including inside async state machine bodies.
+    /// </summary>
+    public class HotReloadSpikeS1PublicizedAccessTests
+    {
+        private const string HarmonyId = "io.github.hatayama.uloop.hot-reload";
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        private const string FixtureTypeFullName =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikePrivateAccessFixture";
+        private const string InternalFixtureTypeFullName =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikeInternalFixture";
+
+        // The snippet body plays the role of a generated hot reload shim: it is compiled outside
+        // Unity against the publicized copy only, then loaded into the Editor Mono runtime.
+        private const string SnippetBodySource = @"public static class SpikeS1Snippet
+{
+    public static int PokePrivateMembers(
+        io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikePrivateAccessFixture instance,
+        int delta)
+    {
+        instance._counter = instance._counter + delta;
+        instance.BumpByOne();
+        return instance._counter;
+    }
+
+    public static int ReadInternalType()
+    {
+        return io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikeInternalFixture.SecretSeed();
+    }
+}
+";
+
+        // Simulates the accessor rewrite the transform worker applies to private accesses: the
+        // snippet only references its own public delegate field, so every method in it is
+        // JIT-legal; the skip-visibility access lives inside the delegate Harmony builds.
+        private const string AccessorSnippetSource = @"public static class SpikeS1AccessorSnippet
+{
+    public static global::HarmonyLib.AccessTools.FieldRef<
+        io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikePrivateAccessFixture, int> CounterRef;
+
+    public static int PokeViaAccessor(
+        io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikePrivateAccessFixture instance,
+        int delta)
+    {
+        CounterRef(instance) = CounterRef(instance) + delta;
+        return CounterRef(instance);
+    }
+}
+";
+
+        // Async variant of the accessor rewrite: the private access lives in the compiler-
+        // generated MoveNext body, which stays JIT-legal because it only calls the delegate.
+        private const string AsyncAccessorSnippetSource = @"public static class SpikeS1AsyncAccessorSnippet
+{
+    public static global::HarmonyLib.AccessTools.FieldRef<
+        io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikePrivateAccessFixture, int> CounterRef;
+
+    public static async System.Threading.Tasks.Task<int> PokeViaAccessorAsync(
+        io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikePrivateAccessFixture instance,
+        int delta)
+    {
+        await System.Threading.Tasks.Task.Yield();
+        CounterRef(instance) = CounterRef(instance) + delta;
+        return CounterRef(instance);
+    }
+}
+";
+
+        // Mirrors PokePrivateMembers as an async method with DIRECT private accesses; a pinned
+        // test shows the compiler-generated MoveNext fails JIT accessibility checks, which is
+        // why async bodies need the accessor rewrite instead of raw member access.
+        private const string AsyncSnippetBodySource = @"public static class SpikeS1AsyncSnippet
+{
+    public static async System.Threading.Tasks.Task<int> PokePrivateMembersAsync(
+        io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikePrivateAccessFixture instance,
+        int delta)
+    {
+        await System.Threading.Tasks.Task.Yield();
+        instance._counter = instance._counter + delta;
+        instance.BumpByOne();
+        return instance._counter;
+    }
+}
+";
+
+        // The runtime would match IgnoresAccessChecksToAttribute by full name if it supported
+        // it, so the snippet declares it locally; a pinned test below shows this Mono ignores it.
+        private const string IgnoresAccessChecksToPreamble = @"using System.Runtime.CompilerServices;
+
+[assembly: IgnoresAccessChecksTo(""UnityCLILoop.Tests.Editor.HotReload"")]
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public sealed class IgnoresAccessChecksToAttribute : Attribute
+    {
+        public IgnoresAccessChecksToAttribute(string assemblyName)
+        {
+            AssemblyName = assemblyName;
+        }
+
+        public string AssemblyName { get; }
+    }
+}
+
+";
+
+        /// <summary>
+        /// What: the Cecil publicizer produces a copy that keeps the original assembly name and
+        /// exposes formerly private/internal types and members as public.
+        /// </summary>
+        [Test]
+        public void PublicizedCopy_KeepsAssemblyNameAndExposesPrivateMembers()
+        {
+            string workRootPath = PrepareCleanDirectory("S1-publicize");
+            string publicizedDllPath = Path.Combine(workRootPath, TestAssemblyName + ".Publicized.dll");
+            WritePublicizedCopy(ResolveTestAssemblyDllPath(), publicizedDllPath);
+
+            using AssemblyDefinition publicizedAssembly = AssemblyDefinition.ReadAssembly(publicizedDllPath);
+            Assert.That(
+                publicizedAssembly.Name.Name,
+                Is.EqualTo(TestAssemblyName),
+                "The publicized copy must keep the original assembly name so runtime type identity resolves to the already-loaded original assembly.");
+
+            TypeDefinition fixtureType = publicizedAssembly.MainModule.GetType(FixtureTypeFullName);
+            Assert.That(fixtureType, Is.Not.Null, $"Type not found in publicized copy: {FixtureTypeFullName}");
+            Assert.That(FindField(fixtureType, "_counter").IsPublic, Is.True, "_counter must be public in the publicized copy.");
+            Assert.That(FindMethod(fixtureType, "BumpByOne").IsPublic, Is.True, "BumpByOne must be public in the publicized copy.");
+
+            TypeDefinition internalFixtureType = publicizedAssembly.MainModule.GetType(InternalFixtureTypeFullName);
+            Assert.That(internalFixtureType, Is.Not.Null, $"Type not found in publicized copy: {InternalFixtureTypeFullName}");
+            Assert.That(internalFixtureType.IsPublic, Is.True, "SpikeInternalFixture must be public in the publicized copy.");
+            Assert.That(FindMethod(internalFixtureType, "SecretSeed").IsPublic, Is.True, "SecretSeed must be public in the publicized copy.");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            new Harmony(HarmonyId).UnpatchAll(HarmonyId);
+        }
+
+        /// <summary>
+        /// What: transplanting the snippet method's IL into an original method via a Harmony
+        /// transpiler lets the snippet body read/write private members and internal types at
+        /// runtime, because the body executes inside Harmony's skip-visibility DynamicMethod
+        /// and the snippet method itself is never JIT-compiled.
+        /// </summary>
+        [Test]
+        public async Task Snippet_TransplantedIntoOriginalMethod_AccessesPrivateMembersAtRuntime()
+        {
+            Type snippetType = await CompileAndLoadSnippetAsync(
+                "S1-transplant", SnippetBodySource, "SpikeS1Snippet", new List<string>());
+            MethodInfo pokeMethod = snippetType.GetMethod("PokePrivateMembers", BindingFlags.Public | BindingFlags.Static);
+            Assert.That(pokeMethod, Is.Not.Null, "PokePrivateMembers not found.");
+
+            // The static instance method pair (this, delta) / (instance, delta) occupies
+            // identical argument slots, so the IL transplants without any rewriting.
+            _transplantSourceMethod = pokeMethod;
+            MethodInfo originalMethod = AccessTools.Method(
+                typeof(SpikePrivateAccessFixture), nameof(SpikePrivateAccessFixture.ReplaceableCompute));
+            MethodInfo transpilerMethod = typeof(HotReloadSpikeS1PublicizedAccessTests).GetMethod(
+                nameof(ReplaceWithTransplantSourceTranspiler), BindingFlags.Public | BindingFlags.Static);
+            Harmony harmony = new(HarmonyId);
+            harmony.Patch(originalMethod, transpiler: new HarmonyMethod(transpilerMethod));
+
+            SpikePrivateAccessFixture fixture = new();
+            int returnedValue = fixture.ReplaceableCompute(5);
+            Assert.That(returnedValue, Is.EqualTo(16), "Transplanted body must observe 10 (initial) + 5 (delta) + 1 (BumpByOne).");
+            Assert.That(fixture.CounterForAssert, Is.EqualTo(16), "The original instance must observe the writes made by the transplanted body.");
+        }
+
+        /// <summary>
+        /// What: a snippet whose private access is rewritten to a Harmony FieldRef accessor
+        /// delegate is JIT-legal and reads/writes the private field at runtime, because the
+        /// skip-visibility access lives inside the delegate Harmony builds.
+        /// </summary>
+        [Test]
+        public async Task Snippet_UsingFieldRefAccessor_AccessesPrivateFieldAtRuntime()
+        {
+            List<string> harmonyReference = new() { typeof(Harmony).Assembly.Location };
+            Type snippetType = await CompileAndLoadSnippetAsync(
+                "S1-accessor", AccessorSnippetSource, "SpikeS1AccessorSnippet", harmonyReference);
+            BindAccessorField(snippetType);
+
+            MethodInfo pokeMethod = snippetType.GetMethod("PokeViaAccessor", BindingFlags.Public | BindingFlags.Static);
+            Assert.That(pokeMethod, Is.Not.Null, "PokeViaAccessor not found.");
+            Func<SpikePrivateAccessFixture, int, int> poke =
+                (Func<SpikePrivateAccessFixture, int, int>)pokeMethod.CreateDelegate(typeof(Func<SpikePrivateAccessFixture, int, int>));
+
+            SpikePrivateAccessFixture fixture = new();
+            int returnedValue = poke(fixture, 5);
+            Assert.That(returnedValue, Is.EqualTo(15), "Accessor snippet must observe 10 (initial) + 5 (delta).");
+            Assert.That(fixture.CounterForAssert, Is.EqualTo(15), "The original instance must observe the writes made through the accessor.");
+        }
+
+        /// <summary>
+        /// What: the accessor rewrite also works inside async methods, where the access lives
+        /// in the compiler-generated MoveNext body — proving the mechanism that covers async
+        /// bodies, which raw private access cannot (see the pinned async failure below).
+        /// </summary>
+        [Test]
+        public async Task AsyncSnippet_UsingFieldRefAccessor_AccessesPrivateFieldAtRuntime()
+        {
+            List<string> harmonyReference = new() { typeof(Harmony).Assembly.Location };
+            Type snippetType = await CompileAndLoadSnippetAsync(
+                "S1-accessor-async", AsyncAccessorSnippetSource, "SpikeS1AsyncAccessorSnippet", harmonyReference);
+            BindAccessorField(snippetType);
+
+            MethodInfo pokeAsyncMethod = snippetType.GetMethod("PokeViaAccessorAsync", BindingFlags.Public | BindingFlags.Static);
+            Assert.That(pokeAsyncMethod, Is.Not.Null, "PokeViaAccessorAsync not found.");
+            Func<SpikePrivateAccessFixture, int, Task<int>> pokeAsync =
+                (Func<SpikePrivateAccessFixture, int, Task<int>>)pokeAsyncMethod.CreateDelegate(typeof(Func<SpikePrivateAccessFixture, int, Task<int>>));
+
+            SpikePrivateAccessFixture fixture = new();
+            int returnedValue = await pokeAsync(fixture, 5);
+            Assert.That(returnedValue, Is.EqualTo(15), "Async accessor snippet must observe 10 (initial) + 5 (delta).");
+            Assert.That(fixture.CounterForAssert, Is.EqualTo(15), "The original instance must observe the writes made through the accessor.");
+        }
+
+        /// <summary>
+        /// What: an async snippet with DIRECT private accesses fails with FieldAccessException
+        /// when its compiler-generated MoveNext body is JIT-compiled on first execution —
+        /// pinning why async bodies need the accessor rewrite.
+        /// </summary>
+        [Test]
+        public async Task AsyncSnippet_InvokedDirectly_ThrowsFieldAccessException()
+        {
+            Type snippetType = await CompileAndLoadSnippetAsync(
+                "S1-enforce-async", AsyncSnippetBodySource, "SpikeS1AsyncSnippet", new List<string>());
+
+            MethodInfo pokeAsyncMethod = snippetType.GetMethod("PokePrivateMembersAsync", BindingFlags.Public | BindingFlags.Static);
+            Assert.That(pokeAsyncMethod, Is.Not.Null, "PokePrivateMembersAsync not found.");
+            Func<SpikePrivateAccessFixture, int, Task<int>> pokeAsync =
+                (Func<SpikePrivateAccessFixture, int, Task<int>>)pokeAsyncMethod.CreateDelegate(typeof(Func<SpikePrivateAccessFixture, int, Task<int>>));
+
+            SpikePrivateAccessFixture fixture = new();
+            // The async stub runs the first MoveNext synchronously, so the JIT failure surfaces
+            // as a synchronous throw from the delegate call, not as a faulted task.
+            Assert.Throws<FieldAccessException>(() => pokeAsync(fixture, 5));
+        }
+
+        /// <summary>
+        /// What: Harmony-patching a private-poking snippet method itself throws
+        /// FieldAccessException at patch time, because Harmony must JIT-compile the patch
+        /// target to detour it — pinning why the shim is transplanted instead of patched.
+        /// </summary>
+        [Test]
+        public async Task SelfPatchingSnippetMethod_ThrowsFieldAccessExceptionAtPatchTime()
+        {
+            Type snippetType = await CompileAndLoadSnippetAsync(
+                "S1-selfpatch", SnippetBodySource, "SpikeS1Snippet", new List<string>());
+            MethodInfo pokeMethod = snippetType.GetMethod("PokePrivateMembers", BindingFlags.Public | BindingFlags.Static);
+            Assert.That(pokeMethod, Is.Not.Null, "PokePrivateMembers not found.");
+            MethodInfo transpilerMethod = typeof(HotReloadSpikeS1PublicizedAccessTests).GetMethod(
+                nameof(IdentityTranspiler), BindingFlags.Public | BindingFlags.Static);
+
+            Harmony harmony = new(HarmonyId);
+            Assert.Throws<FieldAccessException>(
+                () => harmony.Patch(pokeMethod, transpiler: new HarmonyMethod(transpilerMethod)));
+        }
+
+        /// <summary>
+        /// What: invoking the snippet directly fails at JIT time with FieldAccessException,
+        /// pinning the runtime enforcement that shapes the whole access design on this Mono.
+        /// </summary>
+        [Test]
+        public async Task Snippet_InvokedDirectly_ThrowsFieldAccessException()
+        {
+            Type snippetType = await CompileAndLoadSnippetAsync(
+                "S1-enforce", SnippetBodySource, "SpikeS1Snippet", new List<string>());
+
+            MethodInfo pokeMethod = snippetType.GetMethod("PokePrivateMembers", BindingFlags.Public | BindingFlags.Static);
+            Assert.That(pokeMethod, Is.Not.Null, "PokePrivateMembers not found.");
+            Func<SpikePrivateAccessFixture, int, int> poke =
+                (Func<SpikePrivateAccessFixture, int, int>)pokeMethod.CreateDelegate(typeof(Func<SpikePrivateAccessFixture, int, int>));
+
+            SpikePrivateAccessFixture fixture = new();
+            Assert.Throws<FieldAccessException>(() => poke(fixture, 5));
+        }
+
+        /// <summary>
+        /// What: this Mono does not honor IgnoresAccessChecksToAttribute — the snippet still
+        /// fails with FieldAccessException. Pinned so a future Unity upgrade that starts
+        /// honoring the attribute surfaces as a design-simplification opportunity.
+        /// </summary>
+        [Test]
+        public async Task Snippet_WithIgnoresAccessChecksTo_StillThrowsFieldAccessException()
+        {
+            Type snippetType = await CompileAndLoadSnippetAsync(
+                "S1-iact", IgnoresAccessChecksToPreamble + SnippetBodySource, "SpikeS1Snippet", new List<string>());
+
+            MethodInfo pokeMethod = snippetType.GetMethod("PokePrivateMembers", BindingFlags.Public | BindingFlags.Static);
+            Assert.That(pokeMethod, Is.Not.Null, "PokePrivateMembers not found.");
+            Func<SpikePrivateAccessFixture, int, int> poke =
+                (Func<SpikePrivateAccessFixture, int, int>)pokeMethod.CreateDelegate(typeof(Func<SpikePrivateAccessFixture, int, int>));
+
+            SpikePrivateAccessFixture fixture = new();
+            Assert.Throws<FieldAccessException>(() => poke(fixture, 5));
+        }
+
+        /// <summary>
+        /// Identity transpiler: used by the patch-time pin to show that even a no-op patch of a
+        /// private-poking method fails, because Harmony must JIT-compile the patch target.
+        /// </summary>
+        public static IEnumerable<CodeInstruction> IdentityTranspiler(IEnumerable<CodeInstruction> instructions)
+        {
+            return instructions;
+        }
+
+        // Transpilers are resolved statically by Harmony, so the transplant source is handed
+        // over through this field instead of a parameter.
+        private static MethodInfo _transplantSourceMethod;
+
+        /// <summary>
+        /// Transpiler that discards the original instructions and emits the transplant source
+        /// method's IL instead; Harmony compiles the result into the skip-visibility
+        /// DynamicMethod that replaces the patched method.
+        /// </summary>
+        public static IEnumerable<CodeInstruction> ReplaceWithTransplantSourceTranspiler(
+            IEnumerable<CodeInstruction> instructions,
+            ILGenerator generator)
+        {
+            return PatchProcessor.GetOriginalInstructions(_transplantSourceMethod, generator);
+        }
+
+        /// <summary>
+        /// Plays the role of the hot reload infrastructure wiring accessor delegates into a
+        /// freshly loaded shim assembly: binds the snippet's CounterRef field to a Harmony
+        /// FieldRef for the fixture's private _counter field.
+        /// </summary>
+        private static void BindAccessorField(Type snippetType)
+        {
+            FieldInfo counterRefField = snippetType.GetField("CounterRef", BindingFlags.Public | BindingFlags.Static);
+            Assert.That(counterRefField, Is.Not.Null, "CounterRef field not found in the accessor snippet.");
+            counterRefField.SetValue(null, AccessTools.FieldRefAccess<SpikePrivateAccessFixture, int>("_counter"));
+        }
+
+        /// <summary>
+        /// Compiles the given snippet source with the external Roslyn compiler against mscorlib
+        /// and the publicized copy only, loads the produced assembly into the Editor domain, and
+        /// returns the named snippet type.
+        /// </summary>
+        private static async Task<Type> CompileAndLoadSnippetAsync(
+            string workSubdirectoryName,
+            string snippetSource,
+            string snippetTypeName,
+            IReadOnlyList<string> extraReferencePaths)
+        {
+            string workRootPath = PrepareCleanDirectory(workSubdirectoryName);
+            string publicizedDllPath = Path.Combine(workRootPath, TestAssemblyName + ".Publicized.dll");
+            WritePublicizedCopy(ResolveTestAssemblyDllPath(), publicizedDllPath);
+
+            string snippetSourcePath = Path.Combine(workRootPath, "SpikeS1Snippet.cs");
+            File.WriteAllText(snippetSourcePath, snippetSource);
+            string snippetDllPath = Path.Combine(workRootPath, "SpikeS1Snippet.dll");
+
+            // Only mscorlib, the publicized copy, and explicitly requested extras: any leak of
+            // the original assembly into the reference set would let the snippet compile
+            // against private members legally and invalidate the spike result.
+            List<string> references = new()
+            {
+                typeof(object).Assembly.Location,
+                publicizedDllPath
+            };
+            references.AddRange(extraReferencePaths);
+
+            ExternalCompilerPaths externalCompilerPaths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(externalCompilerPaths, Is.Not.Null, "External compiler paths could not be resolved for this Unity installation.");
+
+            RoslynCompilerOptions compilerOptions = new(new List<string>(), false);
+            using CancellationTokenSource cts = new(TimeSpan.FromSeconds(120));
+            DynamicCompilationBackendResult result = await RoslynCompilerBackend.CompileAsync(
+                snippetSourcePath,
+                snippetDllPath,
+                references,
+                externalCompilerPaths,
+                compilerOptions,
+                cts.Token,
+                () => { },
+                () => { },
+                () => { });
+
+            Assert.That(
+                result.BackendKind == DynamicCompilationBackendKind.SharedRoslynWorker
+                || result.BackendKind == DynamicCompilationBackendKind.OneShotRoslyn,
+                Is.True,
+                $"Snippet must be compiled by the external Roslyn compiler, not a fallback that injects Unity's own reference set. Actual: {result.BackendKind}");
+            AssertNoCompileErrors(result.CompilerMessages);
+            Assert.That(File.Exists(snippetDllPath), Is.True, $"Snippet dll was not produced: {snippetDllPath}");
+
+            Assembly snippetAssembly = Assembly.Load(File.ReadAllBytes(snippetDllPath));
+            Type snippetType = snippetAssembly.GetType(snippetTypeName);
+            Assert.That(snippetType, Is.Not.Null, $"{snippetTypeName} type not found in the loaded snippet assembly.");
+            return snippetType;
+        }
+
+        private static string ResolveTestAssemblyDllPath()
+        {
+            string projectRootPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string dllPath = Path.Combine(projectRootPath, "Library", "ScriptAssemblies", TestAssemblyName + ".dll");
+            Assert.That(File.Exists(dllPath), Is.True, $"Test assembly dll not found: {dllPath}");
+            return dllPath;
+        }
+
+        private static string PrepareCleanDirectory(string subdirectoryName)
+        {
+            string projectRootPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string workRootPath = Path.Combine(projectRootPath, "Library", "UloopHotReloadSpike", subdirectoryName);
+            if (Directory.Exists(workRootPath))
+            {
+                Directory.Delete(workRootPath, true);
+            }
+
+            Directory.CreateDirectory(workRootPath);
+            return workRootPath;
+        }
+
+        private static void WritePublicizedCopy(string sourceDllPath, string outputDllPath)
+        {
+            // InMemory read: the source dll is the currently loaded script assembly, so the copy
+            // must not keep a file handle on it.
+            ReaderParameters readerParameters = new() { InMemory = true };
+            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(sourceDllPath, readerParameters);
+            foreach (ModuleDefinition module in assemblyDefinition.Modules)
+            {
+                foreach (TypeDefinition type in module.GetTypes())
+                {
+                    // <Module> is a metadata artifact whose visibility must stay untouched.
+                    if (type.Name == "<Module>")
+                    {
+                        continue;
+                    }
+
+                    PublicizeType(type);
+                }
+            }
+
+            assemblyDefinition.Write(outputDllPath);
+        }
+
+        private static void PublicizeType(TypeDefinition type)
+        {
+            if (type.IsNested)
+            {
+                type.Attributes = (type.Attributes & ~CecilTypeAttributes.VisibilityMask) | CecilTypeAttributes.NestedPublic;
+            }
+            else
+            {
+                type.Attributes = (type.Attributes & ~CecilTypeAttributes.VisibilityMask) | CecilTypeAttributes.Public;
+            }
+
+            foreach (FieldDefinition field in type.Fields)
+            {
+                field.Attributes = (field.Attributes & ~CecilFieldAttributes.FieldAccessMask) | CecilFieldAttributes.Public;
+            }
+
+            foreach (MethodDefinition method in type.Methods)
+            {
+                method.Attributes = (method.Attributes & ~CecilMethodAttributes.MemberAccessMask) | CecilMethodAttributes.Public;
+            }
+        }
+
+        private static FieldDefinition FindField(TypeDefinition type, string fieldName)
+        {
+            foreach (FieldDefinition field in type.Fields)
+            {
+                if (field.Name == fieldName)
+                {
+                    return field;
+                }
+            }
+
+            Assert.Fail($"Field not found: {type.FullName}.{fieldName}");
+            return null;
+        }
+
+        private static MethodDefinition FindMethod(TypeDefinition type, string methodName)
+        {
+            foreach (MethodDefinition method in type.Methods)
+            {
+                if (method.Name == methodName)
+                {
+                    return method;
+                }
+            }
+
+            Assert.Fail($"Method not found: {type.FullName}.{methodName}");
+            return null;
+        }
+
+        private static void AssertNoCompileErrors(CompilerMessage[] compilerMessages)
+        {
+            List<string> errors = new();
+            foreach (CompilerMessage compilerMessage in compilerMessages)
+            {
+                if (compilerMessage.type == CompilerMessageType.Error)
+                {
+                    errors.Add(compilerMessage.message);
+                }
+            }
+
+            Assert.That(errors, Is.Empty, "Snippet compilation failed:\n" + string.Join("\n", errors));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs
@@ -31,7 +31,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
     /// are proven here: (1) transplanting the shim method's IL into the original method's
     /// Harmony replacement via a transpiler, so the shim itself is never JIT-compiled, and
     /// (2) rewriting private accesses to Harmony AccessTools accessor delegates, which keeps
-    /// the shim IL JIT-legal — including inside async state machine bodies.
+    /// the shim IL JIT-legal — including inside async state machine bodies, for private field
+    /// access (FieldRef delegates) and private method calls (open-instance method delegates).
+    /// A delegation transpiler (load arguments, call the shim, return) routes a patched
+    /// original method to such a JIT-legal shim.
     /// </summary>
     public class HotReloadSpikeS1PublicizedAccessTests
     {
@@ -93,6 +96,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
     {
         await System.Threading.Tasks.Task.Yield();
         CounterRef(instance) = CounterRef(instance) + delta;
+        return CounterRef(instance);
+    }
+}
+";
+
+        // Accessor rewrite covering a private METHOD call in an async body: the field access
+        // rides a FieldRef delegate and the method call an open-instance delegate, so the
+        // compiler-generated MoveNext body stays JIT-legal. This is the load-bearing shape of
+        // the v2 accessor stage.
+        private const string AsyncMethodAccessorSnippetSource = @"public static class SpikeS1AsyncMethodAccessorSnippet
+{
+    public static global::HarmonyLib.AccessTools.FieldRef<
+        io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikePrivateAccessFixture, int> CounterRef;
+
+    public static System.Action<
+        io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikePrivateAccessFixture> BumpByOneCall;
+
+    public static async System.Threading.Tasks.Task<int> PokeViaAccessorsAsync(
+        io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike.SpikePrivateAccessFixture instance,
+        int delta)
+    {
+        await System.Threading.Tasks.Task.Yield();
+        CounterRef(instance) = CounterRef(instance) + delta;
+        BumpByOneCall(instance);
         return CounterRef(instance);
     }
 }
@@ -251,6 +278,55 @@ namespace System.Runtime.CompilerServices
         }
 
         /// <summary>
+        /// What: the accessor rewrite extends to private METHOD calls — an open-instance
+        /// delegate built by AccessTools.MethodDelegate invokes the private method from inside
+        /// an async state machine body without tripping JIT accessibility checks. This is the
+        /// load-bearing assumption of the v2 accessor stage.
+        /// </summary>
+        [Test]
+        public async Task AsyncSnippet_UsingMethodDelegateAccessor_CallsPrivateMethodAtRuntime()
+        {
+            Type snippetType = await CompileAndLoadAsyncMethodAccessorSnippetAsync("S1-accessor-async-method");
+
+            MethodInfo pokeAsyncMethod = snippetType.GetMethod("PokeViaAccessorsAsync", BindingFlags.Public | BindingFlags.Static);
+            Assert.That(pokeAsyncMethod, Is.Not.Null, "PokeViaAccessorsAsync not found.");
+            Func<SpikePrivateAccessFixture, int, Task<int>> pokeAsync =
+                (Func<SpikePrivateAccessFixture, int, Task<int>>)pokeAsyncMethod.CreateDelegate(typeof(Func<SpikePrivateAccessFixture, int, Task<int>>));
+
+            SpikePrivateAccessFixture fixture = new();
+            int returnedValue = await pokeAsync(fixture, 5);
+            Assert.That(returnedValue, Is.EqualTo(16), "Accessor snippet must observe 10 (initial) + 5 (delta) + 1 (BumpByOne).");
+            Assert.That(fixture.CounterForAssert, Is.EqualTo(16), "The original instance must observe the writes made through the accessors.");
+        }
+
+        /// <summary>
+        /// What: patching an original async method with a transpiler that replaces its body
+        /// with "load arguments, call the accessor-rewritten async shim, return" routes calls
+        /// to the shim, whose state machine JIT-compiles legally thanks to the accessor
+        /// rewrite. This is the v2 patch shape for methods whose shims are JIT-legal.
+        /// </summary>
+        [Test]
+        public async Task AsyncOriginal_PatchedWithDelegationToAccessorShim_RunsShimBody()
+        {
+            Type snippetType = await CompileAndLoadAsyncMethodAccessorSnippetAsync("S1-delegation-async");
+            MethodInfo pokeAsyncMethod = snippetType.GetMethod("PokeViaAccessorsAsync", BindingFlags.Public | BindingFlags.Static);
+            Assert.That(pokeAsyncMethod, Is.Not.Null, "PokeViaAccessorsAsync not found.");
+
+            _transplantSourceMethod = pokeAsyncMethod;
+            MethodInfo originalMethod = AccessTools.Method(
+                typeof(SpikePrivateAccessFixture), nameof(SpikePrivateAccessFixture.ReplaceableComputeAsync));
+            MethodInfo transpilerMethod = typeof(HotReloadSpikeS1PublicizedAccessTests).GetMethod(
+                nameof(ReplaceWithDelegationToTransplantSourceTranspiler), BindingFlags.Public | BindingFlags.Static);
+            Harmony harmony = new(HarmonyId);
+            harmony.Patch(originalMethod, transpiler: new HarmonyMethod(transpilerMethod));
+
+            SpikePrivateAccessFixture fixture = new();
+            int returnedValue = await fixture.ReplaceableComputeAsync(5);
+            Assert.That(returnedValue, Is.EqualTo(16), "Delegated body must observe 10 (initial) + 5 (delta) + 1 (BumpByOne).");
+            Assert.That(fixture.CounterForAssert, Is.EqualTo(16), "The original instance must observe the writes made by the shim.");
+        }
+
+        /// <summary>
         /// What: an async snippet with DIRECT private accesses fails with FieldAccessException
         /// when its compiler-generated MoveNext body is JIT-compiled on first execution —
         /// pinning why async bodies need the accessor rewrite.
@@ -357,6 +433,24 @@ namespace System.Runtime.CompilerServices
         }
 
         /// <summary>
+        /// Transpiler that discards the original instructions and emits a plain call to the
+        /// transplant source method instead (load every argument slot, call, return). Used for
+        /// JIT-legal shims (accessor-rewritten async bodies), where the goal is to execute the
+        /// shim method itself rather than to transplant its IL.
+        /// </summary>
+        public static IEnumerable<CodeInstruction> ReplaceWithDelegationToTransplantSourceTranspiler(
+            IEnumerable<CodeInstruction> instructions)
+        {
+            return new List<CodeInstruction>
+            {
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldarg_1),
+                new CodeInstruction(OpCodes.Call, _transplantSourceMethod),
+                new CodeInstruction(OpCodes.Ret)
+            };
+        }
+
+        /// <summary>
         /// Plays the role of the hot reload infrastructure wiring accessor delegates into a
         /// freshly loaded shim assembly: binds the snippet's CounterRef field to a Harmony
         /// FieldRef for the fixture's private _counter field.
@@ -366,6 +460,29 @@ namespace System.Runtime.CompilerServices
             FieldInfo counterRefField = snippetType.GetField("CounterRef", BindingFlags.Public | BindingFlags.Static);
             Assert.That(counterRefField, Is.Not.Null, "CounterRef field not found in the accessor snippet.");
             counterRefField.SetValue(null, AccessTools.FieldRefAccess<SpikePrivateAccessFixture, int>("_counter"));
+        }
+
+        /// <summary>
+        /// Compiles the async method-accessor snippet and binds both accessor delegate fields:
+        /// CounterRef to a Harmony FieldRef for the private _counter field, and BumpByOneCall
+        /// to an open-instance delegate for the private BumpByOne method (virtualCall false —
+        /// the exact private method must be called, not a virtual slot).
+        /// </summary>
+        private static async Task<Type> CompileAndLoadAsyncMethodAccessorSnippetAsync(string workSubdirectoryName)
+        {
+            List<string> harmonyReference = new() { typeof(Harmony).Assembly.Location };
+            Type snippetType = await CompileAndLoadSnippetAsync(
+                workSubdirectoryName, AsyncMethodAccessorSnippetSource, "SpikeS1AsyncMethodAccessorSnippet", harmonyReference);
+            BindAccessorField(snippetType);
+
+            FieldInfo bumpByOneCallField = snippetType.GetField("BumpByOneCall", BindingFlags.Public | BindingFlags.Static);
+            Assert.That(bumpByOneCallField, Is.Not.Null, "BumpByOneCall field not found in the accessor snippet.");
+            MethodInfo bumpByOneMethod = AccessTools.Method(typeof(SpikePrivateAccessFixture), "BumpByOne");
+            Assert.That(bumpByOneMethod, Is.Not.Null, "BumpByOne method not found on the fixture.");
+            bumpByOneCallField.SetValue(
+                null,
+                AccessTools.MethodDelegate<Action<SpikePrivateAccessFixture>>(bumpByOneMethod, null, false, null));
+            return snippetType;
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs
@@ -169,6 +169,7 @@ namespace System.Runtime.CompilerServices
         public void TearDown()
         {
             new Harmony(HarmonyId).UnpatchAll(HarmonyId);
+            _transplantSourceMethod = null;
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7576c0ba81a97418ab64768da27f96a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS2WorkerBootstrapTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS2WorkerBootstrapTests.cs
@@ -196,13 +196,25 @@ public static class SpikeWorkerProgram
             Task completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(timeout));
             if (completedTask != waitForExitTask)
             {
-                // HasExited guard: the process may exit between the timeout firing and the
-                // kill, and Kill on an exited process throws, masking the timeout failure.
                 if (!process.HasExited)
                 {
-                    process.Kill();
+                    try
+                    {
+                        process.Kill();
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // The process can still exit between the HasExited check and Kill; the
+                        // kill exists only for cleanup, so the expected race is swallowed and
+                        // the Assert.Fail below stays the single reported diagnosis.
+                    }
                 }
 
+                // Observe the redirected-stream tasks so a fault during teardown cannot
+                // surface later as an unobserved task exception in the Editor.
+                _ = Task.WhenAll(stdoutTask, stderrTask).ContinueWith(
+                    static task => _ = task.Exception,
+                    TaskContinuationOptions.OnlyOnFaulted);
                 Assert.Fail($"Process timed out after {timeout.TotalSeconds}s: {fileName} {arguments}");
             }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS2WorkerBootstrapTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS2WorkerBootstrapTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
+{
+    /// <summary>
+    /// Spike S2 for hot reload: proves that a standalone worker executable can be built with the
+    /// Unity-bundled Roslyn compiler (csc.dll), run on the Unity-bundled .NET host, and use the
+    /// Unity-bundled Microsoft.CodeAnalysis assemblies to parse C# source. The production
+    /// transform worker relies on exactly this bootstrap: compile once with csc against the
+    /// bundled shared framework, resolve Roslyn assemblies at runtime from the compiler
+    /// directory via an AssemblyLoadContext.Resolving hook, and reuse csc's runtimeconfig.
+    /// </summary>
+    public class HotReloadSpikeS2WorkerBootstrapTests
+    {
+        // The Resolving hook must be registered before any Roslyn type is touched, so all Roslyn
+        // usage lives in a method that is only JIT-compiled after the hook is in place.
+        private const string WorkerSource = @"using System;
+using System.IO;
+using System.Runtime.Loader;
+
+public static class SpikeWorkerProgram
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length != 2)
+        {
+            Console.Error.WriteLine(""usage: SpikeWorker <roslyn-directory> <source-path>"");
+            return 1;
+        }
+
+        string roslynDirectoryPath = args[0];
+        AssemblyLoadContext.Default.Resolving += (context, assemblyName) =>
+        {
+            string candidatePath = Path.Combine(roslynDirectoryPath, assemblyName.Name + "".dll"");
+            if (File.Exists(candidatePath))
+            {
+                return context.LoadFromAssemblyPath(candidatePath);
+            }
+
+            return null;
+        };
+
+        ListMethodNames(args[1]);
+        return 0;
+    }
+
+    private static void ListMethodNames(string sourcePath)
+    {
+        string sourceText = File.ReadAllText(sourcePath);
+        Microsoft.CodeAnalysis.SyntaxTree syntaxTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(sourceText);
+        foreach (Microsoft.CodeAnalysis.SyntaxNode node in syntaxTree.GetRoot().DescendantNodes())
+        {
+            if (node is Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax method)
+            {
+                Console.WriteLine(method.Identifier.ValueText);
+            }
+        }
+    }
+}
+";
+
+        private const string ProbeSource = @"public class SpikeProbe
+{
+    private int _seed;
+
+    public void Alpha()
+    {
+        _seed = 1;
+    }
+
+    public static int Beta(int value)
+    {
+        return value * 2 + new SpikeProbe()._seed;
+    }
+}
+";
+
+        /// <summary>
+        /// What: the bundled csc compiles the worker against the bundled shared framework plus
+        /// Roslyn reference assemblies, and the bundled .NET host then runs the worker, which
+        /// parses a C# source file with Microsoft.CodeAnalysis and lists its method names.
+        /// </summary>
+        [Test]
+        public async Task BundledRoslynWorker_CompilesAndRunsOnBundledNetCoreHost()
+        {
+            ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(paths, Is.Not.Null, "External compiler paths could not be resolved for this Unity installation.");
+            AssertFileExists(paths.DotnetHostPath, "bundled .NET host");
+            AssertFileExists(paths.CompilerDllPath, "bundled csc.dll");
+            AssertFileExists(paths.CompilerRuntimeConfigPath, "csc runtimeconfig");
+            AssertFileExists(paths.CodeAnalysisDllPath, "Microsoft.CodeAnalysis.dll");
+            AssertFileExists(paths.CodeAnalysisCSharpDllPath, "Microsoft.CodeAnalysis.CSharp.dll");
+            Assert.That(
+                Directory.Exists(paths.NetCoreRuntimeSharedDirectoryPath),
+                Is.True,
+                $"Shared framework directory not found: {paths.NetCoreRuntimeSharedDirectoryPath}");
+
+            string workRootPath = PrepareCleanDirectory("S2");
+            string workerSourcePath = Path.Combine(workRootPath, "SpikeWorker.cs");
+            File.WriteAllText(workerSourcePath, WorkerSource);
+            string workerDllPath = Path.Combine(workRootPath, "SpikeWorker.dll");
+            string responseFilePath = Path.Combine(workRootPath, "SpikeWorker.rsp");
+            WriteWorkerResponseFile(responseFilePath, workerSourcePath, workerDllPath, paths);
+
+            (int compileExitCode, string compileStandardOutput, string compileStandardError) = await RunProcessAsync(
+                paths.DotnetHostPath,
+                $"\"{paths.CompilerDllPath}\" @\"{responseFilePath}\"",
+                workRootPath,
+                TimeSpan.FromSeconds(120));
+            Assert.That(
+                compileExitCode,
+                Is.EqualTo(0),
+                $"Worker compilation failed.\nstdout:\n{compileStandardOutput}\nstderr:\n{compileStandardError}");
+            Assert.That(File.Exists(workerDllPath), Is.True, $"Worker dll was not produced: {workerDllPath}");
+
+            // csc's own runtimeconfig pins the bundled shared framework the worker was compiled
+            // against; without a runtimeconfig the host refuses to run a framework-dependent dll.
+            File.Copy(paths.CompilerRuntimeConfigPath, Path.Combine(workRootPath, "SpikeWorker.runtimeconfig.json"));
+
+            string probeSourcePath = Path.Combine(workRootPath, "SpikeProbe.cs");
+            File.WriteAllText(probeSourcePath, ProbeSource);
+
+            string roslynDirectoryPath = Path.GetDirectoryName(paths.CompilerDllPath);
+            (int workerExitCode, string workerStandardOutput, string workerStandardError) = await RunProcessAsync(
+                paths.DotnetHostPath,
+                $"\"{workerDllPath}\" \"{roslynDirectoryPath}\" \"{probeSourcePath}\"",
+                workRootPath,
+                TimeSpan.FromSeconds(60));
+            Assert.That(
+                workerExitCode,
+                Is.EqualTo(0),
+                $"Worker run failed.\nstdout:\n{workerStandardOutput}\nstderr:\n{workerStandardError}");
+            Assert.That(workerStandardOutput, Does.Contain("Alpha"), $"Worker output missing method name. stdout:\n{workerStandardOutput}");
+            Assert.That(workerStandardOutput, Does.Contain("Beta"), $"Worker output missing method name. stdout:\n{workerStandardOutput}");
+        }
+
+        private static void WriteWorkerResponseFile(
+            string responseFilePath,
+            string workerSourcePath,
+            string workerDllPath,
+            ExternalCompilerPaths paths)
+        {
+            // Mirrors RoslynCompilerBackend.WriteCompilerResponseFile, except the worker is an
+            // executable compiled against the bundled shared framework instead of Unity Mono.
+            List<string> lines = new()
+            {
+                "-nologo",
+                "-nostdlib+",
+                "-target:exe",
+                $"-out:\"{workerDllPath}\""
+            };
+
+            foreach (string referencePath in Directory.GetFiles(paths.NetCoreRuntimeSharedDirectoryPath, "*.dll"))
+            {
+                lines.Add($"-r:\"{referencePath}\"");
+            }
+
+            lines.Add($"-r:\"{paths.CodeAnalysisDllPath}\"");
+            lines.Add($"-r:\"{paths.CodeAnalysisCSharpDllPath}\"");
+            lines.Add($"\"{workerSourcePath}\"");
+            File.WriteAllLines(responseFilePath, lines);
+        }
+
+        private static async Task<(int exitCode, string standardOutput, string standardError)> RunProcessAsync(
+            string fileName,
+            string arguments,
+            string workingDirectoryPath,
+            TimeSpan timeout)
+        {
+            ProcessStartInfo startInfo = new()
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = workingDirectoryPath,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            using Process process = Process.Start(startInfo);
+            Assert.That(process, Is.Not.Null, $"Failed to start process: {fileName}");
+
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+            // Task.Run around the blocking WaitForExit mirrors RoslynCompilerBackend's
+            // WaitForOneShotCompilerAsync; Process has no awaitable wait on this runtime.
+            Task waitForExitTask = Task.Run(() => process.WaitForExit());
+            Task completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(timeout));
+            if (completedTask != waitForExitTask)
+            {
+                process.Kill();
+                Assert.Fail($"Process timed out after {timeout.TotalSeconds}s: {fileName} {arguments}");
+            }
+
+            // A second WaitForExit flushes the redirected streams after the process exits.
+            process.WaitForExit();
+            string standardOutput = await stdoutTask;
+            string standardError = await stderrTask;
+            return (process.ExitCode, standardOutput, standardError);
+        }
+
+        private static void AssertFileExists(string path, string label)
+        {
+            Assert.That(!string.IsNullOrEmpty(path) && File.Exists(path), Is.True, $"{label} not found: {path}");
+        }
+
+        private static string PrepareCleanDirectory(string subdirectoryName)
+        {
+            string projectRootPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string workRootPath = Path.Combine(projectRootPath, "Library", "UloopHotReloadSpike", subdirectoryName);
+            if (Directory.Exists(workRootPath))
+            {
+                Directory.Delete(workRootPath, true);
+            }
+
+            Directory.CreateDirectory(workRootPath);
+            return workRootPath;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS2WorkerBootstrapTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS2WorkerBootstrapTests.cs
@@ -196,7 +196,13 @@ public static class SpikeWorkerProgram
             Task completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(timeout));
             if (completedTask != waitForExitTask)
             {
-                process.Kill();
+                // HasExited guard: the process may exit between the timeout firing and the
+                // kill, and Kill on an exited process throws, masking the timeout failure.
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                }
+
                 Assert.Fail($"Process timed out after {timeout.TotalSeconds}s: {fileName} {arguments}");
             }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS2WorkerBootstrapTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS2WorkerBootstrapTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0253e39a8ad724f10be8d488684d63ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS3PrefixDelegationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS3PrefixDelegationTests.cs
@@ -17,7 +17,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
     /// </summary>
     public class HotReloadSpikeS3PrefixDelegationTests
     {
-        private const string HarmonyId = "io.github.hatayama.uloop.hot-reload";
+        // Test-scoped id: sharing the production hot reload id would let this suite's
+        // UnpatchAll remove real hot reload patches from the Editor domain.
+        private const string HarmonyId = "io.github.hatayama.uloop.hot-reload-spike-s3";
 
         private class SpikeDelegationTarget
         {

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS3PrefixDelegationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS3PrefixDelegationTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using HarmonyLib;
+using NUnit.Framework;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
+{
+    /// <summary>
+    /// Spike S3 for hot reload: proves that hand-written Harmony prefixes shaped exactly like
+    /// the shims a hot reload transform would generate (static methods binding __instance and
+    /// ref __result by name, returning false to skip the original) fully replace method bodies
+    /// on the Editor Mono runtime, across the method shapes the design promises: instance void,
+    /// instance with return value, static, async, iterator, and private methods, including
+    /// delegates captured before the patch.
+    /// </summary>
+    public class HotReloadSpikeS3PrefixDelegationTests
+    {
+        private const string HarmonyId = "io.github.hatayama.uloop.hot-reload";
+
+        private class SpikeDelegationTarget
+        {
+            public int Offset = 3;
+            public List<string> CallLog = new();
+
+            public void RecordGreeting()
+            {
+                CallLog.Add("original");
+            }
+
+            public int AddOffset(int value)
+            {
+                return value + Offset;
+            }
+
+            public static int StaticDouble(int value)
+            {
+                return value * 2;
+            }
+
+            public async Task<int> ComputeAsync()
+            {
+                await Task.Yield();
+                return 1;
+            }
+
+            public IEnumerable<int> EnumerateNumbers()
+            {
+                yield return 1;
+                yield return 2;
+            }
+
+            public int CallSecretNumber()
+            {
+                return SecretNumber();
+            }
+
+            private int SecretNumber()
+            {
+                return 5;
+            }
+        }
+
+        // Harmony's prefix contract binds __instance/__result by parameter name and requires
+        // ref for __result; the repo-wide no-ref rule yields to that external contract here,
+        // exactly as the generated production shims will.
+        private static class SpikeDelegationShims
+        {
+            public static bool RecordGreetingPrefix(SpikeDelegationTarget __instance)
+            {
+                __instance.CallLog.Add("replaced");
+                return false;
+            }
+
+            public static bool AddOffsetPrefix(SpikeDelegationTarget __instance, ref int __result, int value)
+            {
+                __result = value * 10 + __instance.Offset;
+                return false;
+            }
+
+            public static bool StaticDoublePrefix(ref int __result, int value)
+            {
+                __result = value * 100;
+                return false;
+            }
+
+            public static bool ComputeAsyncPrefix(ref Task<int> __result)
+            {
+                __result = ReplacementComputeAsync();
+                return false;
+            }
+
+            private static async Task<int> ReplacementComputeAsync()
+            {
+                await Task.Yield();
+                return 42;
+            }
+
+            public static bool EnumerateNumbersPrefix(ref IEnumerable<int> __result)
+            {
+                __result = ReplacementNumbers();
+                return false;
+            }
+
+            private static IEnumerable<int> ReplacementNumbers()
+            {
+                yield return 7;
+                yield return 8;
+                yield return 9;
+            }
+
+            public static bool SecretNumberPrefix(ref int __result)
+            {
+                __result = 55;
+                return false;
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            new Harmony(HarmonyId).UnpatchAll(HarmonyId);
+        }
+
+        /// <summary>What: a skipping prefix fully replaces an instance void method body.</summary>
+        [Test]
+        public void InstanceVoidMethod_WithSkippingPrefix_RunsReplacementBodyOnly()
+        {
+            PatchWithPrefix(nameof(SpikeDelegationTarget.RecordGreeting), nameof(SpikeDelegationShims.RecordGreetingPrefix));
+
+            SpikeDelegationTarget target = new();
+            target.RecordGreeting();
+
+            Assert.That(target.CallLog, Is.EqualTo(new[] { "replaced" }));
+        }
+
+        /// <summary>
+        /// What: a skipping prefix replaces the return value of an instance method and can read
+        /// instance state through __instance, proving instance binding.
+        /// </summary>
+        [Test]
+        public void InstanceMethodWithReturn_WithSkippingPrefix_UsesArgumentAndInstanceState()
+        {
+            PatchWithPrefix(nameof(SpikeDelegationTarget.AddOffset), nameof(SpikeDelegationShims.AddOffsetPrefix));
+
+            SpikeDelegationTarget target = new();
+            Assert.That(target.AddOffset(4), Is.EqualTo(43));
+        }
+
+        /// <summary>What: a skipping prefix fully replaces a static method.</summary>
+        [Test]
+        public void StaticMethod_WithSkippingPrefix_ReturnsReplacementValue()
+        {
+            PatchWithPrefix(nameof(SpikeDelegationTarget.StaticDouble), nameof(SpikeDelegationShims.StaticDoublePrefix));
+
+            Assert.That(SpikeDelegationTarget.StaticDouble(4), Is.EqualTo(400));
+        }
+
+        /// <summary>
+        /// What: a skipping prefix replaces an async method by substituting the returned task
+        /// with one produced by a replacement async implementation.
+        /// </summary>
+        [Test]
+        public async Task AsyncMethod_WithSkippingPrefix_AwaitsReplacementTask()
+        {
+            PatchWithPrefix(nameof(SpikeDelegationTarget.ComputeAsync), nameof(SpikeDelegationShims.ComputeAsyncPrefix));
+
+            SpikeDelegationTarget target = new();
+            int computedValue = await target.ComputeAsync();
+
+            Assert.That(computedValue, Is.EqualTo(42));
+        }
+
+        /// <summary>
+        /// What: a skipping prefix replaces an iterator method by substituting the returned
+        /// sequence with one produced by a replacement iterator.
+        /// </summary>
+        [Test]
+        public void IteratorMethod_WithSkippingPrefix_YieldsReplacementSequence()
+        {
+            PatchWithPrefix(nameof(SpikeDelegationTarget.EnumerateNumbers), nameof(SpikeDelegationShims.EnumerateNumbersPrefix));
+
+            SpikeDelegationTarget target = new();
+            List<int> observedValues = new(target.EnumerateNumbers());
+
+            Assert.That(observedValues, Is.EqualTo(new[] { 7, 8, 9 }));
+        }
+
+        /// <summary>
+        /// What: a delegate captured before the patch still hits the detour afterwards, because
+        /// the delegate points at the method entry that Harmony rewrites in place.
+        /// </summary>
+        [Test]
+        public void DelegateCapturedBeforePatch_AfterPatch_HitsDetour()
+        {
+            SpikeDelegationTarget target = new();
+            Func<int, int> capturedDelegate = target.AddOffset;
+            Assert.That(capturedDelegate(4), Is.EqualTo(7), "Sanity check before patching: 4 + Offset(3).");
+
+            PatchWithPrefix(nameof(SpikeDelegationTarget.AddOffset), nameof(SpikeDelegationShims.AddOffsetPrefix));
+
+            Assert.That(capturedDelegate(4), Is.EqualTo(43));
+        }
+
+        /// <summary>
+        /// What: a private method resolved via AccessTools can be patched, observed both through
+        /// a bound delegate and through its public caller compiled before the patch.
+        /// </summary>
+        [Test]
+        public void PrivateMethod_PatchedViaAccessTools_ReturnsReplacementValue()
+        {
+            PatchWithPrefix("SecretNumber", nameof(SpikeDelegationShims.SecretNumberPrefix));
+
+            SpikeDelegationTarget target = new();
+            MethodInfo secretMethod = AccessTools.Method(typeof(SpikeDelegationTarget), "SecretNumber");
+            Func<int> boundSecret = (Func<int>)secretMethod.CreateDelegate(typeof(Func<int>), target);
+            Assert.That(boundSecret(), Is.EqualTo(55));
+
+            // A failure on this line alone would mean the JIT inlined SecretNumber into its
+            // caller — the documented IsLikelyJitInlined limitation — and must be recorded as a
+            // spike finding rather than silently worked around.
+            Assert.That(target.CallSecretNumber(), Is.EqualTo(55));
+        }
+
+        /// <summary>What: UnpatchAll removes the prefix and restores the original behavior.</summary>
+        [Test]
+        public void UnpatchAll_AfterPatch_RestoresOriginalBehavior()
+        {
+            PatchWithPrefix(nameof(SpikeDelegationTarget.AddOffset), nameof(SpikeDelegationShims.AddOffsetPrefix));
+            SpikeDelegationTarget target = new();
+            Assert.That(target.AddOffset(4), Is.EqualTo(43), "Sanity check: the patch must be active before unpatching.");
+
+            new Harmony(HarmonyId).UnpatchAll(HarmonyId);
+
+            Assert.That(target.AddOffset(4), Is.EqualTo(7));
+        }
+
+        private static void PatchWithPrefix(string targetMethodName, string prefixMethodName)
+        {
+            MethodInfo targetMethod = AccessTools.Method(typeof(SpikeDelegationTarget), targetMethodName);
+            MethodInfo prefixMethod = AccessTools.Method(typeof(SpikeDelegationShims), prefixMethodName);
+            Assert.That(targetMethod, Is.Not.Null, $"Target method not found: {targetMethodName}");
+            Assert.That(prefixMethod, Is.Not.Null, $"Prefix method not found: {prefixMethodName}");
+
+            Harmony harmony = new(HarmonyId);
+            harmony.Patch(targetMethod, prefix: new HarmonyMethod(prefixMethod));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS3PrefixDelegationTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS3PrefixDelegationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1fc6edcbab0274fc4a95d4bafa6e401a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/SpikeAccessFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/SpikeAccessFixtures.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
 {
     /// <summary>
@@ -19,6 +21,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
         // snippet method compiled outside Unity; -1 is a sentinel proving the original body ran.
         public int ReplaceableCompute(int delta)
         {
+            return -1 * delta;
+        }
+
+        // Delegation target for the S1 async pin: a Harmony transpiler replaces this body with
+        // a call to an accessor-rewritten async shim; -1 is a sentinel proving the original ran.
+        public async Task<int> ReplaceableComputeAsync(int delta)
+        {
+            await Task.Yield();
             return -1 * delta;
         }
     }

--- a/Assets/Tests/Editor/HotReload/SpikeAccessFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/SpikeAccessFixtures.cs
@@ -1,0 +1,37 @@
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
+{
+    /// <summary>
+    /// Holds private members that the S1 spike snippet must reach through a publicized
+    /// reference copy of this test assembly.
+    /// </summary>
+    public class SpikePrivateAccessFixture
+    {
+        private int _counter = 10;
+
+        public int CounterForAssert => _counter;
+
+        private void BumpByOne()
+        {
+            _counter++;
+        }
+
+        // Transplant target for S1: a Harmony transpiler replaces this body with the IL of a
+        // snippet method compiled outside Unity; -1 is a sentinel proving the original body ran.
+        public int ReplaceableCompute(int delta)
+        {
+            return -1 * delta;
+        }
+    }
+
+    /// <summary>
+    /// Internal type the S1 spike snippet must reach, proving that type-level accessibility
+    /// (not only member-level) is bypassed for code compiled against a publicized copy.
+    /// </summary>
+    internal class SpikeInternalFixture
+    {
+        internal static int SecretSeed()
+        {
+            return 21;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/SpikeAccessFixtures.cs.meta
+++ b/Assets/Tests/Editor/HotReload/SpikeAccessFixtures.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c537a05e90b564fc89b2b13ecb442b44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
+++ b/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "UnityCLILoop.Tests.Editor.HotReload",
+    "rootNamespace": "io.github.hatayama.UnityCliLoop.Tests.Editor",
+    "references": [
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:afe86dd49995e46baa33e099a4d2ee1d"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "UnityCliLoop.0Harmony.dll",
+        "Mono.Cecil.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef.meta
+++ b/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 28ecd484b0cda4a278148b43a090fa74
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/AssemblyInfo.cs
@@ -3,5 +3,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Watch.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.HotReload")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Demo.Editor")]

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -1,0 +1,167 @@
+# Hot Reload: Design Notes and Spike Findings
+
+Status: feasibility spike completed (PR-1). This document records the design, what the spike
+proved and refuted on the Editor Mono runtime, and the mechanism decision derived from it.
+The spike tests live in `Assets/Tests/Editor/HotReload/` and stay in the repository as
+executable pins of the runtime behavior this design depends on.
+
+## Goal
+
+Reload edited method bodies into a running Unity Editor (including Play Mode) without domain
+reload, without requiring any attribute on user code, driven by `uloop hot-reload --files
+<edited .cs files>`. The input is the real source file, so a later `uloop compile` (real
+compilation + domain reload) naturally converges to the same behavior.
+
+Editor-only. Players (Mono or IL2CPP) are out of scope.
+
+## Pipeline Overview
+
+```
+edited .cs file
+  │ (1) resolve owning assembly, defines, and references via CompilationPipeline
+  ▼
+transform worker (external process: Unity-bundled Roslyn on the Unity-bundled .NET host)
+  │ (2) parse + semantic analysis; convert each eligible method body into a static shim
+  │     method source (bare member references qualified via `instance.` / `global::Type.`),
+  │     plus a manifest and per-method skip reasons
+  ▼
+shim compilation (existing external csc infrastructure, RoslynCompilerBackend)
+  │ (3) compile the shim source against publicized reference assemblies
+  │     (Cecil visibility rewrite, same assembly name) → dll + pdb bytes
+  ▼
+Assembly.Load(bytes, pdb)      (4) load the shim assembly into the Editor domain
+  ▼
+Harmony transpiler transplant  (5) patch the original method with a transpiler that discards
+                                   the original instructions and emits the shim method's IL,
+                                   so the body runs inside Harmony's skip-visibility
+                                   DynamicMethod replacement
+```
+
+Harmony ID: `io.github.hatayama.uloop.hot-reload` (distinct from the pause point's ID).
+Caches: `Library/UloopHotReload/PublicizedRefs/<assemblyName>-<mvid>.dll` and
+`Library/UloopHotReload/Worker/<sourceHash>/`.
+
+## Spike Findings
+
+### S1 — access mechanics on the Editor Mono runtime (pivotal)
+
+Test file: `HotReloadSpikeS1PublicizedAccessTests.cs` (Unity 2022.3.62f3).
+
+What the spike **refuted** (each pinned by a test so a Unity upgrade that changes the
+behavior surfaces immediately):
+
+1. **This Mono enforces IL accessibility at JIT time.** A snippet compiled against a
+   publicized reference copy compiles and loads fine, but invoking it throws
+   `FieldAccessException` when the method is JIT-compiled. The original design assumption
+   ("Mono does not re-check accessibility for loaded IL") is false on this runtime.
+2. **`IgnoresAccessChecksToAttribute` is not honored.** Embedding the attribute (declared
+   locally, listing the target assembly) changes nothing; the same exception is thrown.
+3. **A private-poking method cannot even be Harmony-patched.** Harmony must JIT-compile the
+   patch target to detour it, so `Harmony.Patch` on such a method throws
+   `FieldAccessException` at patch time. Consequence: shim IL containing inaccessible
+   references must never be JIT-compiled at all.
+4. The async variant fails identically: the private accesses live in the compiler-generated
+   `MoveNext` body, which fails JIT accessibility checks on first execution.
+
+What the spike **proved**:
+
+- **Publicized reference copies work for compile time.** A Cecil visibility rewrite
+  (types/fields/methods to public, `<Module>` untouched, assembly name preserved) lets the
+  external csc compile snippets that read/write private fields, call private methods, and
+  use internal types, with a reference set of only mscorlib + the publicized copy.
+- **Transplant mechanism (chosen).** Patching a normal method of the target assembly with a
+  Harmony transpiler that discards the original instructions and returns
+  `PatchProcessor.GetOriginalInstructions(shimMethod, generator)` executes the shim's body
+  inside Harmony's skip-visibility DynamicMethod. Private field write, private method call,
+  and internal type access all succeed. The shim method itself is never JIT-compiled; its IL
+  is only read as data. Argument slots line up because an instance method `(this, args…)`
+  and its static shim `(instance, args…)` occupy identical slots.
+- **Accessor mechanism (proven alternative).** Rewriting private accesses to Harmony
+  `AccessTools.FieldRefAccess` delegate fields keeps the shim IL JIT-legal; this works even
+  inside async state machine bodies (verified). Retained as the documented fallback should
+  transplant coverage prove insufficient; not part of v1.
+
+### S2 — transform worker bootstrap
+
+Test file: `HotReloadSpikeS2WorkerBootstrapTests.cs`.
+
+- The Unity-bundled csc (`csc.dll` on the bundled .NET host) compiles a standalone worker
+  executable against the bundled shared framework (`-nostdlib+ -target:exe`, references =
+  every dll in `NetCoreRuntimeSharedDirectoryPath` + the two bundled Roslyn assemblies).
+- The worker resolves `Microsoft.CodeAnalysis*` at runtime from the compiler directory via
+  an `AssemblyLoadContext.Default.Resolving` hook registered in `Main` before any Roslyn
+  type is touched (Roslyn usage lives in a separate method so `Main`'s JIT does not trigger
+  the load early).
+- Copying `csc.runtimeconfig.json` verbatim as the worker's runtimeconfig pins the same
+  bundled runtime the compiler itself runs on.
+- All paths come from the existing `ExternalCompilerPathResolver`; no new resolution logic
+  was needed.
+
+### S3 — Harmony detour behavior
+
+Test file: `HotReloadSpikeS3PrefixDelegationTests.cs`.
+
+Skipping prefixes fully replace instance void, instance-with-return, static, async, and
+iterator methods; a delegate captured before patching still hits the detour (the detour
+rewrites the method entry in place); private methods resolve and patch via `AccessTools`;
+`UnpatchAll` restores original behavior. These tests document the detour semantics the
+transplant mechanism inherits (it uses the same patching machinery with a transpiler instead
+of a prefix).
+
+## Mechanism Decision
+
+**Transplant-primary.** Stage (5) applies a Harmony transpiler per patched method that
+replaces the original instructions with the shim method's instructions.
+
+Why transplant over the accessor rewrite:
+
+- The worker-side transform stays exactly the qualification rewrite stage (2) already needs
+  (`this` → `instance`, bare member references qualified); no per-access-kind accessor
+  machinery, whose corner cases (compound assignments, ref arguments, internal types in
+  locals and signatures, events, object creation of internal types) would each become a skip
+  or a bug.
+- Inside the skip-visibility DynamicMethod, every access kind works uniformly — the spike's
+  pinned tests show the alternative mechanisms fail wholesale, not per-kind.
+- No prefix wrapper generation is needed at all, and Harmony binding conventions
+  (`__instance`, `ref __result`) drop out of the generated code entirely.
+
+Boundaries the mechanism imposes (enforced as per-method skips, detected by the worker's
+semantic model):
+
+- **Async/iterator bodies that touch inaccessible members are skipped.** The transplant
+  replaces the visible method (the async/iterator stub); the shim's compiler-generated
+  `MoveNext` body still JIT-compiles normally and would throw (pinned by the S1 async test).
+  Async/iterator methods whose bodies only touch accessible members are supported.
+- **Lambdas and local functions that touch inaccessible members are skipped** for the same
+  reason: their bodies compile into closure methods of the shim assembly, which JIT-compile
+  normally when the delegate is invoked.
+
+## Convergence and Lifecycle
+
+- Input is the real source file; a later real compile converges to identical behavior. No
+  separate "diff file" workflow exists.
+- The patch ledger and loaded shim assemblies are static state; both are cleared by domain
+  reload by design (no persistence, no auto-reapply). Shim assemblies cannot be unloaded and
+  accumulate until the next domain reload; that is accepted.
+- Mvid guard before patching: if the on-disk `Library/ScriptAssemblies/<asm>.dll` Mvid
+  differs from the loaded module's `ModuleVersionId`, the assembly has already been rebuilt
+  and reloaded — hot reload is refused with a pointer to `uloop compile`.
+- Re-reloading the same method unpatches the previous transpiler before applying the new one.
+
+## Known Limits (documented, not worked around)
+
+- Adding fields, types, or methods; changing signatures; changing field initializers — all
+  require `uloop compile`. Shim compile errors caused by references to newly added members
+  are reported with that hint.
+- In-flight async methods and coroutines keep running the old code until re-entered.
+- Callers whose call sites were JIT-inlined may not observe the detour (`IsLikelyJitInlined`
+  heuristic produces a warning, as with pause points).
+- A transplanted method discards other transpilers' output on that method; in particular a
+  pause point on a hot-reloaded method stops firing. The response carries a warning.
+
+## Open Questions Tracked for Implementation
+
+- Transplant of methods with exception handlers (`try/finally`, `using`) rides on Harmony's
+  standard `CodeInstruction` block round-trip; PR-3's end-to-end tests must include such a
+  body.
+- Struct (value type) methods stay skipped in v1 (same restriction the prefix design had).

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -76,10 +76,15 @@ What the spike **proved**:
   and internal type access all succeed. The shim method itself is never JIT-compiled; its IL
   is only read as data. Argument slots line up because an instance method `(this, args…)`
   and its static shim `(instance, args…)` occupy identical slots.
-- **Accessor mechanism (proven alternative).** Rewriting private accesses to Harmony
-  `AccessTools.FieldRefAccess` delegate fields keeps the shim IL JIT-legal; this works even
-  inside async state machine bodies (verified). Retained as the documented fallback should
-  transplant coverage prove insufficient; not part of v1.
+- **Accessor mechanism (proven; committed as the v2 stage).** Rewriting private accesses to
+  Harmony accessor delegate fields keeps the shim IL JIT-legal; this works even inside async
+  state machine bodies. Verified for private field access (`AccessTools.FieldRefAccess`
+  delegates) and for private method calls (open-instance delegates built by
+  `AccessTools.MethodDelegate`).
+- **Delegation transpiler (proven; the v2 patch shape).** Patching an original async method
+  with a transpiler that replaces its body with "load arguments, call the accessor-rewritten
+  shim, return" routes calls to the shim, whose state machine JIT-compiles legally. Verified
+  end-to-end on an async original.
 
 ### S2 — transform worker bootstrap
 
@@ -128,13 +133,33 @@ Why transplant over the accessor rewrite:
 Boundaries the mechanism imposes (enforced as per-method skips, detected by the worker's
 semantic model):
 
-- **Async/iterator bodies that touch inaccessible members are skipped.** The transplant
+- **Async/iterator bodies that touch inaccessible members are skipped in v1.** The transplant
   replaces the visible method (the async/iterator stub); the shim's compiler-generated
   `MoveNext` body still JIT-compiles normally and would throw (pinned by the S1 async test).
   Async/iterator methods whose bodies only touch accessible members are supported.
-- **Lambdas and local functions that touch inaccessible members are skipped** for the same
-  reason: their bodies compile into closure methods of the shim assembly, which JIT-compile
-  normally when the delegate is invoked.
+- **Lambdas and local functions that touch inaccessible members are skipped in v1** for the
+  same reason: their bodies compile into closure methods of the shim assembly, which
+  JIT-compile normally when the delegate is invoked.
+
+### v2: accessor delegation for async, iterator, and closure bodies
+
+v2 lifts the two v1 boundaries above by rewriting the inaccessible accesses instead of
+transplanting the IL. For a method that v1 would skip only because its async/iterator/closure
+body touches inaccessible members, the worker rewrites each such access into a call through a
+generated accessor delegate field (`AccessTools.FieldRef` for fields; open-instance delegates
+for methods and property accessors). The rewritten shim is JIT-legal, so the original method
+is patched with the delegation transpiler instead of the transplant transpiler.
+
+- The shim self-binds: a generated `__BindAccessors()` method assigns the delegate fields via
+  Harmony's string-based `AccessTools` lookups, and the loader invokes it once after
+  `Assembly.Load`, before patching. The binding code only references public Harmony APIs,
+  `typeof` of accessible types, and string literals, so it JIT-compiles legally.
+- Scope constraint: the rewrite applies only when the containing type and every type
+  appearing in an accessor signature (instance type, field type, parameter and return types)
+  is accessible to a foreign assembly. Inaccessible member *names* are fine; inaccessible
+  *types as types* (locals, casts, `new`, signatures) are not rewritable and keep the skip.
+- Still skipped in v2: bodies using internal types as types (above), private callees with
+  `ref`/`out` parameters, and event add/remove on inaccessible events.
 
 ## Convergence and Lifecycle
 

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -16,7 +16,7 @@ Editor-only. Players (Mono or IL2CPP) are out of scope.
 
 ## Pipeline Overview
 
-```
+```text
 edited .cs file
   │ (1) resolve owning assembly, defines, and references via CompilationPipeline
   ▼
@@ -141,7 +141,12 @@ semantic model):
   same reason: their bodies compile into closure methods of the shim assembly, which
   JIT-compile normally when the delegate is invoked.
 
-### v2: accessor delegation for async, iterator, and closure bodies
+### v2 (planned): accessor delegation for async, iterator, and closure bodies
+
+Status: committed follow-up stage, not yet implemented. The async case is pinned by the S1
+spike tests (method-delegate accessor and delegation transpiler); iterator and closure bodies
+ride the same JIT-legality mechanism and must be verified by that stage's end-to-end tests
+before being documented as supported.
 
 v2 lifts the two v1 boundaries above by rewriting the inaccessible accesses instead of
 transplanting the IL. For a method that v1 would skip only because its async/iterator/closure


### PR DESCRIPTION
## Summary

Feasibility spike (PR-1) for attribute-free hot reload. Adds three EditMode spike test classes under `Assets/Tests/Editor/HotReload/` (dedicated asmdef with the vendored Harmony + Mono.Cecil), the design document `docs/hot-reload.md`, and an `InternalsVisibleTo` entry so the spike can drive `RoslynCompilerBackend` / `ExternalCompilerPathResolver` directly.

## What the spike established

**Refuted (each pinned as a test so a future Unity upgrade surfaces the change):**
- The Editor Mono runtime (2022.3.62f3) enforces IL accessibility at JIT time: a snippet compiled against a publicized reference copy loads fine but throws `FieldAccessException` on first call.
- `IgnoresAccessChecksToAttribute` is not honored by this runtime.
- A private-poking method cannot even be Harmony-patched: Harmony JIT-compiles the patch target to detour it, so `Patch` throws at patch time.
- The async variant fails identically inside the compiler-generated `MoveNext`.

**Proven:**
- S1: Cecil-publicized reference copies (same assembly name) work for compile time; the working runtime mechanism is a Harmony transpiler that transplants the compiled shim method's IL into the original method, so the body executes inside Harmony's skip-visibility DynamicMethod (private field write, private method call, and internal type access all succeed). An `AccessTools.FieldRefAccess` accessor rewrite is proven as a fallback, including inside async state machines.
- S2: a standalone worker compiles with the Unity-bundled csc against the bundled shared framework, runs on the bundled .NET host, and resolves the bundled Roslyn assemblies at runtime via an `AssemblyLoadContext.Default.Resolving` hook; `csc.runtimeconfig.json` is reused verbatim.
- S3: Harmony detour semantics across method shapes (instance void / instance return / static / async / iterator), pre-captured delegates hitting the detour, private targets via `AccessTools`, and `UnpatchAll` restoring behavior.

The mechanism decision (transplant-primary) and its boundaries (async/iterator or lambda bodies touching inaccessible members are skipped) are recorded in `docs/hot-reload.md`.

## Verification

- `dist/darwin-arm64/uloop compile`: 0 errors / 0 warnings
- Spike filter run: 17/17 passed (`--filter-type regex --filter-value HotReloadSpike`)
- Full EditMode suite: 2448 tests, 2441 passed, 0 failed, 7 skipped (pre-existing Windows-only platform skips)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

