### PR TITLE
feat: add hot reload transform worker and shim compilation pipeline

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
     /// <summary>
@@ -12,15 +16,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 
     /// <summary>
+    /// Sibling type in the same namespace — bare references in edited bodies prove shims are
+    /// emitted inside the original namespace (not the global namespace).
+    /// </summary>
+    public class HotReloadE2ESibling
+    {
+        public int Value;
+    }
+
+    public interface IHotReloadE2EMarker
+    {
+        int ExplicitPing();
+    }
+
+    /// <summary>
     /// Compiled fixture whose on-disk source path is passed as <c>files[]</c> to the
     /// orchestrator. Edited copies for worker input live under
     /// <c>Library/UloopHotReload/TestSources/</c> (never under Assets).
     /// </summary>
-    public class HotReloadE2EFixture : HotReloadE2EBase
+    public class HotReloadE2EFixture : HotReloadE2EBase, IHotReloadE2EMarker
     {
         private int _secret = 10;
 
         public int SecretForAssert => _secret;
+
+        public int Counter;
+
+        private int this[int index] => _secret + index;
 
         // Sentinel body: hot reload must replace this with a private-touching shim that returns
         // _secret + delta + 100.
@@ -39,6 +61,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public int CallsMissingHelper(int value)
         {
             return value;
+        }
+
+        // Explicit interface implementation — must be Skipped so its dotted metadata name cannot
+        // poison shim compilation for the rest of the file.
+        int IHotReloadE2EMarker.ExplicitPing()
+        {
+            return _secret;
+        }
+
+        // Sync method + query syntax referencing a private field — must be Skipped (query clauses
+        // become display-class methods that JIT accessibility-check).
+        public int QueryPrivate()
+        {
+            int[] values = { 1, 2, 3 };
+            return (from value in values where value < _secret select value).Count();
+        }
+
+        // Async body reading a private indexer — must be Skipped (MoveNext JIT-checks).
+        public async Task<int> AsyncReadPrivateIndexer()
+        {
+            await Task.Yield();
+            return this[0];
+        }
+
+        // Multidimensional array parameter — exercises Cecil FullName `[0...,0...]` matching.
+        public int SumGrid(int[,] grid)
+        {
+            return -1;
+        }
+
+        // Nested constructed generic parameter — worker manifest must emit Cecil's FullName shape.
+        public int CountEnumerator(List<int>.Enumerator enumerator)
+        {
+            return 0;
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -1,0 +1,44 @@
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Base type used by the e2e fixture to exercise the worker's base-call skip path.
+    /// </summary>
+    public class HotReloadE2EBase
+    {
+        protected int BaseSeed()
+        {
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// Compiled fixture whose on-disk source path is passed as <c>files[]</c> to the
+    /// orchestrator. Edited copies for worker input live under
+    /// <c>Library/UloopHotReload/TestSources/</c> (never under Assets).
+    /// </summary>
+    public class HotReloadE2EFixture : HotReloadE2EBase
+    {
+        private int _secret = 10;
+
+        public int SecretForAssert => _secret;
+
+        // Sentinel body: hot reload must replace this with a private-touching shim that returns
+        // _secret + delta + 100.
+        public int ComputeWithPrivate(int delta)
+        {
+            return _secret + delta;
+        }
+
+        // Contains base. — worker must skip with an explicit reason (not an error).
+        public int CallsBase()
+        {
+            return base.BaseSeed() + 1;
+        }
+
+        // Edited copy will call a non-existent helper so shim compile fails with a new-member hint.
+        public int CallsMissingHelper(int value)
+        {
+            return value;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 075ea9d92a4324ba59cf5127380da982
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -33,7 +33,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string fixturePath = ResolveE2EFixturePath();
             string editedPath = WriteEditedSource(
                 "ComputeWithPrivate.cs",
-                BuildFixtureSourceWithComputeBody("return _secret + delta + 100;"));
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
 
             HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
                 new[] { fixturePath },
@@ -45,6 +47,90 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             HotReloadE2EFixture fixture = new HotReloadE2EFixture();
             Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(10 + 5 + 100));
+        }
+
+        /// <summary>
+        /// What: expression-bodied edited methods keep a terminating semicolon in generated shims
+        /// and still transplant successfully.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedExpressionBodiedMethod_PatchesBehavior()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "ComputeWithPrivateExpression.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta) => _secret + delta + 100;"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(10 + 5 + 100));
+        }
+
+        /// <summary>
+        /// What: bare sibling-type references and owned members inside object initializers both
+        /// compile in generated shims (namespace emission + initializer non-qualification).
+        /// </summary>
+        [Test]
+        public async Task Run_EditedBodyWithSiblingTypeAndObjectInitializer_PatchesBehavior()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "SiblingAndInitializer.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n"
+                    + "            HotReloadE2ESibling s = new HotReloadE2ESibling { Value = delta };\n"
+                    + "            HotReloadE2EFixture other = new HotReloadE2EFixture { Counter = delta };\n"
+                    + "            return _secret + s.Value + other.Counter + 100;\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(10 + 5 + 5 + 100));
+        }
+
+        /// <summary>
+        /// What: a method with a multidimensional array parameter patches successfully (Cecil
+        /// FullName uses [0...,0...] and must match the worker manifest).
+        /// </summary>
+        [Test]
+        public async Task Run_EditedMultidimensionalArrayParameterMethod_PatchesBehavior()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "SumGrid.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    sumGridMethod:
+                    "public int SumGrid(int[,] grid)\n        {\n            return 42;\n        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.SumGrid));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.SumGrid(new int[1, 1]), Is.EqualTo(42));
         }
 
         /// <summary>
@@ -86,7 +172,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string fixturePath = ResolveE2EFixturePath();
             string editedPath = WriteEditedSource(
                 "MissingHelper.cs",
-                BuildFixtureSourceWithMissingHelperCall());
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    callsMissingHelperMethod:
+                    "public int CallsMissingHelper(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }"));
 
             HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
                 new[] { fixturePath },
@@ -171,9 +261,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return path;
         }
 
-        private static string BuildFixtureSourceWithComputeBody(string computeBodyExpression)
+        private static string BuildFixtureSource(
+            string computeWithPrivateMethod,
+            string sumGridMethod = null,
+            string callsMissingHelperMethod = null)
         {
-            return @"namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+            string sumGrid = sumGridMethod ??
+                "public int SumGrid(int[,] grid)\n        {\n            return -1;\n        }";
+            string callsMissingHelper = callsMissingHelperMethod ??
+                "public int CallsMissingHelper(int value)\n        {\n            return value;\n        }";
+
+            return @"using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
     public class HotReloadE2EBase
     {
@@ -183,62 +285,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
     }
 
-    public class HotReloadE2EFixture : HotReloadE2EBase
+    public class HotReloadE2ESibling
+    {
+        public int Value;
+    }
+
+    public interface IHotReloadE2EMarker
+    {
+        int ExplicitPing();
+    }
+
+    public class HotReloadE2EFixture : HotReloadE2EBase, IHotReloadE2EMarker
     {
         private int _secret = 10;
 
         public int SecretForAssert => _secret;
 
-        public int ComputeWithPrivate(int delta)
-        {
-            " + computeBodyExpression + @"
-        }
+        public int Counter;
+
+        private int this[int index] => _secret + index;
+
+        " + computeWithPrivateMethod + @"
 
         public int CallsBase()
         {
             return base.BaseSeed() + 1;
         }
 
-        public int CallsMissingHelper(int value)
+        " + callsMissingHelper + @"
+
+        int IHotReloadE2EMarker.ExplicitPing()
         {
-            return value;
-        }
-    }
-}
-";
+            return _secret;
         }
 
-        private static string BuildFixtureSourceWithMissingHelperCall()
+        public int QueryPrivate()
         {
-            return @"namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
-{
-    public class HotReloadE2EBase
-    {
-        protected int BaseSeed()
-        {
-            return 1;
-        }
-    }
-
-    public class HotReloadE2EFixture : HotReloadE2EBase
-    {
-        private int _secret = 10;
-
-        public int SecretForAssert => _secret;
-
-        public int ComputeWithPrivate(int delta)
-        {
-            return _secret + delta;
+            int[] values = { 1, 2, 3 };
+            return (from value in values where value < _secret select value).Count();
         }
 
-        public int CallsBase()
+        public async Task<int> AsyncReadPrivateIndexer()
         {
-            return base.BaseSeed() + 1;
+            await Task.Yield();
+            return this[0];
         }
 
-        public int CallsMissingHelper(int value)
+        " + sumGrid + @"
+
+        public int CountEnumerator(List<int>.Enumerator enumerator)
         {
-            return MissingHelperAddedByEdit(value);
+            return 0;
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1,0 +1,248 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// End-to-end EditMode coverage for <see cref="HotReloadOrchestrator"/> using the
+    /// files[] / contentPathOverride separation (edited copies under Library/, never Assets/).
+    /// </summary>
+    public class HotReloadOrchestratorTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadPatcher.RevertAll();
+        }
+
+        /// <summary>
+        /// What: an edited copy that changes ComputeWithPrivate is transplanted, including private
+        /// field access, so the live method returns the new value.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedPrivateAccessMethod_PatchesBehavior()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "ComputeWithPrivate.cs",
+                BuildFixtureSourceWithComputeBody("return _secret + delta + 100;"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(10 + 5 + 100));
+        }
+
+        /// <summary>
+        /// What: a method containing base. is reported as Skipped with an explanatory reason.
+        /// </summary>
+        [Test]
+        public async Task Run_MethodWithBaseCall_IsSkippedWithReason()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                contentPathOverride: null,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+
+            bool found = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
+                    && outcome.Method.Contains(nameof(HotReloadE2EFixture.CallsBase))
+                    && outcome.Reason.Contains("base"))
+                {
+                    found = true;
+                }
+            }
+
+            Assert.That(found, Is.True, "Expected CallsBase to be Skipped for base. usage.");
+        }
+
+        /// <summary>
+        /// What: an edited body that calls a non-existent helper fails shim compile with the
+        /// new-member hint (Failed, not a silent skip).
+        /// </summary>
+        [Test]
+        public async Task Run_EditedBodyCallingMissingHelper_FailsShimCompileWithHint()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "MissingHelper.cs",
+                BuildFixtureSourceWithMissingHelperCall());
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            bool foundFailure = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Reason.Contains(HotReloadConstants.NewMemberCompileHint))
+                {
+                    foundFailure = true;
+                }
+            }
+
+            Assert.That(
+                foundFailure,
+                Is.True,
+                "Expected shim-compile Failed carrying the new-member hint. Outcomes:\n"
+                + FormatOutcomes(result));
+        }
+
+        private static void AssertNoFileLevelFailure(HotReloadOrchestratorResult result)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && (outcome.Method == "(file)" || outcome.Method == "(shim-compile)"))
+                {
+                    Assert.Fail("Unexpected file-level failure: " + outcome.Reason);
+                }
+            }
+        }
+
+        private static void AssertHasPatched(HotReloadOrchestratorResult result, string methodName)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
+                    && outcome.Method.Contains(methodName))
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail("Expected Patched outcome for " + methodName + ".\n" + FormatOutcomes(result));
+        }
+
+        private static string FormatOutcomes(HotReloadOrchestratorResult result)
+        {
+            List<string> lines = new List<string>();
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                lines.Add(outcome.Kind + " " + outcome.Method + " :: " + outcome.Reason);
+            }
+
+            return string.Join("\n", lines);
+        }
+
+        private static string ResolveE2EFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadE2EFixtures.cs");
+            Assert.That(File.Exists(path), Is.True, "E2E fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string WriteEditedSource(string fileName, string contents)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(
+                projectRoot,
+                HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string path = Path.Combine(directory, fileName);
+            File.WriteAllText(path, contents);
+            return path;
+        }
+
+        private static string BuildFixtureSourceWithComputeBody(string computeBodyExpression)
+        {
+            return @"namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    public class HotReloadE2EBase
+    {
+        protected int BaseSeed()
+        {
+            return 1;
+        }
+    }
+
+    public class HotReloadE2EFixture : HotReloadE2EBase
+    {
+        private int _secret = 10;
+
+        public int SecretForAssert => _secret;
+
+        public int ComputeWithPrivate(int delta)
+        {
+            " + computeBodyExpression + @"
+        }
+
+        public int CallsBase()
+        {
+            return base.BaseSeed() + 1;
+        }
+
+        public int CallsMissingHelper(int value)
+        {
+            return value;
+        }
+    }
+}
+";
+        }
+
+        private static string BuildFixtureSourceWithMissingHelperCall()
+        {
+            return @"namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    public class HotReloadE2EBase
+    {
+        protected int BaseSeed()
+        {
+            return 1;
+        }
+    }
+
+    public class HotReloadE2EFixture : HotReloadE2EBase
+    {
+        private int _secret = 10;
+
+        public int SecretForAssert => _secret;
+
+        public int ComputeWithPrivate(int delta)
+        {
+            return _secret + delta;
+        }
+
+        public int CallsBase()
+        {
+            return base.BaseSeed() + 1;
+        }
+
+        public int CallsMissingHelper(int value)
+        {
+            return MissingHelperAddedByEdit(value);
+        }
+    }
+}
+";
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -106,6 +106,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: 5+ locals force short-form ldloc.s/stloc.s so the LocalBuilder rebind path is
+        /// exercised (ldloc.0–3 alone would not cover ReadLocalIndexOperand).
+        /// </summary>
+        [Test]
+        public async Task Run_EditedBodyWithFiveLocals_PatchesBehavior()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "FiveLocals.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n"
+                    + "            int a = delta + 1;\n"
+                    + "            int b = a + delta;\n"
+                    + "            int c = b + a;\n"
+                    + "            int d = c + b;\n"
+                    + "            int e = d + c;\n"
+                    + "            return _secret + a + b + c + d + e + (a * b) + (c * d) + (e * a);\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(
+                fixture.ComputeWithPrivate(5),
+                Is.EqualTo(10 + 6 + 11 + 17 + 28 + 45 + (6 * 11) + (17 * 28) + (45 * 6)));
+        }
+
+        /// <summary>
         /// What: a method with a multidimensional array parameter patches successfully (Cecil
         /// FullName uses [0...,0...] and must match the worker manifest).
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a599ad5a918cb4be384176433101c3c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -67,9 +67,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasSkip(result, "ExplicitPing", "Explicit interface");
             AssertHasSkip(result, nameof(HotReloadE2EFixture.QueryPrivate), "query");
             AssertHasSkip(result, nameof(HotReloadE2EFixture.AsyncReadPrivateIndexer), "private/internal");
-
-            // Explicit-interface skip must not prevent other methods in the same file from patching.
-            Assert.That(foundCompute, Is.True);
         }
 
         private static void AssertHasSkip(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -13,18 +13,87 @@ using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
     /// <summary>
-    /// EditMode coverage for transform-worker bootstrap and a smoke invocation that returns entries.
+    /// EditMode coverage for transform-worker bootstrap and skip/manifest smoke checks.
     /// </summary>
     public class TransformWorkerClientTests
     {
         private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        private const string ExpectedListEnumeratorFullName =
+            "System.Collections.Generic.List`1/Enumerator<System.Int32>";
 
         /// <summary>
         /// What: bootstrap compiles (or reuses a cached) worker.dll, then running the worker on the
-        /// e2e fixture source returns at least one shim entry.
+        /// e2e fixture source returns shim entries and the expected skip reasons.
         /// </summary>
         [Test]
-        public async Task BootstrapAndRun_OnE2EFixture_ReturnsEntries()
+        public async Task BootstrapAndRun_OnE2EFixture_ReturnsEntriesAndExpectedSkips()
+        {
+            TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync();
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output, Is.Not.Null);
+            Assert.That(result.Output.entries, Is.Not.Null);
+            Assert.That(result.Output.entries.Length, Is.GreaterThan(0), "Expected at least one shim entry.");
+            Assert.That(result.Output.shimSource, Is.Not.Null.And.Not.Empty);
+
+            bool foundCompute = false;
+            bool foundListEnumeratorFullName = false;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == nameof(HotReloadE2EFixture.ComputeWithPrivate))
+                {
+                    foundCompute = true;
+                    Assert.That(entry.shimMethodName, Does.Contain("__shim"));
+                    Assert.That(entry.shimTypeName, Does.Contain("UloopHotReloadShims"));
+                }
+
+                if (entry.methodName == nameof(HotReloadE2EFixture.CountEnumerator)
+                    && entry.parameterTypeFullNames != null
+                    && entry.parameterTypeFullNames.Length == 1
+                    && entry.parameterTypeFullNames[0] == ExpectedListEnumeratorFullName)
+                {
+                    foundListEnumeratorFullName = true;
+                }
+            }
+
+            Assert.That(foundCompute, Is.True, "ComputeWithPrivate entry missing from worker output.");
+            Assert.That(
+                foundListEnumeratorFullName,
+                Is.True,
+                "CountEnumerator parameterTypeFullNames must use Cecil nested-generic FullName: "
+                + ExpectedListEnumeratorFullName);
+
+            Assert.That(result.Output.skipped, Is.Not.Null, "Expected a skipped list from the worker.");
+            AssertHasSkip(result, nameof(HotReloadE2EFixture.CallsBase), "base");
+            AssertHasSkip(result, "ExplicitPing", "Explicit interface");
+            AssertHasSkip(result, nameof(HotReloadE2EFixture.QueryPrivate), "query");
+            AssertHasSkip(result, nameof(HotReloadE2EFixture.AsyncReadPrivateIndexer), "private/internal");
+
+            // Explicit-interface skip must not prevent other methods in the same file from patching.
+            Assert.That(foundCompute, Is.True);
+        }
+
+        private static void AssertHasSkip(
+            TransformWorkerClientResult result,
+            string methodNameFragment,
+            string reasonFragment)
+        {
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.Contains(methodNameFragment)
+                    && skipped.reason != null
+                    && skipped.reason.Contains(reasonFragment))
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                "Expected skip for '" + methodNameFragment + "' with reason containing '"
+                + reasonFragment + "'.");
+        }
+
+        private static async Task<TransformWorkerClientResult> RunWorkerOnE2EFixtureAsync()
         {
             string fixturePath = ResolveE2EFixturePath();
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
@@ -55,40 +124,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 targetTypesAssemblyPath = targetDllPath
             };
 
-            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(input, CancellationToken.None);
-            Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output, Is.Not.Null);
-            Assert.That(result.Output.entries, Is.Not.Null);
-            Assert.That(result.Output.entries.Length, Is.GreaterThan(0), "Expected at least one shim entry.");
-            Assert.That(result.Output.shimSource, Is.Not.Null.And.Not.Empty);
-
-            bool foundCompute = false;
-            foreach (TransformWorkerEntryDto entry in result.Output.entries)
-            {
-                if (entry.methodName == nameof(HotReloadE2EFixture.ComputeWithPrivate))
-                {
-                    foundCompute = true;
-                    Assert.That(entry.shimMethodName, Does.Contain("__shim"));
-                    Assert.That(entry.shimTypeName, Does.Contain("UloopHotReloadShims"));
-                }
-            }
-
-            Assert.That(foundCompute, Is.True, "ComputeWithPrivate entry missing from worker output.");
-
-            Assert.That(result.Output.skipped, Is.Not.Null, "Expected a skipped list from the worker.");
-            bool foundBaseSkip = false;
-            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
-            {
-                if (skipped.method != null
-                    && skipped.method.Contains(nameof(HotReloadE2EFixture.CallsBase))
-                    && skipped.reason != null
-                    && skipped.reason.Contains("base"))
-                {
-                    foundBaseSkip = true;
-                }
-            }
-
-            Assert.That(foundBaseSkip, Is.True, "CallsBase should be skipped for base. usage.");
+            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
         }
 
         private static string ResolveE2EFixturePath()

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
@@ -54,7 +55,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 targetTypesAssemblyPath = targetDllPath
             };
 
-            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(input);
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(input, CancellationToken.None);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Output, Is.Not.Null);
             Assert.That(result.Output.entries, Is.Not.Null);
@@ -74,6 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(foundCompute, Is.True, "ComputeWithPrivate entry missing from worker output.");
 
+            Assert.That(result.Output.skipped, Is.Not.Null, "Expected a skipped list from the worker.");
             bool foundBaseSkip = false;
             foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
             {

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1,0 +1,104 @@
+using System.IO;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for transform-worker bootstrap and a smoke invocation that returns entries.
+    /// </summary>
+    public class TransformWorkerClientTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+
+        /// <summary>
+        /// What: bootstrap compiles (or reuses a cached) worker.dll, then running the worker on the
+        /// e2e fixture source returns at least one shim entry.
+        /// </summary>
+        [Test]
+        public async Task BootstrapAndRun_OnE2EFixture_ReturnsEntries()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                "Library",
+                "ScriptAssemblies",
+                TestAssemblyName + ".dll");
+            Assert.That(File.Exists(targetDllPath), Is.True, "Test assembly dll missing: " + targetDllPath);
+
+            UnityEditor.Compilation.Assembly compilationAssembly = null;
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == TestAssemblyName)
+                {
+                    compilationAssembly = assembly;
+                    break;
+                }
+            }
+
+            Assert.That(compilationAssembly, Is.Not.Null, "CompilationPipeline assembly not found.");
+
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                sourcePath = fixturePath,
+                defines = compilationAssembly.defines ?? System.Array.Empty<string>(),
+                referencePaths = compilationAssembly.allReferences,
+                targetTypesAssemblyPath = targetDllPath
+            };
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(input);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output, Is.Not.Null);
+            Assert.That(result.Output.entries, Is.Not.Null);
+            Assert.That(result.Output.entries.Length, Is.GreaterThan(0), "Expected at least one shim entry.");
+            Assert.That(result.Output.shimSource, Is.Not.Null.And.Not.Empty);
+
+            bool foundCompute = false;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == nameof(HotReloadE2EFixture.ComputeWithPrivate))
+                {
+                    foundCompute = true;
+                    Assert.That(entry.shimMethodName, Does.Contain("__shim"));
+                    Assert.That(entry.shimTypeName, Does.Contain("UloopHotReloadShims"));
+                }
+            }
+
+            Assert.That(foundCompute, Is.True, "ComputeWithPrivate entry missing from worker output.");
+
+            bool foundBaseSkip = false;
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.Contains(nameof(HotReloadE2EFixture.CallsBase))
+                    && skipped.reason != null
+                    && skipped.reason.Contains("base"))
+                {
+                    foundBaseSkip = true;
+                }
+            }
+
+            Assert.That(foundBaseSkip, Is.True, "CallsBase should be skipped for base. usage.");
+        }
+
+        private static string ResolveE2EFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadE2EFixtures.cs");
+            Assert.That(File.Exists(path), Is.True, "E2E fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1a96a8936af44913922e4199c3cfb9e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -14,7 +16,54 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // never reuses a stale visibility rewrite.
         public const string PublicizedRefsRelativeDirectory = "Library/UloopHotReload/PublicizedRefs";
 
+        // Worker binaries are keyed by SHA256 of the TransformWorker~/TransformWorker.cs source.
+        public const string WorkerCacheRelativeDirectory = "Library/UloopHotReload/Worker";
+
+        // EditMode e2e tests place edited source copies here so AssetDatabase is never provoked.
+        public const string TestSourcesRelativeDirectory = "Library/UloopHotReload/TestSources";
+
+        // Package-relative path of the out-of-process transform worker source (tilde dir = Unity-ignored).
+        public const string WorkerSourcePackageRelativePath =
+            "Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs";
+
+        public const string WorkerDllFileName = "worker.dll";
+        public const string WorkerRuntimeConfigFileName = "worker.runtimeconfig.json";
+        public const string WorkerRoslynDirectorySidecarFileName = "roslyn-directory.txt";
+        public const string WorkerResponseFileName = "worker.rsp";
+
+        public const int WorkerProcessTimeoutMilliseconds = 120_000;
+
         public const string BurstCompileAttributeFullName = "Unity.Burst.BurstCompileAttribute";
+
+        public const string NewMemberCompileHint =
+            "Adding new members requires a real compile (uloop compile); hot reload only replaces existing method bodies.";
+
+        /// <summary>
+        /// Returns whether a ScriptAssemblies DLL is a project assembly that may be publicized.
+        /// Engine / test-runner / system assemblies under ScriptAssemblies must stay untouched —
+        /// some are not rewriteable managed images.
+        /// </summary>
+        public static bool IsPublicizableProjectAssemblyFileName(string fileNameWithoutExtension)
+        {
+            if (string.IsNullOrEmpty(fileNameWithoutExtension))
+            {
+                return false;
+            }
+
+            if (fileNameWithoutExtension.StartsWith("UnityEngine", StringComparison.Ordinal)
+                || fileNameWithoutExtension.StartsWith("UnityEditor", StringComparison.Ordinal)
+                || fileNameWithoutExtension.StartsWith("Unity.", StringComparison.Ordinal)
+                || fileNameWithoutExtension.StartsWith("System.", StringComparison.Ordinal)
+                || fileNameWithoutExtension == "System"
+                || fileNameWithoutExtension == "mscorlib"
+                || fileNameWithoutExtension == "netstandard"
+                || fileNameWithoutExtension == "Mono.Security")
+            {
+                return false;
+            }
+
+            return true;
+        }
 
         // Same heuristic threshold as pause point: small IL bodies may already be inlined by Mono,
         // in which case a Harmony detour on the original method will not reach existing call sites.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -134,7 +134,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
 
             TransformWorkerClientResult workerResult =
-                await TransformWorkerClient.RunAsync(workerInput).ConfigureAwait(true);
+                await TransformWorkerClient.RunAsync(workerInput, ct).ConfigureAwait(true);
             if (!workerResult.Success)
             {
                 outcomes.Add(
@@ -226,7 +226,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return HotReloadMethodOutcome.Failed(methodLabel, matchResult.ErrorMessage, filePath);
             }
 
-            Type shimType = shimAssembly.GetType(entry.shimTypeName);
+            Type shimType = FindShimType(shimAssembly, entry.shimTypeName);
             if (shimType == null)
             {
                 return HotReloadMethodOutcome.Failed(
@@ -267,6 +267,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return HotReloadMethodOutcome.Patched(methodLabel, filePath, patchResult.Warning);
+        }
+
+        private static Type FindShimType(Assembly shimAssembly, string shimTypeName)
+        {
+            if (string.IsNullOrEmpty(shimTypeName))
+            {
+                return null;
+            }
+
+            // Prefer the short-name lookup used when shims are in the global namespace; fall back
+            // to scanning because production emits shims into the original type's namespace.
+            Type direct = shimAssembly.GetType(shimTypeName);
+            if (direct != null)
+            {
+                return direct;
+            }
+
+            foreach (Type candidate in shimAssembly.GetTypes())
+            {
+                if (candidate.Name == shimTypeName)
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
         }
 
         private static UnityCompilationAssembly FindCompilationAssembly(string assemblyName)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1,0 +1,446 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Mono.Cecil;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using Assembly = System.Reflection.Assembly;
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// End-to-end hot-reload pipeline: resolve assembly → worker → shim compile → match → patch.
+    /// </summary>
+    internal static class HotReloadOrchestrator
+    {
+        /// <summary>
+        /// Runs hot reload for each path in <paramref name="files"/>.
+        /// <paramref name="contentPathOverride"/> is test-only: when set, the worker reads that
+        /// path while assembly resolution still uses <paramref name="files"/> (so edited copies
+        /// can live under <c>Library/UloopHotReload/TestSources/</c> without provoking AssetDatabase).
+        /// </summary>
+        public static async Task<HotReloadOrchestratorResult> RunAsync(
+            IReadOnlyList<string> files,
+            string contentPathOverride,
+            CancellationToken ct)
+        {
+            Debug.Assert(files != null, "files must not be null.");
+            Debug.Assert(files.Count > 0, "files must not be empty.");
+
+            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
+            List<string> warnings = new List<string>();
+            int patchedTotal = 0;
+
+            for (int index = 0; index < files.Count; index++)
+            {
+                ct.ThrowIfCancellationRequested();
+                string filePath = files[index];
+                string workerSourcePath = string.IsNullOrEmpty(contentPathOverride)
+                    ? filePath
+                    : contentPathOverride;
+
+                HotReloadFileProcessResult fileResult = await ProcessFileAsync(
+                    filePath,
+                    workerSourcePath,
+                    ct).ConfigureAwait(true);
+
+                outcomes.AddRange(fileResult.Outcomes);
+                warnings.AddRange(fileResult.Warnings);
+                patchedTotal += fileResult.PatchedCount;
+            }
+
+            return new HotReloadOrchestratorResult(
+                outcomes,
+                warnings,
+                patchedTotal,
+                HotReloadPatcher.ActivePatchCount);
+        }
+
+        private static async Task<HotReloadFileProcessResult> ProcessFileAsync(
+            string assemblyResolvePath,
+            string workerSourcePath,
+            CancellationToken ct)
+        {
+            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
+            List<string> warnings = new List<string>();
+
+            // CompilationPipeline.GetAssemblyNameFromScriptPath expects a project-relative path
+            // (Assets/... or Packages/...) and returns a file name that already includes ".dll".
+            string projectRelativePath = ToProjectRelativeScriptPath(assemblyResolvePath);
+            string rawAssemblyName = CompilationPipeline.GetAssemblyNameFromScriptPath(projectRelativePath);
+            if (string.IsNullOrEmpty(rawAssemblyName))
+            {
+                outcomes.Add(
+                    HotReloadMethodOutcome.Failed(
+                        "(file)",
+                        "Script path is not part of any compiled assembly (Assets/Packages paths only): "
+                        + assemblyResolvePath,
+                        assemblyResolvePath));
+                return new HotReloadFileProcessResult(outcomes, warnings, 0);
+            }
+
+            string assemblyName = Path.GetFileNameWithoutExtension(rawAssemblyName);
+            UnityCompilationAssembly compilationAssembly = FindCompilationAssembly(assemblyName);
+            if (compilationAssembly == null)
+            {
+                outcomes.Add(
+                    HotReloadMethodOutcome.Failed(
+                        "(file)",
+                        "CompilationPipeline assembly not found: " + assemblyName,
+                        assemblyResolvePath));
+                return new HotReloadFileProcessResult(outcomes, warnings, 0);
+            }
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                assemblyName + HotReloadConstants.CompiledAssemblyExtension);
+
+            if (!File.Exists(targetDllPath))
+            {
+                outcomes.Add(
+                    HotReloadMethodOutcome.Failed(
+                        "(file)",
+                        "Compiled assembly not found at '" + targetDllPath + "'. Compile the project first.",
+                        assemblyResolvePath));
+                return new HotReloadFileProcessResult(outcomes, warnings, 0);
+            }
+
+            string mvidGuardError = CheckMvidGuard(assemblyName, targetDllPath);
+            if (mvidGuardError != null)
+            {
+                outcomes.Add(HotReloadMethodOutcome.Failed("(file)", mvidGuardError, assemblyResolvePath));
+                return new HotReloadFileProcessResult(outcomes, warnings, 0);
+            }
+
+            string[] defines = compilationAssembly.defines ?? Array.Empty<string>();
+            string[] referencePaths = BuildWorkerReferencePaths(compilationAssembly, targetDllPath);
+
+            TransformWorkerInputDto workerInput = new TransformWorkerInputDto
+            {
+                sourcePath = Path.GetFullPath(workerSourcePath),
+                defines = defines,
+                referencePaths = referencePaths,
+                targetTypesAssemblyPath = Path.GetFullPath(targetDllPath)
+            };
+
+            TransformWorkerClientResult workerResult =
+                await TransformWorkerClient.RunAsync(workerInput).ConfigureAwait(true);
+            if (!workerResult.Success)
+            {
+                outcomes.Add(
+                    HotReloadMethodOutcome.Failed("(file)", workerResult.ErrorMessage, assemblyResolvePath));
+                return new HotReloadFileProcessResult(outcomes, warnings, 0);
+            }
+
+            TransformWorkerOutputDto workerOutput = workerResult.Output;
+            if (workerOutput.parseErrors != null)
+            {
+                foreach (string parseError in workerOutput.parseErrors)
+                {
+                    warnings.Add(parseError);
+                }
+            }
+
+            if (workerOutput.skipped != null)
+            {
+                foreach (TransformWorkerSkippedDto skipped in workerOutput.skipped)
+                {
+                    outcomes.Add(
+                        HotReloadMethodOutcome.Skipped(
+                            skipped.method ?? "(unknown)",
+                            skipped.reason ?? string.Empty,
+                            assemblyResolvePath));
+                }
+            }
+
+            if (string.IsNullOrEmpty(workerOutput.shimSource)
+                || workerOutput.entries == null
+                || workerOutput.entries.Length == 0)
+            {
+                return new HotReloadFileProcessResult(outcomes, warnings, 0);
+            }
+
+            List<string> shimReferences = BuildShimReferencePaths(compilationAssembly, targetDllPath);
+            HotReloadShimCompileResult compileResult = await HotReloadShimCompiler.CompileAndLoadAsync(
+                workerOutput.shimSource,
+                shimReferences,
+                defines,
+                ct).ConfigureAwait(true);
+
+            if (!compileResult.Success)
+            {
+                outcomes.Add(
+                    HotReloadMethodOutcome.Failed(
+                        "(shim-compile)",
+                        compileResult.ErrorMessage,
+                        assemblyResolvePath));
+                return new HotReloadFileProcessResult(outcomes, warnings, 0);
+            }
+
+            int patchedCount = 0;
+            foreach (TransformWorkerEntryDto entry in workerOutput.entries)
+            {
+                HotReloadMethodOutcome outcome = ApplyEntry(
+                    entry,
+                    assemblyName,
+                    compileResult.Assembly,
+                    assemblyResolvePath,
+                    warnings);
+                outcomes.Add(outcome);
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched)
+                {
+                    patchedCount++;
+                }
+            }
+
+            return new HotReloadFileProcessResult(outcomes, warnings, patchedCount);
+        }
+
+        private static HotReloadMethodOutcome ApplyEntry(
+            TransformWorkerEntryDto entry,
+            string assemblyName,
+            Assembly shimAssembly,
+            string filePath,
+            List<string> warnings)
+        {
+            string methodLabel = entry.typeMetadataName + "." + entry.methodName;
+            string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
+
+            HotReloadMethodMatchResult matchResult = HotReloadMethodMatcher.Resolve(
+                assemblyName,
+                entry.typeMetadataName,
+                entry.methodName,
+                parameterTypeFullNames);
+            if (!matchResult.Success)
+            {
+                return HotReloadMethodOutcome.Failed(methodLabel, matchResult.ErrorMessage, filePath);
+            }
+
+            Type shimType = shimAssembly.GetType(entry.shimTypeName);
+            if (shimType == null)
+            {
+                return HotReloadMethodOutcome.Failed(
+                    methodLabel,
+                    "Shim type not found in compiled shim assembly: " + entry.shimTypeName,
+                    filePath);
+            }
+
+            MethodInfo shimMethod = shimType.GetMethod(
+                entry.shimMethodName,
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+            if (shimMethod == null)
+            {
+                // Fall back to a broader lookup — DeclaredOnly can miss when the compiler emits
+                // unexpected metadata flags, but still prefer public static.
+                shimMethod = shimType.GetMethod(
+                    entry.shimMethodName,
+                    BindingFlags.Public | BindingFlags.Static);
+            }
+
+            if (shimMethod == null)
+            {
+                return HotReloadMethodOutcome.Failed(
+                    methodLabel,
+                    "Shim method not found: " + entry.shimTypeName + "." + entry.shimMethodName,
+                    filePath);
+            }
+
+            HotReloadPatchResult patchResult = HotReloadPatcher.Apply(matchResult.Method, shimMethod);
+            if (!patchResult.Success)
+            {
+                return HotReloadMethodOutcome.Failed(methodLabel, patchResult.ErrorMessage, filePath);
+            }
+
+            if (!string.IsNullOrEmpty(patchResult.Warning))
+            {
+                warnings.Add(methodLabel + ": " + patchResult.Warning);
+            }
+
+            return HotReloadMethodOutcome.Patched(methodLabel, filePath, patchResult.Warning);
+        }
+
+        private static UnityCompilationAssembly FindCompilationAssembly(string assemblyName)
+        {
+            foreach (UnityCompilationAssembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == assemblyName)
+                {
+                    return assembly;
+                }
+            }
+
+            return null;
+        }
+
+        private static string CheckMvidGuard(string assemblyName, string targetDllPath)
+        {
+            ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
+            using AssemblyDefinition assemblyDefinition =
+                AssemblyDefinition.ReadAssembly(targetDllPath, readerParameters);
+            string compiledMvid = assemblyDefinition.MainModule.Mvid.ToString();
+
+            foreach (Assembly loaded in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (loaded.GetName().Name != assemblyName)
+                {
+                    continue;
+                }
+
+                if (loaded.ManifestModule.ModuleVersionId.ToString() != compiledMvid)
+                {
+                    return HotReloadConstants.StaleAssemblyHint;
+                }
+
+                return null;
+            }
+
+            return HotReloadConstants.AssemblyNotLoadedHint;
+        }
+
+        private static string[] BuildWorkerReferencePaths(
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath)
+        {
+            List<string> paths = new List<string>();
+            if (compilationAssembly.allReferences != null)
+            {
+                foreach (string reference in compilationAssembly.allReferences)
+                {
+                    if (!string.IsNullOrEmpty(reference) && File.Exists(reference))
+                    {
+                        paths.Add(Path.GetFullPath(reference));
+                    }
+                }
+            }
+
+            string fullTarget = Path.GetFullPath(targetDllPath);
+            bool hasTarget = false;
+            foreach (string path in paths)
+            {
+                if (string.Equals(path, fullTarget, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasTarget = true;
+                    break;
+                }
+            }
+
+            if (!hasTarget)
+            {
+                paths.Add(fullTarget);
+            }
+
+            return paths.ToArray();
+        }
+
+        /// <summary>
+        /// Publicize ScriptAssemblies references; leave engine/system DLLs untouched. Never include
+        /// the original (non-publicized) target assembly.
+        /// </summary>
+        private static List<string> BuildShimReferencePaths(
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string scriptAssembliesDirectory = Path.GetFullPath(
+                Path.Combine(projectRoot, HotReloadConstants.ScriptAssembliesRelativeDirectory));
+
+            List<string> references = new List<string>();
+            string publicizedTarget = ReferencePublicizer.GetOrCreatePublicizedCopy(targetDllPath);
+            references.Add(publicizedTarget);
+
+            if (compilationAssembly.allReferences == null)
+            {
+                return references;
+            }
+
+            string fullTarget = Path.GetFullPath(targetDllPath);
+            foreach (string reference in compilationAssembly.allReferences)
+            {
+                if (string.IsNullOrEmpty(reference) || !File.Exists(reference))
+                {
+                    continue;
+                }
+
+                string fullReference = Path.GetFullPath(reference);
+                if (string.Equals(fullReference, fullTarget, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Replaced by the publicized copy above.
+                    continue;
+                }
+
+                string referenceFileName = Path.GetFileNameWithoutExtension(fullReference);
+                if (IsUnderDirectory(fullReference, scriptAssembliesDirectory)
+                    && HotReloadConstants.IsPublicizableProjectAssemblyFileName(referenceFileName))
+                {
+                    references.Add(ReferencePublicizer.GetOrCreatePublicizedCopy(fullReference));
+                }
+                else
+                {
+                    references.Add(fullReference);
+                }
+            }
+
+            return references;
+        }
+
+        private static bool IsUnderDirectory(string fullPath, string directoryPath)
+        {
+            string normalizedPath = fullPath.Replace('\\', '/');
+            string normalizedDirectory = directoryPath.Replace('\\', '/');
+            StringComparison comparison = Application.platform == RuntimePlatform.WindowsEditor
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            return normalizedPath.StartsWith(normalizedDirectory + "/", comparison);
+        }
+
+        private static string ToProjectRelativeScriptPath(string path)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(path), "path must not be empty.");
+            string normalized = path.Replace('\\', '/');
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, "..")).Replace('\\', '/');
+            if (!projectRoot.EndsWith("/", StringComparison.Ordinal))
+            {
+                projectRoot += "/";
+            }
+
+            string fullPath = Path.GetFullPath(path).Replace('\\', '/');
+            StringComparison comparison = Application.platform == RuntimePlatform.WindowsEditor
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            if (fullPath.StartsWith(projectRoot, comparison))
+            {
+                return fullPath.Substring(projectRoot.Length);
+            }
+
+            // Already project-relative (Assets/... or Packages/...).
+            return normalized;
+        }
+
+        private sealed class HotReloadFileProcessResult
+        {
+            public List<HotReloadMethodOutcome> Outcomes { get; }
+            public List<string> Warnings { get; }
+            public int PatchedCount { get; }
+
+            public HotReloadFileProcessResult(
+                List<HotReloadMethodOutcome> outcomes,
+                List<string> warnings,
+                int patchedCount)
+            {
+                Outcomes = outcomes;
+                Warnings = warnings;
+                PatchedCount = patchedCount;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb789c5a9b57d4c60ba2c7a29ce07f50
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Aggregated outcome of a hot-reload orchestrator run across one or more files.
+    /// </summary>
+    internal sealed class HotReloadOrchestratorResult
+    {
+        public IReadOnlyList<HotReloadMethodOutcome> Methods { get; }
+        public IReadOnlyList<string> Warnings { get; }
+        public int PatchedTotal { get; }
+        public int ActivePatchTotal { get; }
+
+        public HotReloadOrchestratorResult(
+            IReadOnlyList<HotReloadMethodOutcome> methods,
+            IReadOnlyList<string> warnings,
+            int patchedTotal,
+            int activePatchTotal)
+        {
+            Methods = methods;
+            Warnings = warnings;
+            PatchedTotal = patchedTotal;
+            ActivePatchTotal = activePatchTotal;
+        }
+    }
+
+    /// <summary>
+    /// Per-method outcome: Patched, Skipped, or Failed.
+    /// </summary>
+    internal sealed class HotReloadMethodOutcome
+    {
+        public HotReloadMethodOutcomeKind Kind { get; }
+        public string Method { get; }
+        public string Reason { get; }
+        public string FilePath { get; }
+
+        private HotReloadMethodOutcome(
+            HotReloadMethodOutcomeKind kind,
+            string method,
+            string reason,
+            string filePath)
+        {
+            Kind = kind;
+            Method = method;
+            Reason = reason;
+            FilePath = filePath;
+        }
+
+        public static HotReloadMethodOutcome Patched(string method, string filePath, string warning = "")
+        {
+            return new HotReloadMethodOutcome(
+                HotReloadMethodOutcomeKind.Patched,
+                method,
+                warning ?? string.Empty,
+                filePath);
+        }
+
+        public static HotReloadMethodOutcome Skipped(string method, string reason, string filePath)
+        {
+            return new HotReloadMethodOutcome(
+                HotReloadMethodOutcomeKind.Skipped,
+                method,
+                reason,
+                filePath);
+        }
+
+        public static HotReloadMethodOutcome Failed(string method, string reason, string filePath)
+        {
+            return new HotReloadMethodOutcome(
+                HotReloadMethodOutcomeKind.Failed,
+                method,
+                reason,
+                filePath);
+        }
+    }
+
+    internal enum HotReloadMethodOutcomeKind
+    {
+        Patched = 0,
+        Skipped = 1,
+        Failed = 2
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d44dd13fb3e1f4a338bce47b739d0b39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -110,7 +110,147 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(shimMethod != null, "Transplant source must be registered before Patch runs.");
             // Discard the original (and any prior transpiler) instructions entirely — the shim IL
             // is the whole replacement body.
-            return PatchProcessor.GetOriginalInstructions(shimMethod, generator);
+            // Read shim IL without letting MethodBodyReader declare locals on a throwaway path, then
+            // declare locals on THIS patch ILGenerator and rebind short-form ldloc/stloc onto those
+            // LocalBuilders. Numeric short-forms left as-is produce InvalidProgramException after
+            // transplant when the shim body has locals (typical for object-initializer locals).
+            List<CodeInstruction> transplanted =
+                new List<CodeInstruction>(PatchProcessor.GetOriginalInstructions(shimMethod));
+            RebindShortFormLocals(shimMethod, generator, transplanted);
+            return transplanted;
+        }
+
+        private static void RebindShortFormLocals(
+            MethodInfo shimMethod,
+            ILGenerator generator,
+            List<CodeInstruction> instructions)
+        {
+            Debug.Assert(shimMethod != null, "shimMethod must not be null.");
+            Debug.Assert(generator != null, "generator must not be null.");
+            Debug.Assert(instructions != null, "instructions must not be null.");
+
+            MethodBody methodBody = shimMethod.GetMethodBody();
+            if (methodBody == null || methodBody.LocalVariables.Count == 0)
+            {
+                return;
+            }
+
+            LocalBuilder[] locals = new LocalBuilder[methodBody.LocalVariables.Count];
+            for (int localIndex = 0; localIndex < locals.Length; localIndex++)
+            {
+                LocalVariableInfo localVariable = methodBody.LocalVariables[localIndex];
+                locals[localIndex] = generator.DeclareLocal(localVariable.LocalType, localVariable.IsPinned);
+            }
+
+            for (int instructionIndex = 0; instructionIndex < instructions.Count; instructionIndex++)
+            {
+                CodeInstruction instruction = instructions[instructionIndex];
+                int localIndex;
+                bool isAddress;
+                bool isStore;
+                if (!TryGetLocalOpcodeShape(instruction, out localIndex, out isStore, out isAddress))
+                {
+                    continue;
+                }
+
+                Debug.Assert(
+                    localIndex >= 0 && localIndex < locals.Length,
+                    "Local index from shim IL must fall within declared locals.");
+
+                OpCode opCode = isStore
+                    ? OpCodes.Stloc
+                    : (isAddress ? OpCodes.Ldloca : OpCodes.Ldloc);
+                instructions[instructionIndex] = new CodeInstruction(opCode, locals[localIndex])
+                {
+                    labels = instruction.labels,
+                    blocks = instruction.blocks
+                };
+            }
+        }
+
+        private static bool TryGetLocalOpcodeShape(
+            CodeInstruction instruction,
+            out int localIndex,
+            out bool isStore,
+            out bool isAddress)
+        {
+            localIndex = -1;
+            isStore = false;
+            isAddress = false;
+
+            OpCode opCode = instruction.opcode;
+            if (opCode == OpCodes.Ldloc_0 || opCode == OpCodes.Stloc_0)
+            {
+                localIndex = 0;
+                isStore = opCode == OpCodes.Stloc_0;
+                return true;
+            }
+
+            if (opCode == OpCodes.Ldloc_1 || opCode == OpCodes.Stloc_1)
+            {
+                localIndex = 1;
+                isStore = opCode == OpCodes.Stloc_1;
+                return true;
+            }
+
+            if (opCode == OpCodes.Ldloc_2 || opCode == OpCodes.Stloc_2)
+            {
+                localIndex = 2;
+                isStore = opCode == OpCodes.Stloc_2;
+                return true;
+            }
+
+            if (opCode == OpCodes.Ldloc_3 || opCode == OpCodes.Stloc_3)
+            {
+                localIndex = 3;
+                isStore = opCode == OpCodes.Stloc_3;
+                return true;
+            }
+
+            if (opCode == OpCodes.Ldloc_S || opCode == OpCodes.Stloc_S || opCode == OpCodes.Ldloca_S)
+            {
+                localIndex = ReadLocalIndexOperand(instruction.operand);
+                isStore = opCode == OpCodes.Stloc_S;
+                isAddress = opCode == OpCodes.Ldloca_S;
+                return localIndex >= 0;
+            }
+
+            if (opCode == OpCodes.Ldloc || opCode == OpCodes.Stloc || opCode == OpCodes.Ldloca)
+            {
+                // Rebind even when the operand is already a LocalBuilder: GetOriginalInstructions
+                // without this patch's ILGenerator yields builders that are not owned by it.
+                localIndex = ReadLocalIndexOperand(instruction.operand);
+                isStore = opCode == OpCodes.Stloc;
+                isAddress = opCode == OpCodes.Ldloca;
+                return localIndex >= 0;
+            }
+
+            return false;
+        }
+
+        private static int ReadLocalIndexOperand(object operand)
+        {
+            if (operand is byte byteIndex)
+            {
+                return byteIndex;
+            }
+
+            if (operand is ushort ushortIndex)
+            {
+                return ushortIndex;
+            }
+
+            if (operand is int intIndex)
+            {
+                return intIndex;
+            }
+
+            if (operand is LocalBuilder localBuilder)
+            {
+                return localBuilder.LocalIndex;
+            }
+
+            return -1;
         }
 
         private static MethodInfo ResolveTransplantSource(MethodBase original)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadProcessRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadProcessRunner.cs
@@ -3,8 +3,6 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-using UnityEngine;
-
 using Debug = UnityEngine.Debug;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -39,12 +37,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
             Task<string> stderrTask = process.StandardError.ReadToEndAsync();
-            // Task.Run around WaitForExit mirrors RoslynCompilerBackend / spike S2 — Process has
-            // no awaitable wait on this runtime.
-            Task waitForExitTask = Task.Run(() => process.WaitForExit(), ct);
+            // Do not pass ct to WaitForExit — cancel must take the timeout branch so we can kill
+            // and drain before throwing; otherwise the child keeps writing cache/temp files.
+            Task waitForExitTask = Task.Run(() => process.WaitForExit());
             Task delayTask = Task.Delay(timeout, ct);
             Task completedTask = await Task.WhenAny(waitForExitTask, delayTask).ConfigureAwait(true);
-            ct.ThrowIfCancellationRequested();
 
             if (completedTask != waitForExitTask)
             {
@@ -57,12 +54,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // cannot surface as an unobserved task fault in the Editor.
                 string timedOutStdout = await stdoutTask.ConfigureAwait(true);
                 string timedOutStderr = await stderrTask.ConfigureAwait(true);
+                ct.ThrowIfCancellationRequested();
                 return (
                     -1,
                     timedOutStdout,
                     "Process timed out after " + timeout.TotalSeconds + "s.\n" + timedOutStderr);
             }
 
+            // Process finished; return its result even if ct fired at the same moment.
             process.WaitForExit();
             string standardOutput = await stdoutTask.ConfigureAwait(true);
             string standardError = await stderrTask.ConfigureAwait(true);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadProcessRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadProcessRunner.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityEngine;
+
+using Debug = UnityEngine.Debug;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Shared process launch helper for the hot-reload worker bootstrap and client.
+    /// </summary>
+    internal static class HotReloadProcessRunner
+    {
+        public static async Task<(int exitCode, string standardOutput, string standardError)> RunAsync(
+            string fileName,
+            string arguments,
+            string workingDirectoryPath,
+            TimeSpan timeout,
+            CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(fileName), "fileName must not be empty.");
+
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = workingDirectoryPath,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            using Process process = Process.Start(startInfo);
+            Debug.Assert(process != null, "Failed to start process: " + fileName);
+
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+            // Task.Run around WaitForExit mirrors RoslynCompilerBackend / spike S2 — Process has
+            // no awaitable wait on this runtime.
+            Task waitForExitTask = Task.Run(() => process.WaitForExit(), ct);
+            Task delayTask = Task.Delay(timeout, ct);
+            Task completedTask = await Task.WhenAny(waitForExitTask, delayTask).ConfigureAwait(true);
+            ct.ThrowIfCancellationRequested();
+
+            if (completedTask != waitForExitTask)
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                }
+
+                // Drain redirected streams before disposing the process so a late ObjectDisposedException
+                // cannot surface as an unobserved task fault in the Editor.
+                string timedOutStdout = await stdoutTask.ConfigureAwait(true);
+                string timedOutStderr = await stderrTask.ConfigureAwait(true);
+                return (
+                    -1,
+                    timedOutStdout,
+                    "Process timed out after " + timeout.TotalSeconds + "s.\n" + timedOutStderr);
+            }
+
+            process.WaitForExit();
+            string standardOutput = await stdoutTask.ConfigureAwait(true);
+            string standardError = await stderrTask.ConfigureAwait(true);
+            return (process.ExitCode, standardOutput, standardError);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadProcessRunner.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadProcessRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a7a876205f854dfe95b0f673996efb3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -43,47 +43,62 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string workDirectory = CreateWorkDirectory();
-            string sourcePath = Path.Combine(workDirectory, "HotReloadShim.cs");
-            string dllPath = Path.Combine(workDirectory, "HotReloadShim.dll");
-            string pdbPath = Path.ChangeExtension(dllPath, ".pdb");
-            File.WriteAllText(sourcePath, shimSource);
-
-            List<string> references = new List<string>(referencePaths.Count);
-            foreach (string referencePath in referencePaths)
+            try
             {
-                references.Add(referencePath);
+                string sourcePath = Path.Combine(workDirectory, "HotReloadShim.cs");
+                string dllPath = Path.Combine(workDirectory, "HotReloadShim.dll");
+                string pdbPath = Path.ChangeExtension(dllPath, ".pdb");
+                File.WriteAllText(sourcePath, shimSource);
+
+                List<string> references = new List<string>(referencePaths.Count);
+                foreach (string referencePath in referencePaths)
+                {
+                    references.Add(referencePath);
+                }
+
+                RoslynCompilerOptions compilerOptions = new RoslynCompilerOptions(defineSymbols, allowUnsafeCode: false);
+                DynamicCompilationBackendResult backendResult = await RoslynCompilerBackend.CompileAsync(
+                    sourcePath,
+                    dllPath,
+                    references,
+                    externalCompilerPaths,
+                    compilerOptions,
+                    ct,
+                    markBuildStarted: static () => { },
+                    markBuildFinished: static () => { },
+                    incrementBuildCount: static () => { }).ConfigureAwait(true);
+
+                List<string> errors = CollectErrors(backendResult.CompilerMessages);
+                if (errors.Count > 0)
+                {
+                    string message = string.Join("\n", errors);
+                    return HotReloadShimCompileResult.Failure(
+                        message + "\n" + HotReloadConstants.NewMemberCompileHint);
+                }
+
+                if (!File.Exists(dllPath))
+                {
+                    return HotReloadShimCompileResult.Failure("Shim dll was not produced: " + dllPath);
+                }
+
+                byte[] assemblyBytes = File.ReadAllBytes(dllPath);
+                byte[] pdbBytes = File.Exists(pdbPath) ? File.ReadAllBytes(pdbPath) : null;
+                CompiledAssemblyLoadResult loadResult = CompiledAssemblyLoader.Load(assemblyBytes, pdbBytes);
+                if (!loadResult.Success || loadResult.CompiledAssembly == null)
+                {
+                    return HotReloadShimCompileResult.Failure(
+                        "Shim assembly compiled but failed to load: " + dllPath);
+                }
+
+                return HotReloadShimCompileResult.SuccessResult(loadResult.CompiledAssembly);
             }
-
-            RoslynCompilerOptions compilerOptions = new RoslynCompilerOptions(defineSymbols, allowUnsafeCode: false);
-            DynamicCompilationBackendResult backendResult = await RoslynCompilerBackend.CompileAsync(
-                sourcePath,
-                dllPath,
-                references,
-                externalCompilerPaths,
-                compilerOptions,
-                ct,
-                markBuildStarted: static () => { },
-                markBuildFinished: static () => { },
-                incrementBuildCount: static () => { }).ConfigureAwait(true);
-
-            List<string> errors = CollectErrors(backendResult.CompilerMessages);
-            if (errors.Count > 0)
+            finally
             {
-                string message = string.Join("\n", errors);
-                return HotReloadShimCompileResult.Failure(
-                    message + "\n" + HotReloadConstants.NewMemberCompileHint);
+                if (Directory.Exists(workDirectory))
+                {
+                    Directory.Delete(workDirectory, recursive: true);
+                }
             }
-
-            if (!File.Exists(dllPath))
-            {
-                return HotReloadShimCompileResult.Failure("Shim dll was not produced: " + dllPath);
-            }
-
-            byte[] assemblyBytes = File.ReadAllBytes(dllPath);
-            byte[] pdbBytes = File.Exists(pdbPath) ? File.ReadAllBytes(pdbPath) : null;
-            CompiledAssemblyLoadResult loadResult = CompiledAssemblyLoader.Load(assemblyBytes, pdbBytes);
-            Debug.Assert(loadResult.Success, "CompiledAssemblyLoader must succeed for valid dll bytes.");
-            return HotReloadShimCompileResult.SuccessResult(loadResult.CompiledAssembly);
         }
 
         private static List<string> CollectErrors(CompilerMessage[] compilerMessages)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using Assembly = System.Reflection.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Compiles worker-emitted shim source against publicized ScriptAssemblies references via
+    /// <see cref="RoslynCompilerBackend"/> (not <c>IDynamicCompilationService</c> — that path
+    /// cannot inject publicized copies or caller-supplied defines).
+    /// </summary>
+    internal static class HotReloadShimCompiler
+    {
+        /// <summary>
+        /// Compiles <paramref name="shimSource"/> and loads the resulting assembly into the
+        /// Editor domain. The original (non-publicized) target assembly must not appear in
+        /// <paramref name="referencePaths"/>.
+        /// </summary>
+        public static async Task<HotReloadShimCompileResult> CompileAndLoadAsync(
+            string shimSource,
+            IReadOnlyList<string> referencePaths,
+            IReadOnlyList<string> defineSymbols,
+            CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(shimSource), "shimSource must not be empty.");
+            Debug.Assert(referencePaths != null, "referencePaths must not be null.");
+            Debug.Assert(defineSymbols != null, "defineSymbols must not be null.");
+
+            ExternalCompilerPaths externalCompilerPaths = ExternalCompilerPathResolver.Resolve();
+            if (externalCompilerPaths == null)
+            {
+                return HotReloadShimCompileResult.Failure(
+                    "External compiler paths could not be resolved for this Unity installation.");
+            }
+
+            string workDirectory = CreateWorkDirectory();
+            string sourcePath = Path.Combine(workDirectory, "HotReloadShim.cs");
+            string dllPath = Path.Combine(workDirectory, "HotReloadShim.dll");
+            string pdbPath = Path.ChangeExtension(dllPath, ".pdb");
+            File.WriteAllText(sourcePath, shimSource);
+
+            List<string> references = new List<string>(referencePaths.Count);
+            foreach (string referencePath in referencePaths)
+            {
+                references.Add(referencePath);
+            }
+
+            RoslynCompilerOptions compilerOptions = new RoslynCompilerOptions(defineSymbols, allowUnsafeCode: false);
+            DynamicCompilationBackendResult backendResult = await RoslynCompilerBackend.CompileAsync(
+                sourcePath,
+                dllPath,
+                references,
+                externalCompilerPaths,
+                compilerOptions,
+                ct,
+                markBuildStarted: static () => { },
+                markBuildFinished: static () => { },
+                incrementBuildCount: static () => { }).ConfigureAwait(true);
+
+            List<string> errors = CollectErrors(backendResult.CompilerMessages);
+            if (errors.Count > 0)
+            {
+                string message = string.Join("\n", errors);
+                return HotReloadShimCompileResult.Failure(
+                    message + "\n" + HotReloadConstants.NewMemberCompileHint);
+            }
+
+            if (!File.Exists(dllPath))
+            {
+                return HotReloadShimCompileResult.Failure("Shim dll was not produced: " + dllPath);
+            }
+
+            byte[] assemblyBytes = File.ReadAllBytes(dllPath);
+            byte[] pdbBytes = File.Exists(pdbPath) ? File.ReadAllBytes(pdbPath) : null;
+            CompiledAssemblyLoadResult loadResult = CompiledAssemblyLoader.Load(assemblyBytes, pdbBytes);
+            Debug.Assert(loadResult.Success, "CompiledAssemblyLoader must succeed for valid dll bytes.");
+            return HotReloadShimCompileResult.SuccessResult(loadResult.CompiledAssembly);
+        }
+
+        private static List<string> CollectErrors(CompilerMessage[] compilerMessages)
+        {
+            List<string> errors = new List<string>();
+            if (compilerMessages == null)
+            {
+                return errors;
+            }
+
+            foreach (CompilerMessage compilerMessage in compilerMessages)
+            {
+                if (compilerMessage.type == CompilerMessageType.Error)
+                {
+                    errors.Add(compilerMessage.message);
+                }
+            }
+
+            return errors;
+        }
+
+        private static string CreateWorkDirectory()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string workDirectory = Path.Combine(
+                projectRoot,
+                "Library",
+                "UloopHotReload",
+                "ShimCompile",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(workDirectory);
+            return workDirectory;
+        }
+    }
+
+    /// <summary>
+    /// Outcome of compiling and loading a hot-reload shim assembly.
+    /// </summary>
+    internal sealed class HotReloadShimCompileResult
+    {
+        public bool Success { get; }
+        public Assembly Assembly { get; }
+        public string ErrorMessage { get; }
+
+        private HotReloadShimCompileResult(bool success, Assembly assembly, string errorMessage)
+        {
+            Success = success;
+            Assembly = assembly;
+            ErrorMessage = errorMessage;
+        }
+
+        public static HotReloadShimCompileResult SuccessResult(Assembly assembly)
+        {
+            return new HotReloadShimCompileResult(true, assembly, string.Empty);
+        }
+
+        public static HotReloadShimCompileResult Failure(string errorMessage)
+        {
+            return new HotReloadShimCompileResult(false, null, errorMessage);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ea04ae41d98948d4a1d9ee7ed684482
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
@@ -146,6 +146,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             DefaultAssemblyResolver resolver = new DefaultAssemblyResolver();
             resolver.AddSearchDirectory(Path.GetDirectoryName(sourceDllPath));
 
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            resolver.AddSearchDirectory(
+                Path.Combine(projectRoot, HotReloadConstants.ScriptAssembliesRelativeDirectory));
+
             string contentsPath = EditorApplication.applicationContentsPath;
             if (!string.IsNullOrEmpty(contentsPath))
             {
@@ -153,6 +157,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 resolver.AddSearchDirectory(Path.Combine(contentsPath, "Managed", "UnityEngine"));
                 resolver.AddSearchDirectory(Path.Combine(contentsPath, "UnityReferenceAssemblies", "unity-4.8-api"));
             }
+
+            // Why not: walk AppDomain assemblies for extra search dirs — Assembly.Load(byte[])
+            // shims throw NotSupportedException on .Location, and hot reload loads those shims into
+            // the same domain. ScriptAssemblies + Editor Managed cover the project/engine refs
+            // publicize needs for Write.
 
             return resolver;
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
@@ -3,6 +3,8 @@ using System.IO;
 
 using Mono.Cecil;
 
+using UnityEditor;
+
 using UnityEngine;
 
 using CecilFieldAttributes = Mono.Cecil.FieldAttributes;
@@ -32,7 +34,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             AssertIsScriptAssemblyPath(fullSourceDllPath);
 
             // InMemory: the source DLL is the currently loaded script assembly; keep no file handle.
-            ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
+            // A search-path resolver is required so Cecil can satisfy assembly refs while rewriting
+            // (missing mscorlib/netstandard otherwise throws AssemblyResolutionException on Write).
+            using DefaultAssemblyResolver assemblyResolver = CreateAssemblyResolver(fullSourceDllPath);
+            ReaderParameters readerParameters = new ReaderParameters
+            {
+                InMemory = true,
+                AssemblyResolver = assemblyResolver
+            };
             using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(fullSourceDllPath, readerParameters);
 
             string assemblyName = assemblyDefinition.Name.Name;
@@ -130,6 +139,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             return Path.Combine(projectRoot, HotReloadConstants.PublicizedRefsRelativeDirectory);
+        }
+
+        private static DefaultAssemblyResolver CreateAssemblyResolver(string sourceDllPath)
+        {
+            DefaultAssemblyResolver resolver = new DefaultAssemblyResolver();
+            resolver.AddSearchDirectory(Path.GetDirectoryName(sourceDllPath));
+
+            string contentsPath = EditorApplication.applicationContentsPath;
+            if (!string.IsNullOrEmpty(contentsPath))
+            {
+                resolver.AddSearchDirectory(Path.Combine(contentsPath, "Managed"));
+                resolver.AddSearchDirectory(Path.Combine(contentsPath, "Managed", "UnityEngine"));
+                resolver.AddSearchDirectory(Path.Combine(contentsPath, "UnityReferenceAssemblies", "unity-4.8-api"));
+            }
+
+            return resolver;
         }
 
         private static void PublicizeType(TypeDefinition type)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+using UnityEditor.PackageManager;
+
+using UnityEngine;
+
+using Debug = UnityEngine.Debug;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Compiles and caches the out-of-process transform worker against the Unity-bundled Roslyn
+    /// and .NET host (same bootstrap shape as spike S2).
+    /// </summary>
+    internal static class TransformWorkerBootstrap
+    {
+        /// <summary>
+        /// Ensures a worker.dll matching the current worker source exists under
+        /// <c>Library/UloopHotReload/Worker/&lt;sha256&gt;/</c> and returns that directory.
+        /// </summary>
+        public static async Task<TransformWorkerBootstrapResult> EnsureWorkerAsync()
+        {
+            ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
+            if (paths == null)
+            {
+                return TransformWorkerBootstrapResult.Failure(
+                    "External compiler paths could not be resolved for this Unity installation.");
+            }
+
+            string workerSourcePath = ResolveWorkerSourcePath();
+            if (!File.Exists(workerSourcePath))
+            {
+                return TransformWorkerBootstrapResult.Failure(
+                    "Transform worker source not found: " + workerSourcePath);
+            }
+
+            string sourceHash = ComputeSha256Hex(workerSourcePath);
+            string cacheDirectory = Path.Combine(ResolveWorkerCacheRoot(), sourceHash);
+            string workerDllPath = Path.Combine(cacheDirectory, HotReloadConstants.WorkerDllFileName);
+            string runtimeConfigPath = Path.Combine(cacheDirectory, HotReloadConstants.WorkerRuntimeConfigFileName);
+            string roslynSidecarPath = Path.Combine(
+                cacheDirectory,
+                HotReloadConstants.WorkerRoslynDirectorySidecarFileName);
+
+            if (File.Exists(workerDllPath) && File.Exists(runtimeConfigPath) && File.Exists(roslynSidecarPath))
+            {
+                return TransformWorkerBootstrapResult.SuccessResult(cacheDirectory);
+            }
+
+            Directory.CreateDirectory(cacheDirectory);
+            TransformWorkerBootstrapResult compileResult = await CompileWorkerAsync(
+                paths,
+                workerSourcePath,
+                workerDllPath,
+                cacheDirectory).ConfigureAwait(true);
+            if (!compileResult.Success)
+            {
+                return compileResult;
+            }
+
+            File.Copy(paths.CompilerRuntimeConfigPath, runtimeConfigPath, overwrite: true);
+
+            // Sidecar lets the worker register an ALC Resolving hook without changing the
+            // <in> <out> argv contract from the plan.
+            string roslynDirectoryPath = Path.GetDirectoryName(paths.CompilerDllPath);
+            File.WriteAllText(
+                roslynSidecarPath,
+                roslynDirectoryPath + Environment.NewLine,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+            if (!File.Exists(workerDllPath))
+            {
+                return TransformWorkerBootstrapResult.Failure(
+                    "Worker dll was not produced: " + workerDllPath);
+            }
+
+            return TransformWorkerBootstrapResult.SuccessResult(cacheDirectory);
+        }
+
+        internal static string ResolveWorkerSourcePath()
+        {
+            PackageInfo packageInfo = PackageInfo.FindForAssembly(typeof(TransformWorkerBootstrap).Assembly);
+            Debug.Assert(packageInfo != null, "PackageInfo must resolve for the HotReload assembly.");
+            return Path.Combine(packageInfo.resolvedPath, HotReloadConstants.WorkerSourcePackageRelativePath);
+        }
+
+        private static async Task<TransformWorkerBootstrapResult> CompileWorkerAsync(
+            ExternalCompilerPaths paths,
+            string workerSourcePath,
+            string workerDllPath,
+            string cacheDirectory)
+        {
+            string responseFilePath = Path.Combine(cacheDirectory, HotReloadConstants.WorkerResponseFileName);
+            WriteWorkerResponseFile(responseFilePath, workerSourcePath, workerDllPath, paths);
+
+            (int exitCode, string standardOutput, string standardError) = await RunProcessAsync(
+                paths.DotnetHostPath,
+                "\"" + paths.CompilerDllPath + "\" @\"" + responseFilePath + "\"",
+                cacheDirectory,
+                TimeSpan.FromMilliseconds(HotReloadConstants.WorkerProcessTimeoutMilliseconds)).ConfigureAwait(true);
+
+            if (exitCode != 0)
+            {
+                return TransformWorkerBootstrapResult.Failure(
+                    "Transform worker compilation failed.\nstdout:\n" + standardOutput
+                    + "\nstderr:\n" + standardError);
+            }
+
+            return TransformWorkerBootstrapResult.SuccessResult(cacheDirectory);
+        }
+
+        private static void WriteWorkerResponseFile(
+            string responseFilePath,
+            string workerSourcePath,
+            string workerDllPath,
+            ExternalCompilerPaths paths)
+        {
+            // Mirrors spike S2: framework-dependent exe against the bundled shared framework + Roslyn.
+            List<string> lines = new List<string>
+            {
+                "-nologo",
+                "-nostdlib+",
+                "-target:exe",
+                "-out:\"" + workerDllPath + "\""
+            };
+
+            foreach (string referencePath in Directory.GetFiles(paths.NetCoreRuntimeSharedDirectoryPath, "*.dll"))
+            {
+                lines.Add("-r:\"" + referencePath + "\"");
+            }
+
+            lines.Add("-r:\"" + paths.CodeAnalysisDllPath + "\"");
+            lines.Add("-r:\"" + paths.CodeAnalysisCSharpDllPath + "\"");
+            lines.Add("\"" + workerSourcePath + "\"");
+            File.WriteAllLines(responseFilePath, lines);
+        }
+
+        private static async Task<(int exitCode, string standardOutput, string standardError)> RunProcessAsync(
+            string fileName,
+            string arguments,
+            string workingDirectoryPath,
+            TimeSpan timeout)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = workingDirectoryPath,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            using Process process = Process.Start(startInfo);
+            Debug.Assert(process != null, "Failed to start process: " + fileName);
+
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+            // Task.Run around WaitForExit mirrors RoslynCompilerBackend / spike S2 — Process has
+            // no awaitable wait on this runtime.
+            Task waitForExitTask = Task.Run(() => process.WaitForExit());
+            Task completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(timeout)).ConfigureAwait(true);
+            if (completedTask != waitForExitTask)
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                }
+
+                return (-1, string.Empty, "Process timed out after " + timeout.TotalSeconds + "s.");
+            }
+
+            process.WaitForExit();
+            string standardOutput = await stdoutTask.ConfigureAwait(true);
+            string standardError = await stderrTask.ConfigureAwait(true);
+            return (process.ExitCode, standardOutput, standardError);
+        }
+
+        private static string ComputeSha256Hex(string filePath)
+        {
+            using SHA256 sha256 = SHA256.Create();
+            using FileStream stream = File.OpenRead(filePath);
+            byte[] hash = sha256.ComputeHash(stream);
+            StringBuilder builder = new StringBuilder(hash.Length * 2);
+            foreach (byte value in hash)
+            {
+                builder.Append(value.ToString("x2"));
+            }
+
+            return builder.ToString();
+        }
+
+        private static string ResolveWorkerCacheRoot()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            return Path.Combine(projectRoot, HotReloadConstants.WorkerCacheRelativeDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Outcome of ensuring a cached transform worker binary exists.
+    /// </summary>
+    internal sealed class TransformWorkerBootstrapResult
+    {
+        public bool Success { get; }
+        public string WorkerDirectory { get; }
+        public string ErrorMessage { get; }
+
+        private TransformWorkerBootstrapResult(bool success, string workerDirectory, string errorMessage)
+        {
+            Success = success;
+            WorkerDirectory = workerDirectory;
+            ErrorMessage = errorMessage;
+        }
+
+        public static TransformWorkerBootstrapResult SuccessResult(string workerDirectory)
+        {
+            return new TransformWorkerBootstrapResult(true, workerDirectory, string.Empty);
+        }
+
+        public static TransformWorkerBootstrapResult Failure(string errorMessage)
+        {
+            return new TransformWorkerBootstrapResult(false, null, errorMessage);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 using UnityEditor.PackageManager;
@@ -22,9 +22,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         /// <summary>
         /// Ensures a worker.dll matching the current worker source exists under
-        /// <c>Library/UloopHotReload/Worker/&lt;sha256&gt;/</c> and returns that directory.
+        /// <c>Library/UloopHotReload/Worker/&lt;hash&gt;/</c> and returns that directory.
         /// </summary>
-        public static async Task<TransformWorkerBootstrapResult> EnsureWorkerAsync()
+        public static async Task<TransformWorkerBootstrapResult> EnsureWorkerAsync(CancellationToken ct)
         {
             ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
             if (paths == null)
@@ -40,8 +40,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     "Transform worker source not found: " + workerSourcePath);
             }
 
-            string sourceHash = ComputeSha256Hex(workerSourcePath);
-            string cacheDirectory = Path.Combine(ResolveWorkerCacheRoot(), sourceHash);
+            // Include toolchain paths so a Unity Editor upgrade cannot reuse a stale sidecar that
+            // points at a removed Roslyn directory under Library/.
+            string cacheKey = ComputeCacheKey(workerSourcePath, paths);
+            string cacheDirectory = Path.Combine(ResolveWorkerCacheRoot(), cacheKey);
             string workerDllPath = Path.Combine(cacheDirectory, HotReloadConstants.WorkerDllFileName);
             string runtimeConfigPath = Path.Combine(cacheDirectory, HotReloadConstants.WorkerRuntimeConfigFileName);
             string roslynSidecarPath = Path.Combine(
@@ -58,7 +60,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 paths,
                 workerSourcePath,
                 workerDllPath,
-                cacheDirectory).ConfigureAwait(true);
+                cacheDirectory,
+                ct).ConfigureAwait(true);
             if (!compileResult.Success)
             {
                 return compileResult;
@@ -94,16 +97,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ExternalCompilerPaths paths,
             string workerSourcePath,
             string workerDllPath,
-            string cacheDirectory)
+            string cacheDirectory,
+            CancellationToken ct)
         {
             string responseFilePath = Path.Combine(cacheDirectory, HotReloadConstants.WorkerResponseFileName);
             WriteWorkerResponseFile(responseFilePath, workerSourcePath, workerDllPath, paths);
 
-            (int exitCode, string standardOutput, string standardError) = await RunProcessAsync(
+            (int exitCode, string standardOutput, string standardError) = await HotReloadProcessRunner.RunAsync(
                 paths.DotnetHostPath,
                 "\"" + paths.CompilerDllPath + "\" @\"" + responseFilePath + "\"",
                 cacheDirectory,
-                TimeSpan.FromMilliseconds(HotReloadConstants.WorkerProcessTimeoutMilliseconds)).ConfigureAwait(true);
+                TimeSpan.FromMilliseconds(HotReloadConstants.WorkerProcessTimeoutMilliseconds),
+                ct).ConfigureAwait(true);
 
             if (exitCode != 0)
             {
@@ -141,55 +146,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             File.WriteAllLines(responseFilePath, lines);
         }
 
-        private static async Task<(int exitCode, string standardOutput, string standardError)> RunProcessAsync(
-            string fileName,
-            string arguments,
-            string workingDirectoryPath,
-            TimeSpan timeout)
-        {
-            ProcessStartInfo startInfo = new ProcessStartInfo
-            {
-                FileName = fileName,
-                Arguments = arguments,
-                WorkingDirectory = workingDirectoryPath,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true
-            };
-
-            using Process process = Process.Start(startInfo);
-            Debug.Assert(process != null, "Failed to start process: " + fileName);
-
-            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
-            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
-            // Task.Run around WaitForExit mirrors RoslynCompilerBackend / spike S2 — Process has
-            // no awaitable wait on this runtime.
-            Task waitForExitTask = Task.Run(() => process.WaitForExit());
-            Task completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(timeout)).ConfigureAwait(true);
-            if (completedTask != waitForExitTask)
-            {
-                if (!process.HasExited)
-                {
-                    process.Kill();
-                }
-
-                return (-1, string.Empty, "Process timed out after " + timeout.TotalSeconds + "s.");
-            }
-
-            process.WaitForExit();
-            string standardOutput = await stdoutTask.ConfigureAwait(true);
-            string standardError = await stderrTask.ConfigureAwait(true);
-            return (process.ExitCode, standardOutput, standardError);
-        }
-
-        private static string ComputeSha256Hex(string filePath)
+        private static string ComputeCacheKey(string workerSourcePath, ExternalCompilerPaths paths)
         {
             using SHA256 sha256 = SHA256.Create();
-            using FileStream stream = File.OpenRead(filePath);
-            byte[] hash = sha256.ComputeHash(stream);
-            StringBuilder builder = new StringBuilder(hash.Length * 2);
-            foreach (byte value in hash)
+            using FileStream sourceStream = File.OpenRead(workerSourcePath);
+            byte[] sourceHash = sha256.ComputeHash(sourceStream);
+
+            string toolchainIdentity = string.Join(
+                "|",
+                paths.CompilerDllPath ?? string.Empty,
+                paths.CompilerRuntimeConfigPath ?? string.Empty,
+                paths.DotnetHostPath ?? string.Empty,
+                paths.CodeAnalysisDllPath ?? string.Empty,
+                paths.CodeAnalysisCSharpDllPath ?? string.Empty);
+            byte[] toolchainBytes = Encoding.UTF8.GetBytes(toolchainIdentity);
+            byte[] toolchainHash = sha256.ComputeHash(toolchainBytes);
+
+            byte[] combined = new byte[sourceHash.Length + toolchainHash.Length];
+            Buffer.BlockCopy(sourceHash, 0, combined, 0, sourceHash.Length);
+            Buffer.BlockCopy(toolchainHash, 0, combined, sourceHash.Length, toolchainHash.Length);
+            byte[] finalHash = sha256.ComputeHash(combined);
+
+            StringBuilder builder = new StringBuilder(finalHash.Length * 2);
+            foreach (byte value in finalHash)
             {
                 builder.Append(value.ToString("x2"));
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eba058be7998641fa804668badccbfbd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Newtonsoft.Json;
@@ -19,13 +19,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Bootstraps the worker if needed, writes <paramref name="input"/> to a temp JSON file,
         /// runs <c>dotnet worker.dll &lt;in&gt; &lt;out&gt;</c>, and deserializes the output.
         /// </summary>
-        public static async Task<TransformWorkerClientResult> RunAsync(TransformWorkerInputDto input)
+        public static async Task<TransformWorkerClientResult> RunAsync(
+            TransformWorkerInputDto input,
+            CancellationToken ct)
         {
             Debug.Assert(input != null, "input must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(input.sourcePath), "sourcePath must not be empty.");
 
             TransformWorkerBootstrapResult bootstrapResult =
-                await TransformWorkerBootstrap.EnsureWorkerAsync().ConfigureAwait(true);
+                await TransformWorkerBootstrap.EnsureWorkerAsync(ct).ConfigureAwait(true);
             if (!bootstrapResult.Success)
             {
                 return TransformWorkerClientResult.Failure(bootstrapResult.ErrorMessage);
@@ -51,11 +53,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     bootstrapResult.WorkerDirectory,
                     HotReloadConstants.WorkerDllFileName);
                 string arguments = "\"" + workerDllPath + "\" \"" + inputJsonPath + "\" \"" + outputJsonPath + "\"";
-                (int exitCode, string standardOutput, string standardError) = await RunProcessAsync(
+                (int exitCode, string standardOutput, string standardError) = await HotReloadProcessRunner.RunAsync(
                     paths.DotnetHostPath,
                     arguments,
                     bootstrapResult.WorkerDirectory,
-                    TimeSpan.FromMilliseconds(HotReloadConstants.WorkerProcessTimeoutMilliseconds)).ConfigureAwait(true);
+                    TimeSpan.FromMilliseconds(HotReloadConstants.WorkerProcessTimeoutMilliseconds),
+                    ct).ConfigureAwait(true);
 
                 if (exitCode != 0)
                 {
@@ -99,48 +102,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static void WriteUtf8NoBom(string path, string contents)
         {
             File.WriteAllText(path, contents, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-        }
-
-        private static async Task<(int exitCode, string standardOutput, string standardError)> RunProcessAsync(
-            string fileName,
-            string arguments,
-            string workingDirectoryPath,
-            TimeSpan timeout)
-        {
-            ProcessStartInfo startInfo = new ProcessStartInfo
-            {
-                FileName = fileName,
-                Arguments = arguments,
-                WorkingDirectory = workingDirectoryPath,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true
-            };
-
-            using Process process = Process.Start(startInfo);
-            Debug.Assert(process != null, "Failed to start process: " + fileName);
-
-            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
-            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
-            // Task.Run around WaitForExit mirrors RoslynCompilerBackend / spike S2 — Process has
-            // no awaitable wait on this runtime.
-            Task waitForExitTask = Task.Run(() => process.WaitForExit());
-            Task completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(timeout)).ConfigureAwait(true);
-            if (completedTask != waitForExitTask)
-            {
-                if (!process.HasExited)
-                {
-                    process.Kill();
-                }
-
-                return (-1, string.Empty, "Process timed out after " + timeout.TotalSeconds + "s.");
-            }
-
-            process.WaitForExit();
-            string standardOutput = await stdoutTask.ConfigureAwait(true);
-            string standardError = await stderrTask.ConfigureAwait(true);
-            return (process.ExitCode, standardOutput, standardError);
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+
+using Debug = UnityEngine.Debug;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Runs the cached transform worker with file-path JSON I/O (UTF-8, no BOM).
+    /// </summary>
+    internal static class TransformWorkerClient
+    {
+        /// <summary>
+        /// Bootstraps the worker if needed, writes <paramref name="input"/> to a temp JSON file,
+        /// runs <c>dotnet worker.dll &lt;in&gt; &lt;out&gt;</c>, and deserializes the output.
+        /// </summary>
+        public static async Task<TransformWorkerClientResult> RunAsync(TransformWorkerInputDto input)
+        {
+            Debug.Assert(input != null, "input must not be null.");
+            Debug.Assert(!string.IsNullOrEmpty(input.sourcePath), "sourcePath must not be empty.");
+
+            TransformWorkerBootstrapResult bootstrapResult =
+                await TransformWorkerBootstrap.EnsureWorkerAsync().ConfigureAwait(true);
+            if (!bootstrapResult.Success)
+            {
+                return TransformWorkerClientResult.Failure(bootstrapResult.ErrorMessage);
+            }
+
+            ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
+            if (paths == null)
+            {
+                return TransformWorkerClientResult.Failure(
+                    "External compiler paths could not be resolved for this Unity installation.");
+            }
+
+            string tempDirectory = Path.Combine(Path.GetTempPath(), "uloop-hot-reload-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDirectory);
+            string inputJsonPath = Path.Combine(tempDirectory, "input.json");
+            string outputJsonPath = Path.Combine(tempDirectory, "output.json");
+
+            try
+            {
+                WriteUtf8NoBom(inputJsonPath, JsonConvert.SerializeObject(input));
+
+                string workerDllPath = Path.Combine(
+                    bootstrapResult.WorkerDirectory,
+                    HotReloadConstants.WorkerDllFileName);
+                string arguments = "\"" + workerDllPath + "\" \"" + inputJsonPath + "\" \"" + outputJsonPath + "\"";
+                (int exitCode, string standardOutput, string standardError) = await RunProcessAsync(
+                    paths.DotnetHostPath,
+                    arguments,
+                    bootstrapResult.WorkerDirectory,
+                    TimeSpan.FromMilliseconds(HotReloadConstants.WorkerProcessTimeoutMilliseconds)).ConfigureAwait(true);
+
+                if (exitCode != 0)
+                {
+                    return TransformWorkerClientResult.Failure(
+                        "Transform worker exited with code " + exitCode
+                        + ".\nstdout:\n" + standardOutput
+                        + "\nstderr:\n" + standardError);
+                }
+
+                if (!File.Exists(outputJsonPath))
+                {
+                    return TransformWorkerClientResult.Failure(
+                        "Transform worker did not produce an output JSON file.");
+                }
+
+                string outputJson = File.ReadAllText(
+                    outputJsonPath,
+                    new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                TransformWorkerOutputDto output = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(outputJson);
+                if (output == null)
+                {
+                    return TransformWorkerClientResult.Failure(
+                        "Failed to deserialize transform worker output JSON.");
+                }
+
+                output.entries ??= Array.Empty<TransformWorkerEntryDto>();
+                output.skipped ??= Array.Empty<TransformWorkerSkippedDto>();
+                output.parseErrors ??= Array.Empty<string>();
+                output.shimSource ??= string.Empty;
+                return TransformWorkerClientResult.SuccessResult(output);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDirectory))
+                {
+                    Directory.Delete(tempDirectory, recursive: true);
+                }
+            }
+        }
+
+        private static void WriteUtf8NoBom(string path, string contents)
+        {
+            File.WriteAllText(path, contents, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        }
+
+        private static async Task<(int exitCode, string standardOutput, string standardError)> RunProcessAsync(
+            string fileName,
+            string arguments,
+            string workingDirectoryPath,
+            TimeSpan timeout)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = workingDirectoryPath,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            using Process process = Process.Start(startInfo);
+            Debug.Assert(process != null, "Failed to start process: " + fileName);
+
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+            // Task.Run around WaitForExit mirrors RoslynCompilerBackend / spike S2 — Process has
+            // no awaitable wait on this runtime.
+            Task waitForExitTask = Task.Run(() => process.WaitForExit());
+            Task completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(timeout)).ConfigureAwait(true);
+            if (completedTask != waitForExitTask)
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                }
+
+                return (-1, string.Empty, "Process timed out after " + timeout.TotalSeconds + "s.");
+            }
+
+            process.WaitForExit();
+            string standardOutput = await stdoutTask.ConfigureAwait(true);
+            string standardError = await stderrTask.ConfigureAwait(true);
+            return (process.ExitCode, standardOutput, standardError);
+        }
+    }
+
+    /// <summary>
+    /// Outcome of one transform-worker invocation.
+    /// </summary>
+    internal sealed class TransformWorkerClientResult
+    {
+        public bool Success { get; }
+        public TransformWorkerOutputDto Output { get; }
+        public string ErrorMessage { get; }
+
+        private TransformWorkerClientResult(bool success, TransformWorkerOutputDto output, string errorMessage)
+        {
+            Success = success;
+            Output = output;
+            ErrorMessage = errorMessage;
+        }
+
+        public static TransformWorkerClientResult SuccessResult(TransformWorkerOutputDto output)
+        {
+            return new TransformWorkerClientResult(true, output, string.Empty);
+        }
+
+        public static TransformWorkerClientResult Failure(string errorMessage)
+        {
+            return new TransformWorkerClientResult(false, null, errorMessage);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25852036fbb404194988423ee8949ee7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Input payload written for the out-of-process transform worker (UTF-8 JSON, no BOM).
+    /// </summary>
+    [Serializable]
+    internal sealed class TransformWorkerInputDto
+    {
+        public string sourcePath;
+        public string[] defines;
+        public string[] referencePaths;
+        public string targetTypesAssemblyPath;
+    }
+
+    /// <summary>
+    /// Output payload read from the out-of-process transform worker.
+    /// </summary>
+    [Serializable]
+    internal sealed class TransformWorkerOutputDto
+    {
+        public string shimSource;
+        public TransformWorkerEntryDto[] entries;
+        public TransformWorkerSkippedDto[] skipped;
+        public string[] parseErrors;
+    }
+
+    [Serializable]
+    internal sealed class TransformWorkerEntryDto
+    {
+        public string typeMetadataName;
+        public string methodName;
+        public string[] parameterTypeFullNames;
+        public string shimTypeName;
+        public string shimMethodName;
+    }
+
+    [Serializable]
+    internal sealed class TransformWorkerSkippedDto
+    {
+        public string method;
+        public string reason;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32d2d0bf9d0464f1ab2949877e9e4520
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -237,7 +237,14 @@ public static class TransformWorkerProgram
                 {
                     string shimTypeName = typeSymbol.Name + "_UloopHotReloadShims_" + shimTypeCounter;
                     shimTypeCounter++;
-                    currentShimType = new ShimTypeBuilder(shimTypeName, typeSymbol);
+                    string namespaceName = typeSymbol.ContainingNamespace == null
+                        || typeSymbol.ContainingNamespace.IsGlobalNamespace
+                        ? string.Empty
+                        : typeSymbol.ContainingNamespace.ToDisplayString();
+                    currentShimType = new ShimTypeBuilder(
+                        shimTypeName,
+                        namespaceName,
+                        CollectUsingsForType(root, typeDeclaration));
                     shimTypes.Add(currentShimType);
                 }
 
@@ -249,7 +256,7 @@ public static class TransformWorkerProgram
                     methodSymbol,
                     typeSymbol,
                     semanticModel);
-                currentShimType.AddMethod(rewrittenMethod, methodSymbol, shimMethodName);
+                currentShimType.AddMethod(rewrittenMethod, shimMethodName);
 
                 entries.Add(new WorkerEntry
                 {
@@ -291,9 +298,15 @@ public static class TransformWorkerProgram
         IMethodSymbol methodSymbol,
         SemanticModel semanticModel)
     {
-        if (typeDeclaration.Modifiers.Any(static modifier => modifier.IsKind(SyntaxKind.PartialKeyword)))
+        // A nested type inside a partial outer type still has an incomplete single-file model.
+        for (TypeDeclarationSyntax declaration = typeDeclaration;
+             declaration != null;
+             declaration = declaration.Parent as TypeDeclarationSyntax)
         {
-            return "Partial types are skipped because a single file cannot provide a complete semantic model.";
+            if (declaration.Modifiers.Any(static modifier => modifier.IsKind(SyntaxKind.PartialKeyword)))
+            {
+                return "Partial types are skipped because a single file cannot provide a complete semantic model.";
+            }
         }
 
         if (typeSymbol.TypeKind == TypeKind.Struct || typeSymbol.IsValueType)
@@ -423,6 +436,30 @@ public static class TransformWorkerProgram
     {
         return typeSymbol.ToDisplayString(FullyQualifiedTypeFormat) + "." + methodSymbol.Name;
     }
+
+    private static List<UsingDirectiveSyntax> CollectUsingsForType(
+        CompilationUnitSyntax root,
+        TypeDeclarationSyntax typeDeclaration)
+    {
+        List<UsingDirectiveSyntax> usings = new List<UsingDirectiveSyntax>();
+        foreach (UsingDirectiveSyntax usingDirective in root.Usings)
+        {
+            usings.Add(usingDirective.WithoutTrivia());
+        }
+
+        for (SyntaxNode node = typeDeclaration.Parent; node != null; node = node.Parent)
+        {
+            if (node is BaseNamespaceDeclarationSyntax namespaceDeclaration)
+            {
+                foreach (UsingDirectiveSyntax usingDirective in namespaceDeclaration.Usings)
+                {
+                    usings.Add(usingDirective.WithoutTrivia());
+                }
+            }
+        }
+
+        return usings;
+    }
 }
 
 internal static class AccessibilityRules
@@ -511,7 +548,8 @@ internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
     {
         if (IsMemberAccessNameSide(node)
             || IsQualifiedNameRightSide(node)
-            || IsMemberBindingName(node))
+            || IsMemberBindingName(node)
+            || IsObjectOrCollectionInitializerMemberName(node))
         {
             return original;
         }
@@ -619,6 +657,18 @@ internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
         return node.Parent is MemberBindingExpressionSyntax memberBinding
             && memberBinding.Name == node;
     }
+
+    // `new T { _field = 1 }` must keep the bare member name; qualifying to instance._field is
+    // invalid inside an object/collection initializer.
+    private static bool IsObjectOrCollectionInitializerMemberName(SimpleNameSyntax node)
+    {
+        if (node.Parent is not AssignmentExpressionSyntax assignment || assignment.Left != node)
+        {
+            return false;
+        }
+
+        return assignment.Parent is InitializerExpressionSyntax;
+    }
 }
 
 // Nested access to the instance parameter name without exposing TransformWorkerProgram fields
@@ -648,15 +698,19 @@ internal static class ShimMethodFactory
         }
 
         SeparatedSyntaxList<ParameterSyntax> parameters = BuildShimParameters(rewrittenOriginal, methodSymbol);
-        return rewrittenOriginal
+        MethodDeclarationSyntax shim = rewrittenOriginal
             .WithAttributeLists(default)
             .WithModifiers(modifiers)
             .WithReturnType(returnType)
             .WithParameterList(SyntaxFactory.ParameterList(parameters))
             .WithExplicitInterfaceSpecifier(null)
             .WithConstraintClauses(default)
-            .WithSemicolonToken(default)
             .WithTriviaFrom(rewrittenOriginal);
+
+        // Expression-bodied methods must keep their terminating semicolon; block bodies must not.
+        return rewrittenOriginal.ExpressionBody != null
+            ? shim.WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+            : shim.WithSemicolonToken(default);
     }
 
     private static SeparatedSyntaxList<ParameterSyntax> BuildShimParameters(
@@ -685,26 +739,27 @@ internal static class ShimMethodFactory
 internal sealed class ShimTypeBuilder
 {
     private readonly List<MethodDeclarationSyntax> _methods = new List<MethodDeclarationSyntax>();
-    private readonly List<string> _shimMethodNames = new List<string>();
 
-    public ShimTypeBuilder(string shimTypeName, INamedTypeSymbol targetType)
+    public ShimTypeBuilder(
+        string shimTypeName,
+        string namespaceName,
+        List<UsingDirectiveSyntax> usings)
     {
         ShimTypeName = shimTypeName;
-        TargetType = targetType;
+        NamespaceName = namespaceName ?? string.Empty;
+        Usings = usings ?? new List<UsingDirectiveSyntax>();
     }
 
     public string ShimTypeName { get; }
 
-    public INamedTypeSymbol TargetType { get; }
+    public string NamespaceName { get; }
 
-    public void AddMethod(
-        MethodDeclarationSyntax shimMethod,
-        IMethodSymbol originalMethod,
-        string shimMethodName)
+    public List<UsingDirectiveSyntax> Usings { get; }
+
+    public void AddMethod(MethodDeclarationSyntax shimMethod, string shimMethodName)
     {
         MethodDeclarationSyntax named = shimMethod.WithIdentifier(SyntaxFactory.Identifier(shimMethodName));
         _methods.Add(named);
-        _shimMethodNames.Add(shimMethodName);
     }
 
     public IReadOnlyList<MethodDeclarationSyntax> Methods => _methods;
@@ -719,14 +774,10 @@ internal static class ShimSourceEmitter
             return string.Empty;
         }
 
+        // Emit each shim type in the original type's namespace (and with that type's usings) so
+        // unqualified sibling-type references in transplanted bodies still resolve. Manifest
+        // shimTypeName stays the short name; orchestrator resolves by Type.Name.
         CompilationUnitSyntax unit = SyntaxFactory.CompilationUnit();
-        foreach (UsingDirectiveSyntax usingDirective in originalRoot.Usings)
-        {
-            unit = unit.AddUsings(usingDirective.WithoutTrivia());
-        }
-
-        // Emit shim types in the global namespace so Assembly.GetType(shimTypeName) resolves
-        // with the short name recorded in the manifest (matches the plan's shape).
         foreach (ShimTypeBuilder shimType in shimTypes)
         {
             ClassDeclarationSyntax classDeclaration = SyntaxFactory.ClassDeclaration(shimType.ShimTypeName)
@@ -735,7 +786,25 @@ internal static class ShimSourceEmitter
                         SyntaxFactory.Token(SyntaxKind.PublicKeyword),
                         SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
                 .WithMembers(SyntaxFactory.List<MemberDeclarationSyntax>(shimType.Methods));
-            unit = unit.AddMembers(classDeclaration);
+
+            if (string.IsNullOrEmpty(shimType.NamespaceName))
+            {
+                foreach (UsingDirectiveSyntax usingDirective in shimType.Usings)
+                {
+                    unit = unit.AddUsings(usingDirective);
+                }
+
+                unit = unit.AddMembers(classDeclaration);
+            }
+            else
+            {
+                NamespaceDeclarationSyntax namespaceDeclaration = SyntaxFactory.NamespaceDeclaration(
+                        SyntaxFactory.ParseName(shimType.NamespaceName))
+                    .WithUsings(SyntaxFactory.List(shimType.Usings))
+                    .WithMembers(
+                        SyntaxFactory.SingletonList<MemberDeclarationSyntax>(classDeclaration));
+                unit = unit.AddMembers(namespaceDeclaration);
+            }
         }
 
         unit = unit.NormalizeWhitespace();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -320,6 +320,14 @@ public static class TransformWorkerProgram
             return "Generic methods and methods inside generic types cannot be safely patched with Harmony.";
         }
 
+        // Explicit interface implementations have dotted metadata names (e.g. IFoo.Bar) that are
+        // not valid C# identifiers for shim method names; sanitizing would also desync the
+        // matcher (Cecil MethodDefinition.Name). v1 skips them with an explicit reason.
+        if (methodDeclaration.ExplicitInterfaceSpecifier != null)
+        {
+            return "Explicit interface implementations are skipped in v1.";
+        }
+
         SyntaxNode bodyNode = (SyntaxNode)methodDeclaration.Body ?? methodDeclaration.ExpressionBody;
         if (bodyNode == null)
         {
@@ -331,10 +339,10 @@ public static class TransformWorkerProgram
             return "Methods that call base. members are skipped; C# cannot express base calls outside the type.";
         }
 
-        if (SubtreeHasInaccessibleMemberAccess(semanticModel, FindLambdaAndLocalFunctionBodies(bodyNode)))
+        if (SubtreeHasInaccessibleMemberAccess(semanticModel, FindClosureBodies(bodyNode)))
         {
-            return "Lambda or local-function bodies that access private/internal members are skipped in v1 "
-                + "(closure methods JIT-compile normally and fail accessibility checks).";
+            return "Lambda, local-function, or query-expression bodies that access private/internal members "
+                + "are skipped in v1 (closure methods JIT-compile normally and fail accessibility checks).";
         }
 
         if (IsAsyncOrIterator(methodDeclaration, bodyNode)
@@ -359,10 +367,32 @@ public static class TransformWorkerProgram
             return true;
         }
 
-        return bodyNode.DescendantNodes().OfType<YieldStatementSyntax>().Any();
+        // Yields inside local functions do not make the outer method an iterator.
+        foreach (YieldStatementSyntax yieldStatement in bodyNode.DescendantNodes().OfType<YieldStatementSyntax>())
+        {
+            if (!IsInsideLocalFunction(yieldStatement, bodyNode))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
-    private static List<SyntaxNode> FindLambdaAndLocalFunctionBodies(SyntaxNode bodyNode)
+    private static bool IsInsideLocalFunction(SyntaxNode node, SyntaxNode stopAt)
+    {
+        for (SyntaxNode current = node.Parent; current != null && current != stopAt; current = current.Parent)
+        {
+            if (current is LocalFunctionStatementSyntax)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static List<SyntaxNode> FindClosureBodies(SyntaxNode bodyNode)
     {
         List<SyntaxNode> bodies = new List<SyntaxNode>();
         foreach (SyntaxNode node in bodyNode.DescendantNodes())
@@ -387,6 +417,12 @@ public static class TransformWorkerProgram
                     bodies.Add(localBody);
                 }
             }
+            else if (node is QueryExpressionSyntax queryExpression)
+            {
+                // Query clauses compile to display-class methods that JIT normally; treat the
+                // whole query (including the source expression) as a closure body for v1.
+                bodies.Add(queryExpression);
+            }
         }
 
         return bodies;
@@ -405,7 +441,7 @@ public static class TransformWorkerProgram
 
             foreach (SyntaxNode node in root.DescendantNodesAndSelf())
             {
-                if (node is not IdentifierNameSyntax && node is not GenericNameSyntax)
+                if (!IsInaccessibleAccessCandidateNode(node))
                 {
                     continue;
                 }
@@ -419,6 +455,15 @@ public static class TransformWorkerProgram
         }
 
         return false;
+    }
+
+    private static bool IsInaccessibleAccessCandidateNode(SyntaxNode node)
+    {
+        return node is IdentifierNameSyntax
+            || node is GenericNameSyntax
+            || node is ElementAccessExpressionSyntax
+            || node is ObjectCreationExpressionSyntax
+            || node is ImplicitObjectCreationExpressionSyntax;
     }
 
     private static MethodDeclarationSyntax RewriteMethodBody(
@@ -560,15 +605,16 @@ internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
             return original;
         }
 
-        if (!IsOwnedMember(symbol, out bool isStatic, out INamedTypeSymbol containingType))
+        (bool owned, bool isStatic, INamedTypeSymbol containingType) ownership = ResolveOwnedMember(symbol);
+        if (!ownership.owned)
         {
             return original;
         }
 
-        if (isStatic)
+        if (ownership.isStatic)
         {
             TypeSyntax typeSyntax = SyntaxFactory.ParseTypeName(
-                containingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+                ownership.containingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
             return SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     typeSyntax,
@@ -583,17 +629,17 @@ internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
             .WithTriviaFrom(node);
     }
 
-    private bool IsOwnedMember(ISymbol symbol, out bool isStatic, out INamedTypeSymbol containingType)
+    private (bool owned, bool isStatic, INamedTypeSymbol containingType) ResolveOwnedMember(ISymbol symbol)
     {
-        isStatic = false;
-        containingType = null;
+        INamedTypeSymbol containingType;
+        bool isStatic;
 
         if (symbol is IMethodSymbol methodSymbol)
         {
             // Extension methods live on unrelated static classes; leave them alone.
             if (methodSymbol.IsExtensionMethod)
             {
-                return false;
+                return (false, false, null);
             }
 
             containingType = methodSymbol.ContainingType;
@@ -616,15 +662,20 @@ internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
         }
         else
         {
-            return false;
+            return (false, false, null);
         }
 
         if (containingType == null)
         {
-            return false;
+            return (false, false, null);
         }
 
-        return IsInInheritanceHierarchy(_targetType, containingType);
+        if (!IsInInheritanceHierarchy(_targetType, containingType))
+        {
+            return (false, false, null);
+        }
+
+        return (true, isStatic, containingType);
     }
 
     private static bool IsInInheritanceHierarchy(INamedTypeSymbol derived, INamedTypeSymbol candidate)
@@ -861,24 +912,51 @@ internal static class CecilTypeNames
                 return elementName + "[]";
             }
 
-            return elementName + "[" + new string(',', arrayType.Rank - 1) + "]";
+            // Cecil ArrayType.FullName for non-vector arrays uses "[0...,0...]" (lower bounds),
+            // not the C# syntactic "[,]".
+            string[] dimensionMarks = new string[arrayType.Rank];
+            for (int index = 0; index < arrayType.Rank; index++)
+            {
+                dimensionMarks[index] = "0...";
+            }
+
+            return elementName + "[" + string.Join(",", dimensionMarks) + "]";
         }
 
         if (typeSymbol is INamedTypeSymbol namedType)
         {
-            if (namedType.IsGenericType && !namedType.IsUnboundGenericType)
+            // Cecil nests constructed generics as Outer/Inner<all-args-outer-to-inner>, so collect
+            // TypeArguments from the containment chain rather than only the leaf type.
+            List<ITypeSymbol> typeArguments = new List<ITypeSymbol>();
+            CollectConstructedTypeArgumentsOuterToInner(namedType, typeArguments);
+            string head = ToMetadataName(namedType.OriginalDefinition);
+            if (typeArguments.Count == 0)
             {
-                string head = ToMetadataName(namedType.OriginalDefinition);
-                string args = string.Join(",", namedType.TypeArguments.Select(ToCecilFullName));
-                return head + "<" + args + ">";
+                return head;
             }
 
-            return ToMetadataName(namedType);
+            string args = string.Join(",", typeArguments.Select(ToCecilFullName));
+            return head + "<" + args + ">";
         }
 
         return typeSymbol.ToDisplayString(
             new SymbolDisplayFormat(
                 typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces));
+    }
+
+    private static void CollectConstructedTypeArgumentsOuterToInner(
+        INamedTypeSymbol namedType,
+        List<ITypeSymbol> typeArguments)
+    {
+        if (namedType.ContainingType != null)
+        {
+            CollectConstructedTypeArgumentsOuterToInner(namedType.ContainingType, typeArguments);
+        }
+
+        if (namedType.IsGenericType && !namedType.IsUnboundGenericType)
+        {
+            typeArguments.AddRange(namedType.TypeArguments);
+        }
     }
 }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -1,0 +1,856 @@
+// Hot-reload transform worker: parse + semantic analysis of one edited C# file, emit static
+// shim method sources (no Prefix wrappers) plus a per-method manifest / skip list.
+// Runs out-of-process on the Unity-bundled .NET host against the Unity-bundled Roslyn.
+// Generated shims mirror user method signatures verbatim; repo style rules apply to
+// hand-written code only.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+public static class TransformWorkerProgram
+{
+    private const string RoslynDirectorySidecarFileName = "roslyn-directory.txt";
+
+    private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    private static readonly SymbolDisplayFormat FullyQualifiedTypeFormat =
+        SymbolDisplayFormat.FullyQualifiedFormat;
+
+    public static int Main(string[] args)
+    {
+        if (args.Length != 2)
+        {
+            Console.Error.WriteLine("usage: TransformWorker <input-json-path> <output-json-path>");
+            return 2;
+        }
+
+        string roslynDirectoryPath = ReadRoslynDirectorySidecar();
+        AssemblyLoadContext.Default.Resolving += (context, assemblyName) =>
+        {
+            string candidatePath = Path.Combine(roslynDirectoryPath, assemblyName.Name + ".dll");
+            if (File.Exists(candidatePath))
+            {
+                return context.LoadFromAssemblyPath(candidatePath);
+            }
+
+            return null;
+        };
+
+        return RunTransform(args[0], args[1]);
+    }
+
+    private static string ReadRoslynDirectorySidecar()
+    {
+        string baseDirectory = AppContext.BaseDirectory;
+        string sidecarPath = Path.Combine(baseDirectory, RoslynDirectorySidecarFileName);
+        if (!File.Exists(sidecarPath))
+        {
+            throw new InvalidOperationException(
+                "Roslyn directory sidecar not found next to worker.dll: " + sidecarPath);
+        }
+
+        string roslynDirectoryPath = File.ReadAllText(sidecarPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)).Trim();
+        if (string.IsNullOrEmpty(roslynDirectoryPath) || !Directory.Exists(roslynDirectoryPath))
+        {
+            throw new InvalidOperationException("Roslyn directory from sidecar is missing: " + roslynDirectoryPath);
+        }
+
+        return roslynDirectoryPath;
+    }
+
+    private static int RunTransform(string inputJsonPath, string outputJsonPath)
+    {
+        WorkerInput input = ReadInput(inputJsonPath);
+        WorkerOutput output = TransformFile(input);
+        WriteOutput(outputJsonPath, output);
+        return 0;
+    }
+
+    private static WorkerInput ReadInput(string inputJsonPath)
+    {
+        byte[] bytes = File.ReadAllBytes(inputJsonPath);
+        WorkerInput input = JsonSerializer.Deserialize<WorkerInput>(bytes, JsonOptions);
+        if (input == null)
+        {
+            throw new InvalidOperationException("Failed to deserialize worker input JSON.");
+        }
+
+        if (string.IsNullOrEmpty(input.SourcePath))
+        {
+            throw new InvalidOperationException("sourcePath is required.");
+        }
+
+        input.Defines ??= Array.Empty<string>();
+        input.ReferencePaths ??= Array.Empty<string>();
+        return input;
+    }
+
+    private static void WriteOutput(string outputJsonPath, WorkerOutput output)
+    {
+        byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(output, JsonOptions);
+        File.WriteAllBytes(outputJsonPath, bytes);
+    }
+
+    private static WorkerOutput TransformFile(WorkerInput input)
+    {
+        List<string> parseErrors = new List<string>();
+        string sourceText;
+        try
+        {
+            sourceText = File.ReadAllText(input.SourcePath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        }
+        catch (Exception exception)
+        {
+            return new WorkerOutput
+            {
+                ShimSource = string.Empty,
+                Entries = Array.Empty<WorkerEntry>(),
+                Skipped = Array.Empty<WorkerSkipped>(),
+                ParseErrors = new[] { "Failed to read sourcePath: " + exception.Message }
+            };
+        }
+
+        CSharpParseOptions parseOptions = new CSharpParseOptions(
+            languageVersion: LanguageVersion.Latest,
+            preprocessorSymbols: input.Defines);
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(
+            SourceText.From(sourceText, Encoding.UTF8),
+            parseOptions,
+            path: input.SourcePath);
+
+        ImmutableArray<Diagnostic> parseDiagnostics = syntaxTree.GetDiagnostics().ToImmutableArray();
+        foreach (Diagnostic diagnostic in parseDiagnostics)
+        {
+            if (diagnostic.Severity == DiagnosticSeverity.Error)
+            {
+                parseErrors.Add(diagnostic.ToString());
+            }
+        }
+
+        List<MetadataReference> references = new List<MetadataReference>();
+        foreach (string referencePath in input.ReferencePaths)
+        {
+            if (File.Exists(referencePath))
+            {
+                references.Add(MetadataReference.CreateFromFile(referencePath));
+            }
+            else
+            {
+                parseErrors.Add("Reference not found: " + referencePath);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(input.TargetTypesAssemblyPath) && File.Exists(input.TargetTypesAssemblyPath))
+        {
+            bool alreadyListed = false;
+            foreach (string referencePath in input.ReferencePaths)
+            {
+                if (string.Equals(
+                        Path.GetFullPath(referencePath),
+                        Path.GetFullPath(input.TargetTypesAssemblyPath),
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    alreadyListed = true;
+                    break;
+                }
+            }
+
+            if (!alreadyListed)
+            {
+                references.Add(MetadataReference.CreateFromFile(input.TargetTypesAssemblyPath));
+            }
+        }
+
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName: "UloopHotReloadTransformWorkerCompilation",
+            syntaxTrees: new[] { syntaxTree },
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        SemanticModel semanticModel = compilation.GetSemanticModel(syntaxTree, ignoreAccessibility: true);
+        CompilationUnitSyntax root = syntaxTree.GetCompilationUnitRoot();
+
+        List<WorkerEntry> entries = new List<WorkerEntry>();
+        List<WorkerSkipped> skipped = new List<WorkerSkipped>();
+        List<ShimTypeBuilder> shimTypes = new List<ShimTypeBuilder>();
+        int globalShimMethodCounter = 0;
+        int shimTypeCounter = 0;
+
+        foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
+        {
+            INamedTypeSymbol typeSymbol = semanticModel.GetDeclaredSymbol(typeDeclaration);
+            if (typeSymbol == null)
+            {
+                continue;
+            }
+
+            List<MethodDeclarationSyntax> methods = typeDeclaration.Members
+                .OfType<MethodDeclarationSyntax>()
+                .ToList();
+            if (methods.Count == 0)
+            {
+                continue;
+            }
+
+            ShimTypeBuilder currentShimType = null;
+            foreach (MethodDeclarationSyntax methodDeclaration in methods)
+            {
+                IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration);
+                if (methodSymbol == null)
+                {
+                    continue;
+                }
+
+                string skipReason = EvaluateSkipReason(
+                    typeDeclaration,
+                    typeSymbol,
+                    methodDeclaration,
+                    methodSymbol,
+                    semanticModel);
+                if (skipReason != null)
+                {
+                    skipped.Add(new WorkerSkipped
+                    {
+                        Method = FormatMethodLabel(typeSymbol, methodSymbol),
+                        Reason = skipReason
+                    });
+                    continue;
+                }
+
+                if (currentShimType == null)
+                {
+                    string shimTypeName = typeSymbol.Name + "_UloopHotReloadShims_" + shimTypeCounter;
+                    shimTypeCounter++;
+                    currentShimType = new ShimTypeBuilder(shimTypeName, typeSymbol);
+                    shimTypes.Add(currentShimType);
+                }
+
+                string shimMethodName = methodSymbol.Name + "__shim" + globalShimMethodCounter;
+                globalShimMethodCounter++;
+
+                MethodDeclarationSyntax rewrittenMethod = RewriteMethodBody(
+                    methodDeclaration,
+                    methodSymbol,
+                    typeSymbol,
+                    semanticModel);
+                currentShimType.AddMethod(rewrittenMethod, methodSymbol, shimMethodName);
+
+                entries.Add(new WorkerEntry
+                {
+                    TypeMetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
+                    MethodName = methodSymbol.Name,
+                    ParameterTypeFullNames = methodSymbol.Parameters
+                        .Select(CecilTypeNames.ToParameterTypeFullName)
+                        .ToArray(),
+                    ShimTypeName = currentShimType.ShimTypeName,
+                    ShimMethodName = shimMethodName
+                });
+            }
+        }
+
+        string shimSource = ShimSourceEmitter.Emit(root, shimTypes);
+        return new WorkerOutput
+        {
+            ShimSource = shimSource,
+            Entries = entries.ToArray(),
+            Skipped = skipped.ToArray(),
+            ParseErrors = parseErrors.ToArray()
+        };
+    }
+
+    private static IEnumerable<TypeDeclarationSyntax> EnumerateTypeDeclarations(CompilationUnitSyntax root)
+    {
+        return root.DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .Where(static typeDeclaration =>
+                typeDeclaration is ClassDeclarationSyntax
+                || typeDeclaration is StructDeclarationSyntax
+                || typeDeclaration is RecordDeclarationSyntax);
+    }
+
+    private static string EvaluateSkipReason(
+        TypeDeclarationSyntax typeDeclaration,
+        INamedTypeSymbol typeSymbol,
+        MethodDeclarationSyntax methodDeclaration,
+        IMethodSymbol methodSymbol,
+        SemanticModel semanticModel)
+    {
+        if (typeDeclaration.Modifiers.Any(static modifier => modifier.IsKind(SyntaxKind.PartialKeyword)))
+        {
+            return "Partial types are skipped because a single file cannot provide a complete semantic model.";
+        }
+
+        if (typeSymbol.TypeKind == TypeKind.Struct || typeSymbol.IsValueType)
+        {
+            return "Struct (value type) methods are out of scope for v1; byref instance transplant is unverified.";
+        }
+
+        if (typeSymbol.IsGenericType || methodSymbol.IsGenericMethod
+            || methodDeclaration.TypeParameterList != null)
+        {
+            return "Generic methods and methods inside generic types cannot be safely patched with Harmony.";
+        }
+
+        SyntaxNode bodyNode = (SyntaxNode)methodDeclaration.Body ?? methodDeclaration.ExpressionBody;
+        if (bodyNode == null)
+        {
+            return "Methods without a body (abstract/extern) are skipped.";
+        }
+
+        if (ContainsBaseExpression(bodyNode))
+        {
+            return "Methods that call base. members are skipped; C# cannot express base calls outside the type.";
+        }
+
+        if (SubtreeHasInaccessibleMemberAccess(semanticModel, FindLambdaAndLocalFunctionBodies(bodyNode)))
+        {
+            return "Lambda or local-function bodies that access private/internal members are skipped in v1 "
+                + "(closure methods JIT-compile normally and fail accessibility checks).";
+        }
+
+        if (IsAsyncOrIterator(methodDeclaration, bodyNode)
+            && SubtreeHasInaccessibleMemberAccess(semanticModel, new[] { bodyNode }))
+        {
+            return "Async or iterator methods whose bodies access private/internal members are skipped in v1 "
+                + "(state-machine MoveNext JIT-compiles normally and fails accessibility checks).";
+        }
+
+        return null;
+    }
+
+    private static bool ContainsBaseExpression(SyntaxNode bodyNode)
+    {
+        return bodyNode.DescendantNodes().OfType<BaseExpressionSyntax>().Any();
+    }
+
+    private static bool IsAsyncOrIterator(MethodDeclarationSyntax methodDeclaration, SyntaxNode bodyNode)
+    {
+        if (methodDeclaration.Modifiers.Any(static modifier => modifier.IsKind(SyntaxKind.AsyncKeyword)))
+        {
+            return true;
+        }
+
+        return bodyNode.DescendantNodes().OfType<YieldStatementSyntax>().Any();
+    }
+
+    private static List<SyntaxNode> FindLambdaAndLocalFunctionBodies(SyntaxNode bodyNode)
+    {
+        List<SyntaxNode> bodies = new List<SyntaxNode>();
+        foreach (SyntaxNode node in bodyNode.DescendantNodes())
+        {
+            if (node is SimpleLambdaExpressionSyntax simpleLambda)
+            {
+                bodies.Add(simpleLambda.Body);
+            }
+            else if (node is ParenthesizedLambdaExpressionSyntax parenthesizedLambda)
+            {
+                bodies.Add(parenthesizedLambda.Body);
+            }
+            else if (node is AnonymousMethodExpressionSyntax anonymousMethod && anonymousMethod.Body != null)
+            {
+                bodies.Add(anonymousMethod.Body);
+            }
+            else if (node is LocalFunctionStatementSyntax localFunction)
+            {
+                SyntaxNode localBody = (SyntaxNode)localFunction.Body ?? localFunction.ExpressionBody;
+                if (localBody != null)
+                {
+                    bodies.Add(localBody);
+                }
+            }
+        }
+
+        return bodies;
+    }
+
+    private static bool SubtreeHasInaccessibleMemberAccess(
+        SemanticModel semanticModel,
+        IEnumerable<SyntaxNode> roots)
+    {
+        foreach (SyntaxNode root in roots)
+        {
+            if (root == null)
+            {
+                continue;
+            }
+
+            foreach (SyntaxNode node in root.DescendantNodesAndSelf())
+            {
+                if (node is not IdentifierNameSyntax && node is not GenericNameSyntax)
+                {
+                    continue;
+                }
+
+                ISymbol symbol = semanticModel.GetSymbolInfo(node).Symbol;
+                if (symbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static MethodDeclarationSyntax RewriteMethodBody(
+        MethodDeclarationSyntax methodDeclaration,
+        IMethodSymbol methodSymbol,
+        INamedTypeSymbol targetType,
+        SemanticModel semanticModel)
+    {
+        InstanceMemberQualifier qualifier = new InstanceMemberQualifier(semanticModel, targetType);
+        MethodDeclarationSyntax rewritten = (MethodDeclarationSyntax)qualifier.Visit(methodDeclaration);
+        return ShimMethodFactory.ToShimMethod(rewritten, methodSymbol);
+    }
+
+    private static string FormatMethodLabel(INamedTypeSymbol typeSymbol, IMethodSymbol methodSymbol)
+    {
+        return typeSymbol.ToDisplayString(FullyQualifiedTypeFormat) + "." + methodSymbol.Name;
+    }
+}
+
+internal static class AccessibilityRules
+{
+    public static bool IsInaccessibleFromExternalAssembly(ISymbol symbol)
+    {
+        if (symbol is ILocalSymbol
+            || symbol is IParameterSymbol
+            || symbol is IRangeVariableSymbol
+            || symbol is ITypeParameterSymbol
+            || symbol is INamespaceSymbol
+            || symbol is ILabelSymbol
+            || symbol is IDiscardSymbol)
+        {
+            return false;
+        }
+
+        if (symbol is ITypeSymbol typeSymbol)
+        {
+            return HasInaccessibleAccessibility(typeSymbol.DeclaredAccessibility)
+                || (typeSymbol.ContainingType != null
+                    && IsInaccessibleFromExternalAssembly(typeSymbol.ContainingType));
+        }
+
+        if (symbol is IFieldSymbol
+            || symbol is IPropertySymbol
+            || symbol is IMethodSymbol
+            || symbol is IEventSymbol)
+        {
+            if (HasInaccessibleAccessibility(symbol.DeclaredAccessibility))
+            {
+                return true;
+            }
+
+            if (symbol.ContainingType != null
+                && HasInaccessibleAccessibility(symbol.ContainingType.DeclaredAccessibility))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasInaccessibleAccessibility(Accessibility accessibility)
+    {
+        return accessibility == Accessibility.Private
+            || accessibility == Accessibility.Internal
+            || accessibility == Accessibility.Protected
+            || accessibility == Accessibility.ProtectedAndInternal
+            || accessibility == Accessibility.ProtectedOrInternal;
+    }
+}
+
+/// <summary>
+/// Qualifies bare instance/static member references so a static shim can host the original body.
+/// </summary>
+internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
+{
+    private readonly SemanticModel _semanticModel;
+    private readonly INamedTypeSymbol _targetType;
+
+    public InstanceMemberQualifier(SemanticModel semanticModel, INamedTypeSymbol targetType)
+    {
+        _semanticModel = semanticModel;
+        _targetType = targetType;
+    }
+
+    public override SyntaxNode VisitThisExpression(ThisExpressionSyntax node)
+    {
+        return SyntaxFactory.IdentifierName(TransformWorkerProgramMarker.InstanceParameterName)
+            .WithTriviaFrom(node);
+    }
+
+    public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        return VisitName(node, node);
+    }
+
+    public override SyntaxNode VisitGenericName(GenericNameSyntax node)
+    {
+        return VisitName(node, node);
+    }
+
+    private SyntaxNode VisitName(SimpleNameSyntax node, SyntaxNode original)
+    {
+        if (IsMemberAccessNameSide(node)
+            || IsQualifiedNameRightSide(node)
+            || IsMemberBindingName(node))
+        {
+            return original;
+        }
+
+        ISymbol symbol = _semanticModel.GetSymbolInfo(node).Symbol;
+        if (symbol == null)
+        {
+            return original;
+        }
+
+        if (!IsOwnedMember(symbol, out bool isStatic, out INamedTypeSymbol containingType))
+        {
+            return original;
+        }
+
+        if (isStatic)
+        {
+            TypeSyntax typeSyntax = SyntaxFactory.ParseTypeName(
+                containingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+            return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    typeSyntax,
+                    (SimpleNameSyntax)node.WithoutTrivia())
+                .WithTriviaFrom(node);
+        }
+
+        return SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.IdentifierName(TransformWorkerProgramMarker.InstanceParameterName),
+                (SimpleNameSyntax)node.WithoutTrivia())
+            .WithTriviaFrom(node);
+    }
+
+    private bool IsOwnedMember(ISymbol symbol, out bool isStatic, out INamedTypeSymbol containingType)
+    {
+        isStatic = false;
+        containingType = null;
+
+        if (symbol is IMethodSymbol methodSymbol)
+        {
+            // Extension methods live on unrelated static classes; leave them alone.
+            if (methodSymbol.IsExtensionMethod)
+            {
+                return false;
+            }
+
+            containingType = methodSymbol.ContainingType;
+            isStatic = methodSymbol.IsStatic;
+        }
+        else if (symbol is IFieldSymbol fieldSymbol)
+        {
+            containingType = fieldSymbol.ContainingType;
+            isStatic = fieldSymbol.IsStatic;
+        }
+        else if (symbol is IPropertySymbol propertySymbol)
+        {
+            containingType = propertySymbol.ContainingType;
+            isStatic = propertySymbol.IsStatic;
+        }
+        else if (symbol is IEventSymbol eventSymbol)
+        {
+            containingType = eventSymbol.ContainingType;
+            isStatic = eventSymbol.IsStatic;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (containingType == null)
+        {
+            return false;
+        }
+
+        return IsInInheritanceHierarchy(_targetType, containingType);
+    }
+
+    private static bool IsInInheritanceHierarchy(INamedTypeSymbol derived, INamedTypeSymbol candidate)
+    {
+        for (INamedTypeSymbol current = derived; current != null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsMemberAccessNameSide(SimpleNameSyntax node)
+    {
+        return node.Parent is MemberAccessExpressionSyntax memberAccess
+            && memberAccess.Name == node;
+    }
+
+    private static bool IsQualifiedNameRightSide(SimpleNameSyntax node)
+    {
+        return node.Parent is QualifiedNameSyntax qualifiedName
+            && qualifiedName.Right == node;
+    }
+
+    private static bool IsMemberBindingName(SimpleNameSyntax node)
+    {
+        return node.Parent is MemberBindingExpressionSyntax memberBinding
+            && memberBinding.Name == node;
+    }
+}
+
+// Nested access to the instance parameter name without exposing TransformWorkerProgram fields
+// to the rewriter as a circular partial. Kept as a tiny marker type so the rewriter stays free
+// of string literals scattered across Visit overrides.
+internal static class TransformWorkerProgramMarker
+{
+    public const string InstanceParameterName = "instance";
+}
+
+internal static class ShimMethodFactory
+{
+    public static MethodDeclarationSyntax ToShimMethod(
+        MethodDeclarationSyntax rewrittenOriginal,
+        IMethodSymbol methodSymbol)
+    {
+        TypeSyntax returnType = rewrittenOriginal.ReturnType.WithoutTrivia();
+        SyntaxTokenList modifiers = SyntaxFactory.TokenList(
+            SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+            SyntaxFactory.Token(SyntaxKind.StaticKeyword));
+
+        // Async is preserved so the shim assembly still emits a state machine when the original
+        // was async (transplant covers the stub; MoveNext stays in the shim assembly).
+        if (rewrittenOriginal.Modifiers.Any(static modifier => modifier.IsKind(SyntaxKind.AsyncKeyword)))
+        {
+            modifiers = modifiers.Add(SyntaxFactory.Token(SyntaxKind.AsyncKeyword));
+        }
+
+        SeparatedSyntaxList<ParameterSyntax> parameters = BuildShimParameters(rewrittenOriginal, methodSymbol);
+        return rewrittenOriginal
+            .WithAttributeLists(default)
+            .WithModifiers(modifiers)
+            .WithReturnType(returnType)
+            .WithParameterList(SyntaxFactory.ParameterList(parameters))
+            .WithExplicitInterfaceSpecifier(null)
+            .WithConstraintClauses(default)
+            .WithSemicolonToken(default)
+            .WithTriviaFrom(rewrittenOriginal);
+    }
+
+    private static SeparatedSyntaxList<ParameterSyntax> BuildShimParameters(
+        MethodDeclarationSyntax rewrittenOriginal,
+        IMethodSymbol methodSymbol)
+    {
+        List<ParameterSyntax> parameters = new List<ParameterSyntax>();
+        if (!methodSymbol.IsStatic)
+        {
+            TypeSyntax instanceType = SyntaxFactory.ParseTypeName(
+                methodSymbol.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+            parameters.Add(
+                SyntaxFactory.Parameter(SyntaxFactory.Identifier(TransformWorkerProgramMarker.InstanceParameterName))
+                    .WithType(instanceType));
+        }
+
+        foreach (ParameterSyntax originalParameter in rewrittenOriginal.ParameterList.Parameters)
+        {
+            parameters.Add(originalParameter.WithoutTrivia());
+        }
+
+        return SyntaxFactory.SeparatedList(parameters);
+    }
+}
+
+internal sealed class ShimTypeBuilder
+{
+    private readonly List<MethodDeclarationSyntax> _methods = new List<MethodDeclarationSyntax>();
+    private readonly List<string> _shimMethodNames = new List<string>();
+
+    public ShimTypeBuilder(string shimTypeName, INamedTypeSymbol targetType)
+    {
+        ShimTypeName = shimTypeName;
+        TargetType = targetType;
+    }
+
+    public string ShimTypeName { get; }
+
+    public INamedTypeSymbol TargetType { get; }
+
+    public void AddMethod(
+        MethodDeclarationSyntax shimMethod,
+        IMethodSymbol originalMethod,
+        string shimMethodName)
+    {
+        MethodDeclarationSyntax named = shimMethod.WithIdentifier(SyntaxFactory.Identifier(shimMethodName));
+        _methods.Add(named);
+        _shimMethodNames.Add(shimMethodName);
+    }
+
+    public IReadOnlyList<MethodDeclarationSyntax> Methods => _methods;
+}
+
+internal static class ShimSourceEmitter
+{
+    public static string Emit(CompilationUnitSyntax originalRoot, List<ShimTypeBuilder> shimTypes)
+    {
+        if (shimTypes.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        CompilationUnitSyntax unit = SyntaxFactory.CompilationUnit();
+        foreach (UsingDirectiveSyntax usingDirective in originalRoot.Usings)
+        {
+            unit = unit.AddUsings(usingDirective.WithoutTrivia());
+        }
+
+        // Emit shim types in the global namespace so Assembly.GetType(shimTypeName) resolves
+        // with the short name recorded in the manifest (matches the plan's shape).
+        foreach (ShimTypeBuilder shimType in shimTypes)
+        {
+            ClassDeclarationSyntax classDeclaration = SyntaxFactory.ClassDeclaration(shimType.ShimTypeName)
+                .WithModifiers(
+                    SyntaxFactory.TokenList(
+                        SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+                        SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
+                .WithMembers(SyntaxFactory.List<MemberDeclarationSyntax>(shimType.Methods));
+            unit = unit.AddMembers(classDeclaration);
+        }
+
+        unit = unit.NormalizeWhitespace();
+
+        StringBuilder builder = new StringBuilder();
+        builder.AppendLine(
+            "// Generated shims mirror user method signatures verbatim; repo style rules apply to hand-written code only.");
+        builder.Append(unit.ToFullString());
+        return builder.ToString();
+    }
+}
+
+internal static class CecilTypeNames
+{
+    public static string ToMetadataName(INamedTypeSymbol typeSymbol)
+    {
+        if (typeSymbol.ContainingType != null)
+        {
+            return ToMetadataName(typeSymbol.ContainingType) + "/" + typeSymbol.MetadataName;
+        }
+
+        if (typeSymbol.ContainingNamespace == null || typeSymbol.ContainingNamespace.IsGlobalNamespace)
+        {
+            return typeSymbol.MetadataName;
+        }
+
+        return typeSymbol.ContainingNamespace.ToDisplayString() + "." + typeSymbol.MetadataName;
+    }
+
+    public static string ToParameterTypeFullName(IParameterSymbol parameterSymbol)
+    {
+        // Roslyn's IParameterSymbol.Type omits the byref wrapper; Cecil FullName uses a trailing '&'.
+        string typeName = ToCecilFullName(parameterSymbol.Type);
+        if (parameterSymbol.RefKind != RefKind.None)
+        {
+            return typeName + "&";
+        }
+
+        return typeName;
+    }
+
+    private static string ToCecilFullName(ITypeSymbol typeSymbol)
+    {
+        if (typeSymbol is IPointerTypeSymbol pointerType)
+        {
+            return ToCecilFullName(pointerType.PointedAtType) + "*";
+        }
+
+        if (typeSymbol is IArrayTypeSymbol arrayType)
+        {
+            string elementName = ToCecilFullName(arrayType.ElementType);
+            if (arrayType.Rank == 1)
+            {
+                return elementName + "[]";
+            }
+
+            return elementName + "[" + new string(',', arrayType.Rank - 1) + "]";
+        }
+
+        if (typeSymbol is INamedTypeSymbol namedType)
+        {
+            if (namedType.IsGenericType && !namedType.IsUnboundGenericType)
+            {
+                string head = ToMetadataName(namedType.OriginalDefinition);
+                string args = string.Join(",", namedType.TypeArguments.Select(ToCecilFullName));
+                return head + "<" + args + ">";
+            }
+
+            return ToMetadataName(namedType);
+        }
+
+        return typeSymbol.ToDisplayString(
+            new SymbolDisplayFormat(
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces));
+    }
+}
+
+internal sealed class WorkerInput
+{
+    public string SourcePath { get; set; }
+
+    public string[] Defines { get; set; }
+
+    public string[] ReferencePaths { get; set; }
+
+    public string TargetTypesAssemblyPath { get; set; }
+}
+
+internal sealed class WorkerOutput
+{
+    public string ShimSource { get; set; }
+
+    public WorkerEntry[] Entries { get; set; }
+
+    public WorkerSkipped[] Skipped { get; set; }
+
+    public string[] ParseErrors { get; set; }
+}
+
+internal sealed class WorkerEntry
+{
+    public string TypeMetadataName { get; set; }
+
+    public string MethodName { get; set; }
+
+    public string[] ParameterTypeFullNames { get; set; }
+
+    public string ShimTypeName { get; set; }
+
+    public string ShimMethodName { get; set; }
+}
+
+internal sealed class WorkerSkipped
+{
+    public string Method { get; set; }
+
+    public string Reason { get; set; }
+}


### PR DESCRIPTION
## Summary

- Adds the out-of-process Roslyn transform worker (`TransformWorker~/`) that parses an edited C# file with the project's defines, qualifies instance/static member references, and emits static shim methods plus a per-method manifest / skip list (UTF-8 JSON file I/O, no Prefix wrappers).
- Wires Unity-side bootstrap, worker client, publicized-ref shim compilation via `RoslynCompilerBackend` (not `IDynamicCompilationService`), and `HotReloadOrchestrator` end-to-end transplant application.
- Adds EditMode coverage for worker bootstrap/smoke and orchestrator e2e (private-access patch, `base.` skip, missing-helper shim compile failure), using `files[]` / `contentPathOverride` so edited copies stay under `Library/UloopHotReload/TestSources/`.

## User Impact

Editors (and agents) can reload edited method bodies into a running Unity Editor without a domain reload once this pipeline is exposed as a tool (follow-up PR). This PR lands the worker + compile + patch path that makes that possible.

## Test plan

- [x] `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` — 0 errors / 0 warnings
- [x] `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "HotReload"` — 36 passed (includes new TransformWorkerClient + Orchestrator e2e tests)
- [ ] CI green on this PR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

