### PR TITLE
feat: expose hot-reload as a first-party tool

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: uloop-hot-reload
+toolName: hot-reload
+description: "Apply method-body hot reload to edited C# sources in a running Unity Editor without domain reload. Use after small method edits when you need PlayMode/EditMode feedback without uloop compile."
+---
+
+# uloop hot-reload
+
+DRAFT — prose wording will be finalized by the Fable session. Parameter table below must stay aligned with the implemented schema.
+
+Reload method bodies from edited project source files into the running Editor (EditMode or PlayMode) without a domain reload. No `[HotReload]` attribute is required. Private/internal access, static methods, return values, async, and iterators are supported within v1 skip rules. Methods that cannot be patched are reported as Skipped with a reason (not as a hard tool failure for that method alone).
+
+## Usage
+
+```bash
+uloop hot-reload --files Assets/Scripts/Enemy.cs
+uloop hot-reload --files Assets/Scripts/Enemy.cs Assets/Scripts/Boss.cs
+uloop hot-reload --revert-all
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
+| `--revert-all` | flag | - | Remove every active hot-reload transplant and clear the patch ledger. When set, `--files` is ignored |
+
+## What it does
+
+1. Resolves each file to its compiled assembly via `CompilationPipeline`.
+2. Transforms edited method bodies into static shim methods in an out-of-process worker.
+3. Compiles shims against publicized reference assemblies and loads them into the Editor domain.
+4. Transplants each shim's IL into the original method with Harmony (ID `io.github.hatayama.uloop.hot-reload`).
+
+## v1 skip conditions
+
+| Condition | Reason (summary) |
+|-----------|------------------|
+| Body contains `base.` call | Cannot express `base` from outside the type |
+| Method on a `partial` type | Single-file semantic model is incomplete |
+| Generic method or method on a generic type | Harmony cannot safely patch these |
+| Method on a struct (value type) | Value-type transplant semantics are out of v1 scope |
+| Property/indexer accessor, constructor, finalizer, operator | v1 covers ordinary methods only |
+| Async/iterator body with private/internal access | State machine `MoveNext` is normally JIT-checked |
+| Lambda/local-function body with private/internal access | Closure methods are normally JIT-checked |
+| Signature missing from the loaded assembly | New/renamed/changed members need `uloop compile` |
+| abstract / extern / `[BurstCompile]` | Not patchable |
+| Shim compile error (e.g. calling a newly added helper) | Needs `uloop compile`; response includes the csc error and hint |
+
+## Convergence and lifecycle
+
+- Input is the real project source file. A later `uloop compile` (real compile + domain reload) converges to the same behavior as the patch.
+- Active Harmony patches and loaded shim assemblies are static state and disappear on domain reload by design. There is no persistence or automatic re-apply.
+- Field additions, field initializers, and new types are never reflected by hot reload.
+
+## Pause point interaction
+
+Hot-reload transplant discards the original IL and any prior transpiler output on that method. A source pause point on a hot-reloaded method will not fire until the patch is reverted (`--revert-all` or a later revert of that method) or a domain reload restores the original IL. Apply responses include this as a `Warnings` entry when any method was patched.
+
+## Output
+
+Returns JSON with:
+
+- `Success` (boolean): `false` on validation failure or when any method outcome is `Failed`; skips alone do not force failure
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
+- `Warnings` (array): Inlining risk, pause-point interaction, and other non-fatal notes
+- `PatchedTotal` (number): Methods patched in this run
+- `ActivePatchTotal` (number): Methods still patched after this run
+- `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)
+- `Message` (string): Short summary

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -6,17 +6,22 @@ description: "Apply method-body hot reload to edited C# sources in a running Uni
 
 # uloop hot-reload
 
-DRAFT — prose wording will be finalized by the Fable session. Parameter table below must stay aligned with the implemented schema.
-
-Reload method bodies from edited project source files into the running Editor (EditMode or PlayMode) without a domain reload. No `[HotReload]` attribute is required. Private/internal access, static methods, return values, async, and iterators are supported within v1 skip rules. Methods that cannot be patched are reported as Skipped with a reason (not as a hard tool failure for that method alone).
+Replaces method bodies in the running Editor (EditMode or PlayMode) directly from edited
+project source files — no domain reload, no attributes, no source markers. Private/internal
+member access, static methods, return values, async methods, and iterators all work within
+the v1 limits below. Methods that cannot be patched are reported per method as `Skipped` or
+`Failed`; one unpatchable method never aborts the rest of the run.
 
 ## Usage
 
 ```bash
 uloop hot-reload --files Assets/Scripts/Enemy.cs
-uloop hot-reload --files Assets/Scripts/Enemy.cs Assets/Scripts/Boss.cs
+uloop hot-reload --files Assets/Scripts/Enemy.cs,Assets/Scripts/Boss.cs
 uloop hot-reload --revert-all
 ```
+
+Multiple files are passed as one comma-separated value (or a JSON array); array options
+consume exactly one value token.
 
 ## Parameters
 
@@ -25,45 +30,70 @@ uloop hot-reload --revert-all
 | `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
 | `--revert-all` | flag | - | Remove every active hot-reload transplant and clear the patch ledger. When set, `--files` is ignored |
 
-## What it does
+## How it works
 
 1. Resolves each file to its compiled assembly via `CompilationPipeline`.
-2. Transforms edited method bodies into static shim methods in an out-of-process worker.
-3. Compiles shims against publicized reference assemblies and loads them into the Editor domain.
-4. Transplants each shim's IL into the original method with Harmony (ID `io.github.hatayama.uloop.hot-reload`).
+2. Rewrites each editable method body into a static shim in an out-of-process Roslyn worker.
+3. Compiles the shims against publicized reference copies and loads the result into the Editor domain.
+4. Transplants each shim's IL into the original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`).
 
-## v1 skip conditions
+Re-running on the same method replaces its previous patch; `ActivePatchTotal` tracks the
+ledger across runs.
 
-| Condition | Reason (summary) |
-|-----------|------------------|
-| Body contains `base.` call | Cannot express `base` from outside the type |
-| Method on a `partial` type | Single-file semantic model is incomplete |
-| Generic method or method on a generic type | Harmony cannot safely patch these |
-| Method on a struct (value type) | Value-type transplant semantics are out of v1 scope |
-| Property/indexer accessor, constructor, finalizer, operator | v1 covers ordinary methods only |
-| Async/iterator body with private/internal access | State machine `MoveNext` is normally JIT-checked |
-| Lambda/local-function body with private/internal access | Closure methods are normally JIT-checked |
-| Signature missing from the loaded assembly | New/renamed/changed members need `uloop compile` |
-| abstract / extern / `[BurstCompile]` | Not patchable |
-| Shim compile error (e.g. calling a newly added helper) | Needs `uloop compile`; response includes the csc error and hint |
+## Scope and limits (v1)
+
+Only ordinary method declarations are scanned. Property and indexer accessors, constructors,
+finalizers, operators, and event accessors are never scanned: edits to them produce **no
+per-method entry at all** and are silently not applied — use `uloop compile` for those.
+
+### Skipped — reported per method, never flips `Success`
+
+| Condition | Why |
+|-----------|-----|
+| Method on a `partial` type (including a type nested inside a partial outer type) | A single file cannot provide a complete semantic model |
+| Method on a struct (value type) | Value-type transplant is out of v1 scope |
+| Generic method, or method on a generic type | Harmony cannot safely patch open generics |
+| Explicit interface implementation | Dotted metadata names cannot be expressed as shim identifiers |
+| No body (`abstract` / `extern`) | Nothing to transplant |
+| Body contains a `base.` call | `base` cannot be expressed from outside the type |
+| Lambda, local function, or LINQ query in the body accesses private/internal members | Closure bodies run from the shim assembly, where that access fails runtime accessibility checks; only the named method's IL is transplanted |
+| `async` or iterator body accesses private/internal members | Same as above — the state machine's `MoveNext` runs from the shim assembly |
+
+### Failed — flips `Success` to `false`
+
+| Condition | Notes |
+|-----------|-------|
+| File does not belong to any compiled assembly | Per-file entry with `Method` = `(file)`; only `Assets/` and `Packages/` sources resolve |
+| Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
+| Source file fails to parse | Per-file entry carrying the parse errors |
+| Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
+| Patch rejected at apply time (e.g. `[BurstCompile]`) | Not patchable by Harmony transplant |
 
 ## Convergence and lifecycle
 
-- Input is the real project source file. A later `uloop compile` (real compile + domain reload) converges to the same behavior as the patch.
-- Active Harmony patches and loaded shim assemblies are static state and disappear on domain reload by design. There is no persistence or automatic re-apply.
-- Field additions, field initializers, and new types are never reflected by hot reload.
+- The input is the real project source file, so a later `uloop compile` (real compile +
+  domain reload) lands the exact same edit permanently. There is nothing to undo first;
+  behavior converges by construction.
+- Patches and loaded shim assemblies are static Editor state and disappear on the next
+  domain reload. There is no persistence and no automatic re-apply.
+- Never reflected by hot reload: new fields, field initializer changes, new types, and
+  signature changes. Those always need `uloop compile`.
 
 ## Pause point interaction
 
-Hot-reload transplant discards the original IL and any prior transpiler output on that method. A source pause point on a hot-reloaded method will not fire until the patch is reverted (`--revert-all` or a later revert of that method) or a domain reload restores the original IL. Apply responses include this as a `Warnings` entry when any method was patched.
+A hot-reload transplant discards the original IL and any prior transpiler output on that
+method, so a source pause point on a hot-reloaded method stops firing until the patch is
+reverted (`--revert-all`) or a domain reload restores the original IL. Apply responses
+include this as a `Warnings` entry whenever any method was patched.
 
 ## Output
 
 Returns JSON with:
 
-- `Success` (boolean): `false` on validation failure or when any method outcome is `Failed`; skips alone do not force failure
+- `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
-- `Warnings` (array): Inlining risk, pause-point interaction, and other non-fatal notes
+- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), and the pause-point interaction above
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: uloop-hot-reload
+toolName: hot-reload
+description: "Apply method-body hot reload to edited C# sources in a running Unity Editor without domain reload. Use after small method edits when you need PlayMode/EditMode feedback without uloop compile."
+---
+
+# uloop hot-reload
+
+DRAFT — prose wording will be finalized by the Fable session. Parameter table below must stay aligned with the implemented schema.
+
+Reload method bodies from edited project source files into the running Editor (EditMode or PlayMode) without a domain reload. No `[HotReload]` attribute is required. Private/internal access, static methods, return values, async, and iterators are supported within v1 skip rules. Methods that cannot be patched are reported as Skipped with a reason (not as a hard tool failure for that method alone).
+
+## Usage
+
+```bash
+uloop hot-reload --files Assets/Scripts/Enemy.cs
+uloop hot-reload --files Assets/Scripts/Enemy.cs Assets/Scripts/Boss.cs
+uloop hot-reload --revert-all
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
+| `--revert-all` | flag | - | Remove every active hot-reload transplant and clear the patch ledger. When set, `--files` is ignored |
+
+## What it does
+
+1. Resolves each file to its compiled assembly via `CompilationPipeline`.
+2. Transforms edited method bodies into static shim methods in an out-of-process worker.
+3. Compiles shims against publicized reference assemblies and loads them into the Editor domain.
+4. Transplants each shim's IL into the original method with Harmony (ID `io.github.hatayama.uloop.hot-reload`).
+
+## v1 skip conditions
+
+| Condition | Reason (summary) |
+|-----------|------------------|
+| Body contains `base.` call | Cannot express `base` from outside the type |
+| Method on a `partial` type | Single-file semantic model is incomplete |
+| Generic method or method on a generic type | Harmony cannot safely patch these |
+| Method on a struct (value type) | Value-type transplant semantics are out of v1 scope |
+| Property/indexer accessor, constructor, finalizer, operator | v1 covers ordinary methods only |
+| Async/iterator body with private/internal access | State machine `MoveNext` is normally JIT-checked |
+| Lambda/local-function body with private/internal access | Closure methods are normally JIT-checked |
+| Signature missing from the loaded assembly | New/renamed/changed members need `uloop compile` |
+| abstract / extern / `[BurstCompile]` | Not patchable |
+| Shim compile error (e.g. calling a newly added helper) | Needs `uloop compile`; response includes the csc error and hint |
+
+## Convergence and lifecycle
+
+- Input is the real project source file. A later `uloop compile` (real compile + domain reload) converges to the same behavior as the patch.
+- Active Harmony patches and loaded shim assemblies are static state and disappear on domain reload by design. There is no persistence or automatic re-apply.
+- Field additions, field initializers, and new types are never reflected by hot reload.
+
+## Pause point interaction
+
+Hot-reload transplant discards the original IL and any prior transpiler output on that method. A source pause point on a hot-reloaded method will not fire until the patch is reverted (`--revert-all` or a later revert of that method) or a domain reload restores the original IL. Apply responses include this as a `Warnings` entry when any method was patched.
+
+## Output
+
+Returns JSON with:
+
+- `Success` (boolean): `false` on validation failure or when any method outcome is `Failed`; skips alone do not force failure
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
+- `Warnings` (array): Inlining risk, pause-point interaction, and other non-fatal notes
+- `PatchedTotal` (number): Methods patched in this run
+- `ActivePatchTotal` (number): Methods still patched after this run
+- `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)
+- `Message` (string): Short summary

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -6,17 +6,22 @@ description: "Apply method-body hot reload to edited C# sources in a running Uni
 
 # uloop hot-reload
 
-DRAFT — prose wording will be finalized by the Fable session. Parameter table below must stay aligned with the implemented schema.
-
-Reload method bodies from edited project source files into the running Editor (EditMode or PlayMode) without a domain reload. No `[HotReload]` attribute is required. Private/internal access, static methods, return values, async, and iterators are supported within v1 skip rules. Methods that cannot be patched are reported as Skipped with a reason (not as a hard tool failure for that method alone).
+Replaces method bodies in the running Editor (EditMode or PlayMode) directly from edited
+project source files — no domain reload, no attributes, no source markers. Private/internal
+member access, static methods, return values, async methods, and iterators all work within
+the v1 limits below. Methods that cannot be patched are reported per method as `Skipped` or
+`Failed`; one unpatchable method never aborts the rest of the run.
 
 ## Usage
 
 ```bash
 uloop hot-reload --files Assets/Scripts/Enemy.cs
-uloop hot-reload --files Assets/Scripts/Enemy.cs Assets/Scripts/Boss.cs
+uloop hot-reload --files Assets/Scripts/Enemy.cs,Assets/Scripts/Boss.cs
 uloop hot-reload --revert-all
 ```
+
+Multiple files are passed as one comma-separated value (or a JSON array); array options
+consume exactly one value token.
 
 ## Parameters
 
@@ -25,45 +30,70 @@ uloop hot-reload --revert-all
 | `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
 | `--revert-all` | flag | - | Remove every active hot-reload transplant and clear the patch ledger. When set, `--files` is ignored |
 
-## What it does
+## How it works
 
 1. Resolves each file to its compiled assembly via `CompilationPipeline`.
-2. Transforms edited method bodies into static shim methods in an out-of-process worker.
-3. Compiles shims against publicized reference assemblies and loads them into the Editor domain.
-4. Transplants each shim's IL into the original method with Harmony (ID `io.github.hatayama.uloop.hot-reload`).
+2. Rewrites each editable method body into a static shim in an out-of-process Roslyn worker.
+3. Compiles the shims against publicized reference copies and loads the result into the Editor domain.
+4. Transplants each shim's IL into the original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`).
 
-## v1 skip conditions
+Re-running on the same method replaces its previous patch; `ActivePatchTotal` tracks the
+ledger across runs.
 
-| Condition | Reason (summary) |
-|-----------|------------------|
-| Body contains `base.` call | Cannot express `base` from outside the type |
-| Method on a `partial` type | Single-file semantic model is incomplete |
-| Generic method or method on a generic type | Harmony cannot safely patch these |
-| Method on a struct (value type) | Value-type transplant semantics are out of v1 scope |
-| Property/indexer accessor, constructor, finalizer, operator | v1 covers ordinary methods only |
-| Async/iterator body with private/internal access | State machine `MoveNext` is normally JIT-checked |
-| Lambda/local-function body with private/internal access | Closure methods are normally JIT-checked |
-| Signature missing from the loaded assembly | New/renamed/changed members need `uloop compile` |
-| abstract / extern / `[BurstCompile]` | Not patchable |
-| Shim compile error (e.g. calling a newly added helper) | Needs `uloop compile`; response includes the csc error and hint |
+## Scope and limits (v1)
+
+Only ordinary method declarations are scanned. Property and indexer accessors, constructors,
+finalizers, operators, and event accessors are never scanned: edits to them produce **no
+per-method entry at all** and are silently not applied — use `uloop compile` for those.
+
+### Skipped — reported per method, never flips `Success`
+
+| Condition | Why |
+|-----------|-----|
+| Method on a `partial` type (including a type nested inside a partial outer type) | A single file cannot provide a complete semantic model |
+| Method on a struct (value type) | Value-type transplant is out of v1 scope |
+| Generic method, or method on a generic type | Harmony cannot safely patch open generics |
+| Explicit interface implementation | Dotted metadata names cannot be expressed as shim identifiers |
+| No body (`abstract` / `extern`) | Nothing to transplant |
+| Body contains a `base.` call | `base` cannot be expressed from outside the type |
+| Lambda, local function, or LINQ query in the body accesses private/internal members | Closure bodies run from the shim assembly, where that access fails runtime accessibility checks; only the named method's IL is transplanted |
+| `async` or iterator body accesses private/internal members | Same as above — the state machine's `MoveNext` runs from the shim assembly |
+
+### Failed — flips `Success` to `false`
+
+| Condition | Notes |
+|-----------|-------|
+| File does not belong to any compiled assembly | Per-file entry with `Method` = `(file)`; only `Assets/` and `Packages/` sources resolve |
+| Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
+| Source file fails to parse | Per-file entry carrying the parse errors |
+| Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
+| Patch rejected at apply time (e.g. `[BurstCompile]`) | Not patchable by Harmony transplant |
 
 ## Convergence and lifecycle
 
-- Input is the real project source file. A later `uloop compile` (real compile + domain reload) converges to the same behavior as the patch.
-- Active Harmony patches and loaded shim assemblies are static state and disappear on domain reload by design. There is no persistence or automatic re-apply.
-- Field additions, field initializers, and new types are never reflected by hot reload.
+- The input is the real project source file, so a later `uloop compile` (real compile +
+  domain reload) lands the exact same edit permanently. There is nothing to undo first;
+  behavior converges by construction.
+- Patches and loaded shim assemblies are static Editor state and disappear on the next
+  domain reload. There is no persistence and no automatic re-apply.
+- Never reflected by hot reload: new fields, field initializer changes, new types, and
+  signature changes. Those always need `uloop compile`.
 
 ## Pause point interaction
 
-Hot-reload transplant discards the original IL and any prior transpiler output on that method. A source pause point on a hot-reloaded method will not fire until the patch is reverted (`--revert-all` or a later revert of that method) or a domain reload restores the original IL. Apply responses include this as a `Warnings` entry when any method was patched.
+A hot-reload transplant discards the original IL and any prior transpiler output on that
+method, so a source pause point on a hot-reloaded method stops firing until the patch is
+reverted (`--revert-all`) or a domain reload restores the original IL. Apply responses
+include this as a `Warnings` entry whenever any method was patched.
 
 ## Output
 
 Returns JSON with:
 
-- `Success` (boolean): `false` on validation failure or when any method outcome is `Failed`; skips alone do not force failure
+- `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
-- `Warnings` (array): Inlining risk, pause-point interaction, and other non-fatal notes
+- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), and the pause-point interaction above
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using Newtonsoft.Json.Linq;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Lightweight coverage for HotReloadTool validation and response aggregation
+    /// (no orchestrator / worker invocation).
+    /// </summary>
+    public class HotReloadToolTests
+    {
+        [Test]
+        public void ToolName_ReturnsHotReload()
+        {
+            // Verifies the registered CLI command name is hot-reload.
+            HotReloadTool tool = new HotReloadTool();
+            Assert.That(tool.ToolName, Is.EqualTo("hot-reload"));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WithoutFilesOrRevertAll_ReturnsValidationFailure()
+        {
+            // Verifies --files is required when --revert-all is not set.
+            HotReloadTool tool = new HotReloadTool();
+            JObject parameters = new JObject();
+
+            UnityCliLoopToolResponse baseResponse =
+                await tool.ExecuteAsync(parameters, CancellationToken.None);
+            HotReloadResponse response = baseResponse as HotReloadResponse;
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Does.Contain("Files is required"));
+        }
+
+        [Test]
+        public void ValidateApplyParameters_WhitespaceOnlyPath_ReturnsError()
+        {
+            // Verifies blank path entries are rejected before the orchestrator runs.
+            HotReloadSchema schema = new HotReloadSchema
+            {
+                Files = new[] { "   " }
+            };
+
+            string error = HotReloadTool.ValidateApplyParameters(schema);
+
+            Assert.That(error, Is.EqualTo("Files must not contain null or empty paths."));
+        }
+
+        [Test]
+        public void BuildApplyResponse_WithFailedOutcome_SetsSuccessFalse()
+        {
+            // Verifies any Failed method outcome flips Success to false.
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Failed("Type.Method", "shim compile failed", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 0,
+                activePatchTotal: 0);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Methods.Count, Is.EqualTo(1));
+            Assert.That(response.Methods[0].Kind, Is.EqualTo("Failed"));
+        }
+
+        [Test]
+        public void BuildApplyResponse_AddsPausePointWarningOnlyWhenPatched()
+        {
+            // Verifies the pause-point interaction warning appears iff PatchedTotal > 0.
+            HotReloadOrchestratorResult patched = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Patched("Type.Method", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 1,
+                activePatchTotal: 1);
+            HotReloadOrchestratorResult skippedOnly = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Skipped("Type.Other", "partial type", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 0,
+                activePatchTotal: 0);
+
+            HotReloadResponse patchedResponse = HotReloadTool.BuildApplyResponse(patched);
+            HotReloadResponse skippedResponse = HotReloadTool.BuildApplyResponse(skippedOnly);
+
+            Assert.That(
+                patchedResponse.Warnings,
+                Does.Contain(HotReloadConstants.PausePointInteractionWarning));
+            Assert.That(
+                skippedResponse.Warnings,
+                Does.Not.Contain(HotReloadConstants.PausePointInteractionWarning));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_RevertAllWithNoActivePatches_ReportsClearedCountZero()
+        {
+            // Verifies --revert-all succeeds with a clear message when the ledger is empty.
+            HotReloadPatcher.RevertAll();
+            HotReloadTool tool = new HotReloadTool();
+            JObject parameters = new JObject
+            {
+                ["RevertAll"] = true
+            };
+
+            UnityCliLoopToolResponse baseResponse =
+                await tool.ExecuteAsync(parameters, CancellationToken.None);
+            HotReloadResponse response = baseResponse as HotReloadResponse;
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.ClearedCount, Is.EqualTo(0));
+            Assert.That(response.Message, Is.EqualTo("No active hot-reload patches to revert."));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91bd628f30c234358a9204788ff83803
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
+++ b/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
@@ -5,7 +5,8 @@
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:afe86dd49995e46baa33e099a4d2ee1d",
-        "GUID:774ab7841db34070bf18932c90cf9ea6"
+        "GUID:774ab7841db34070bf18932c90cf9ea6",
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
     ],
     "includePlatforms": [
         "Editor"
@@ -15,7 +16,8 @@
     "overrideReferences": true,
     "precompiledReferences": [
         "UnityCliLoop.0Harmony.dll",
-        "Mono.Cecil.dll"
+        "Mono.Cecil.dll",
+        "Newtonsoft.Json.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [],

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -82,5 +82,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string AssemblyNotLoadedHint =
             "The target assembly is not currently loaded in this AppDomain. Ensure the code path "
             + "that loads it has run, then retry.";
+
+        // Transplant discards the original IL and any prior transpiler output on that method,
+        // so a source pause point on a hot-reloaded method stops firing until domain reload
+        // (or until the method is reverted and re-armed).
+        public const string PausePointInteractionWarning =
+            "Hot reload transplant replaces the method body and discards other transpilers on "
+            + "that method; a pause point on a hot-reloaded method will not fire until the patch "
+            + "is reverted or a domain reload restores the original IL.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -11,6 +11,8 @@ using UnityEditor.Compilation;
 
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
 using Assembly = System.Reflection.Assembly;
 using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
 
@@ -47,21 +49,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ? filePath
                     : contentPathOverride;
 
-                // Why ConfigureAwait(true): continuations must resume on the Unity main thread
-                // because the pipeline calls main-thread-only editor APIs (CompilationPipeline,
-                // Application.dataPath, EditorApplication.applicationContentsPath) and applies
-                // Harmony patches between awaits. The tool layer's ConfigureAwait(false) only
-                // moves BuildApplyResponse off-thread; it does not detach this pipeline.
+                // Why ConfigureAwait(false): UnityCliLoopTool forbids capturing Unity's
+                // SynchronizationContext across awaits — while Play Mode is paused that context
+                // does not run continuations, so a true resume would hang the tool forever.
+                // ProcessFileAsync switches back via MainThreadSwitcher (EditorApplication.update
+                // queue) before any main-thread-only editor API or Harmony patch.
                 HotReloadFileProcessResult fileResult = await ProcessFileAsync(
                     filePath,
                     workerSourcePath,
-                    ct).ConfigureAwait(true);
+                    ct).ConfigureAwait(false);
 
                 outcomes.AddRange(fileResult.Outcomes);
                 warnings.AddRange(fileResult.Warnings);
                 patchedTotal += fileResult.PatchedCount;
             }
 
+            await MainThreadSwitcher.SwitchToMainThread(ct);
             return new HotReloadOrchestratorResult(
                 outcomes,
                 warnings,
@@ -76,6 +79,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
+
+            // CompilationPipeline / Application.dataPath require the Unity main thread.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
 
             // CompilationPipeline.GetAssemblyNameFromScriptPath expects a project-relative path
             // (Assets/... or Packages/...) and returns a file name that already includes ".dll".
@@ -139,7 +145,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
 
             TransformWorkerClientResult workerResult =
-                await TransformWorkerClient.RunAsync(workerInput, ct).ConfigureAwait(true);
+                await TransformWorkerClient.RunAsync(workerInput, ct).ConfigureAwait(false);
             if (!workerResult.Success)
             {
                 outcomes.Add(
@@ -175,12 +181,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return new HotReloadFileProcessResult(outcomes, warnings, 0);
             }
 
+            // BuildShimReferencePaths reads Application.dataPath / platform; stay on main thread.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
             List<string> shimReferences = BuildShimReferencePaths(compilationAssembly, targetDllPath);
             HotReloadShimCompileResult compileResult = await HotReloadShimCompiler.CompileAndLoadAsync(
                 workerOutput.shimSource,
                 shimReferences,
                 defines,
-                ct).ConfigureAwait(true);
+                ct).ConfigureAwait(false);
 
             if (!compileResult.Success)
             {
@@ -192,6 +200,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return new HotReloadFileProcessResult(outcomes, warnings, 0);
             }
 
+            // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
             int patchedCount = 0;
             foreach (TransformWorkerEntryDto entry in workerOutput.entries)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -47,6 +47,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ? filePath
                     : contentPathOverride;
 
+                // Why ConfigureAwait(true): continuations must resume on the Unity main thread
+                // because the pipeline calls main-thread-only editor APIs (CompilationPipeline,
+                // Application.dataPath, EditorApplication.applicationContentsPath) and applies
+                // Harmony patches between awaits. The tool layer's ConfigureAwait(false) only
+                // moves BuildApplyResponse off-thread; it does not detach this pipeline.
                 HotReloadFileProcessResult fileResult = await ProcessFileAsync(
                     filePath,
                     workerSourcePath,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadProcessRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadProcessRunner.cs
@@ -41,7 +41,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // and drain before throwing; otherwise the child keeps writing cache/temp files.
             Task waitForExitTask = Task.Run(() => process.WaitForExit());
             Task delayTask = Task.Delay(timeout, ct);
-            Task completedTask = await Task.WhenAny(waitForExitTask, delayTask).ConfigureAwait(true);
+            // No Unity APIs here — ConfigureAwait(false) is required so a paused Play Mode
+            // SynchronizationContext cannot strand these process waits.
+            Task completedTask = await Task.WhenAny(waitForExitTask, delayTask).ConfigureAwait(false);
 
             if (completedTask != waitForExitTask)
             {
@@ -52,8 +54,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 // Drain redirected streams before disposing the process so a late ObjectDisposedException
                 // cannot surface as an unobserved task fault in the Editor.
-                string timedOutStdout = await stdoutTask.ConfigureAwait(true);
-                string timedOutStderr = await stderrTask.ConfigureAwait(true);
+                string timedOutStdout = await stdoutTask.ConfigureAwait(false);
+                string timedOutStderr = await stderrTask.ConfigureAwait(false);
                 ct.ThrowIfCancellationRequested();
                 return (
                     -1,
@@ -63,8 +65,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Process finished; return its result even if ct fired at the same moment.
             process.WaitForExit();
-            string standardOutput = await stdoutTask.ConfigureAwait(true);
-            string standardError = await stderrTask.ConfigureAwait(true);
+            string standardOutput = await stdoutTask.ConfigureAwait(false);
+            string standardError = await stderrTask.ConfigureAwait(false);
             return (process.ExitCode, standardOutput, standardError);
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -8,6 +8,8 @@ using UnityEditor.Compilation;
 
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
 using Assembly = System.Reflection.Assembly;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -33,6 +35,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(!string.IsNullOrEmpty(shimSource), "shimSource must not be empty.");
             Debug.Assert(referencePaths != null, "referencePaths must not be null.");
             Debug.Assert(defineSymbols != null, "defineSymbols must not be null.");
+
+            // Resolver and Application.dataPath (CreateWorkDirectory) need the Unity main thread.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
 
             ExternalCompilerPaths externalCompilerPaths = ExternalCompilerPathResolver.Resolve();
             if (externalCompilerPaths == null)
@@ -65,7 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ct,
                     markBuildStarted: static () => { },
                     markBuildFinished: static () => { },
-                    incrementBuildCount: static () => { }).ConfigureAwait(true);
+                    incrementBuildCount: static () => { }).ConfigureAwait(false);
 
                 List<string> errors = CollectErrors(backendResult.CompilerMessages);
                 if (errors.Count > 0)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -104,7 +104,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         // Returns an error message when apply-mode arguments are invalid, or null when valid.
-        private static string ValidateApplyParameters(HotReloadSchema parameters)
+        internal static string ValidateApplyParameters(HotReloadSchema parameters)
         {
             if (parameters.Files == null || parameters.Files.Length == 0)
             {
@@ -122,7 +122,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
-        private static HotReloadResponse BuildApplyResponse(HotReloadOrchestratorResult result)
+        internal static HotReloadResponse BuildApplyResponse(HotReloadOrchestratorResult result)
         {
             Debug.Assert(result != null, "result must not be null.");
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Parameters for applying hot reload to edited source files, or reverting every active patch.
+    /// </summary>
+    public class HotReloadSchema : UnityCliLoopToolSchema
+    {
+        /// <summary>
+        /// Project-relative source file paths to hot-reload. Required when RevertAll is false.
+        /// </summary>
+        public string[] Files { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// When true, removes every active hot-reload transplant and ignores Files.
+        /// </summary>
+        public bool RevertAll { get; set; }
+    }
+
+    /// <summary>
+    /// One per-method outcome from a hot-reload apply run.
+    /// </summary>
+    public class HotReloadMethodResult
+    {
+        public string Kind { get; set; } = string.Empty;
+        public string Method { get; set; } = string.Empty;
+        public string Reason { get; set; } = string.Empty;
+        public string FilePath { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Response for the hot-reload tool: aggregated apply outcomes or revert-all status.
+    /// </summary>
+    public class HotReloadResponse : UnityCliLoopToolResponse
+    {
+        public IReadOnlyList<HotReloadMethodResult> Methods { get; set; } =
+            Array.Empty<HotReloadMethodResult>();
+
+        public IReadOnlyList<string> Warnings { get; set; } = Array.Empty<string>();
+
+        public int PatchedTotal { get; set; }
+
+        public int ActivePatchTotal { get; set; }
+
+        public int ClearedCount { get; set; }
+
+        public string Message { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Exposes attribute-free hot reload as a Unity CLI Loop first-party tool.
+    /// </summary>
+    [UnityCliLoopTool]
+    public class HotReloadTool : UnityCliLoopTool<HotReloadSchema, HotReloadResponse>
+    {
+        public override string ToolName => UnityCliLoopConstants.TOOL_NAME_HOT_RELOAD;
+
+        protected override async Task<HotReloadResponse> ExecuteAsync(
+            HotReloadSchema parameters,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Debug.Assert(parameters != null, "parameters must not be null.");
+
+            if (parameters.RevertAll)
+            {
+                return ExecuteRevertAll();
+            }
+
+            string validationError = ValidateApplyParameters(parameters);
+            if (validationError != null)
+            {
+                return CreateValidationFailure(validationError);
+            }
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator
+                .RunAsync(parameters.Files, contentPathOverride: null, ct)
+                .ConfigureAwait(false);
+
+            return BuildApplyResponse(result);
+        }
+
+        private static HotReloadResponse ExecuteRevertAll()
+        {
+            int clearedCount = HotReloadPatcher.ActivePatchCount;
+            HotReloadPatcher.RevertAll();
+            return new HotReloadResponse
+            {
+                Success = true,
+                ClearedCount = clearedCount,
+                ActivePatchTotal = HotReloadPatcher.ActivePatchCount,
+                Message = clearedCount == 0
+                    ? "No active hot-reload patches to revert."
+                    : "Reverted all active hot-reload patches."
+            };
+        }
+
+        // Returns an error message when apply-mode arguments are invalid, or null when valid.
+        private static string ValidateApplyParameters(HotReloadSchema parameters)
+        {
+            if (parameters.Files == null || parameters.Files.Length == 0)
+            {
+                return "Files is required when --revert-all is not set.";
+            }
+
+            for (int index = 0; index < parameters.Files.Length; index++)
+            {
+                if (string.IsNullOrWhiteSpace(parameters.Files[index]))
+                {
+                    return "Files must not contain null or empty paths.";
+                }
+            }
+
+            return null;
+        }
+
+        private static HotReloadResponse BuildApplyResponse(HotReloadOrchestratorResult result)
+        {
+            Debug.Assert(result != null, "result must not be null.");
+
+            List<HotReloadMethodResult> methods = new List<HotReloadMethodResult>(result.Methods.Count);
+            bool hasFailure = false;
+            for (int index = 0; index < result.Methods.Count; index++)
+            {
+                HotReloadMethodOutcome outcome = result.Methods[index];
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed)
+                {
+                    hasFailure = true;
+                }
+
+                methods.Add(
+                    new HotReloadMethodResult
+                    {
+                        Kind = outcome.Kind.ToString(),
+                        Method = outcome.Method,
+                        Reason = outcome.Reason ?? string.Empty,
+                        FilePath = outcome.FilePath ?? string.Empty
+                    });
+            }
+
+            List<string> warnings = new List<string>(result.Warnings);
+            if (result.PatchedTotal > 0)
+            {
+                // Always surface the pause-point interaction when any transplant was applied.
+                warnings.Add(HotReloadConstants.PausePointInteractionWarning);
+            }
+
+            return new HotReloadResponse
+            {
+                Success = !hasFailure,
+                Methods = methods,
+                Warnings = warnings,
+                PatchedTotal = result.PatchedTotal,
+                ActivePatchTotal = result.ActivePatchTotal,
+                Message = BuildApplyMessage(result, hasFailure)
+            };
+        }
+
+        private static string BuildApplyMessage(HotReloadOrchestratorResult result, bool hasFailure)
+        {
+            if (hasFailure)
+            {
+                return "Hot reload finished with one or more Failed method outcomes. See Methods.";
+            }
+
+            if (result.PatchedTotal == 0)
+            {
+                return "Hot reload finished with no methods patched. See Methods for Skipped reasons.";
+            }
+
+            return "Hot reload applied. PatchedTotal=" + result.PatchedTotal
+                + ", ActivePatchTotal=" + result.ActivePatchTotal + ".";
+        }
+
+        private static HotReloadResponse CreateValidationFailure(string message)
+        {
+            return new HotReloadResponse
+            {
+                Success = false,
+                Message = message
+            };
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9a32d3e84e5a4544a348c3db46cdfd7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f05c69339d3144b8aa4cf7c98e91df01
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: uloop-hot-reload
+toolName: hot-reload
+description: "Apply method-body hot reload to edited C# sources in a running Unity Editor without domain reload. Use after small method edits when you need PlayMode/EditMode feedback without uloop compile."
+---
+
+# uloop hot-reload
+
+DRAFT — prose wording will be finalized by the Fable session. Parameter table below must stay aligned with the implemented schema.
+
+Reload method bodies from edited project source files into the running Editor (EditMode or PlayMode) without a domain reload. No `[HotReload]` attribute is required. Private/internal access, static methods, return values, async, and iterators are supported within v1 skip rules. Methods that cannot be patched are reported as Skipped with a reason (not as a hard tool failure for that method alone).
+
+## Usage
+
+```bash
+uloop hot-reload --files Assets/Scripts/Enemy.cs
+uloop hot-reload --files Assets/Scripts/Enemy.cs Assets/Scripts/Boss.cs
+uloop hot-reload --revert-all
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
+| `--revert-all` | flag | - | Remove every active hot-reload transplant and clear the patch ledger. When set, `--files` is ignored |
+
+## What it does
+
+1. Resolves each file to its compiled assembly via `CompilationPipeline`.
+2. Transforms edited method bodies into static shim methods in an out-of-process worker.
+3. Compiles shims against publicized reference assemblies and loads them into the Editor domain.
+4. Transplants each shim's IL into the original method with Harmony (ID `io.github.hatayama.uloop.hot-reload`).
+
+## v1 skip conditions
+
+| Condition | Reason (summary) |
+|-----------|------------------|
+| Body contains `base.` call | Cannot express `base` from outside the type |
+| Method on a `partial` type | Single-file semantic model is incomplete |
+| Generic method or method on a generic type | Harmony cannot safely patch these |
+| Method on a struct (value type) | Value-type transplant semantics are out of v1 scope |
+| Property/indexer accessor, constructor, finalizer, operator | v1 covers ordinary methods only |
+| Async/iterator body with private/internal access | State machine `MoveNext` is normally JIT-checked |
+| Lambda/local-function body with private/internal access | Closure methods are normally JIT-checked |
+| Signature missing from the loaded assembly | New/renamed/changed members need `uloop compile` |
+| abstract / extern / `[BurstCompile]` | Not patchable |
+| Shim compile error (e.g. calling a newly added helper) | Needs `uloop compile`; response includes the csc error and hint |
+
+## Convergence and lifecycle
+
+- Input is the real project source file. A later `uloop compile` (real compile + domain reload) converges to the same behavior as the patch.
+- Active Harmony patches and loaded shim assemblies are static state and disappear on domain reload by design. There is no persistence or automatic re-apply.
+- Field additions, field initializers, and new types are never reflected by hot reload.
+
+## Pause point interaction
+
+Hot-reload transplant discards the original IL and any prior transpiler output on that method. A source pause point on a hot-reloaded method will not fire until the patch is reverted (`--revert-all` or a later revert of that method) or a domain reload restores the original IL. Apply responses include this as a `Warnings` entry when any method was patched.
+
+## Output
+
+Returns JSON with:
+
+- `Success` (boolean): `false` on validation failure or when any method outcome is `Failed`; skips alone do not force failure
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
+- `Warnings` (array): Inlining risk, pause-point interaction, and other non-fatal notes
+- `PatchedTotal` (number): Methods patched in this run
+- `ActivePatchTotal` (number): Methods still patched after this run
+- `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)
+- `Message` (string): Short summary

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -6,17 +6,22 @@ description: "Apply method-body hot reload to edited C# sources in a running Uni
 
 # uloop hot-reload
 
-DRAFT — prose wording will be finalized by the Fable session. Parameter table below must stay aligned with the implemented schema.
-
-Reload method bodies from edited project source files into the running Editor (EditMode or PlayMode) without a domain reload. No `[HotReload]` attribute is required. Private/internal access, static methods, return values, async, and iterators are supported within v1 skip rules. Methods that cannot be patched are reported as Skipped with a reason (not as a hard tool failure for that method alone).
+Replaces method bodies in the running Editor (EditMode or PlayMode) directly from edited
+project source files — no domain reload, no attributes, no source markers. Private/internal
+member access, static methods, return values, async methods, and iterators all work within
+the v1 limits below. Methods that cannot be patched are reported per method as `Skipped` or
+`Failed`; one unpatchable method never aborts the rest of the run.
 
 ## Usage
 
 ```bash
 uloop hot-reload --files Assets/Scripts/Enemy.cs
-uloop hot-reload --files Assets/Scripts/Enemy.cs Assets/Scripts/Boss.cs
+uloop hot-reload --files Assets/Scripts/Enemy.cs,Assets/Scripts/Boss.cs
 uloop hot-reload --revert-all
 ```
+
+Multiple files are passed as one comma-separated value (or a JSON array); array options
+consume exactly one value token.
 
 ## Parameters
 
@@ -25,45 +30,70 @@ uloop hot-reload --revert-all
 | `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
 | `--revert-all` | flag | - | Remove every active hot-reload transplant and clear the patch ledger. When set, `--files` is ignored |
 
-## What it does
+## How it works
 
 1. Resolves each file to its compiled assembly via `CompilationPipeline`.
-2. Transforms edited method bodies into static shim methods in an out-of-process worker.
-3. Compiles shims against publicized reference assemblies and loads them into the Editor domain.
-4. Transplants each shim's IL into the original method with Harmony (ID `io.github.hatayama.uloop.hot-reload`).
+2. Rewrites each editable method body into a static shim in an out-of-process Roslyn worker.
+3. Compiles the shims against publicized reference copies and loads the result into the Editor domain.
+4. Transplants each shim's IL into the original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`).
 
-## v1 skip conditions
+Re-running on the same method replaces its previous patch; `ActivePatchTotal` tracks the
+ledger across runs.
 
-| Condition | Reason (summary) |
-|-----------|------------------|
-| Body contains `base.` call | Cannot express `base` from outside the type |
-| Method on a `partial` type | Single-file semantic model is incomplete |
-| Generic method or method on a generic type | Harmony cannot safely patch these |
-| Method on a struct (value type) | Value-type transplant semantics are out of v1 scope |
-| Property/indexer accessor, constructor, finalizer, operator | v1 covers ordinary methods only |
-| Async/iterator body with private/internal access | State machine `MoveNext` is normally JIT-checked |
-| Lambda/local-function body with private/internal access | Closure methods are normally JIT-checked |
-| Signature missing from the loaded assembly | New/renamed/changed members need `uloop compile` |
-| abstract / extern / `[BurstCompile]` | Not patchable |
-| Shim compile error (e.g. calling a newly added helper) | Needs `uloop compile`; response includes the csc error and hint |
+## Scope and limits (v1)
+
+Only ordinary method declarations are scanned. Property and indexer accessors, constructors,
+finalizers, operators, and event accessors are never scanned: edits to them produce **no
+per-method entry at all** and are silently not applied — use `uloop compile` for those.
+
+### Skipped — reported per method, never flips `Success`
+
+| Condition | Why |
+|-----------|-----|
+| Method on a `partial` type (including a type nested inside a partial outer type) | A single file cannot provide a complete semantic model |
+| Method on a struct (value type) | Value-type transplant is out of v1 scope |
+| Generic method, or method on a generic type | Harmony cannot safely patch open generics |
+| Explicit interface implementation | Dotted metadata names cannot be expressed as shim identifiers |
+| No body (`abstract` / `extern`) | Nothing to transplant |
+| Body contains a `base.` call | `base` cannot be expressed from outside the type |
+| Lambda, local function, or LINQ query in the body accesses private/internal members | Closure bodies run from the shim assembly, where that access fails runtime accessibility checks; only the named method's IL is transplanted |
+| `async` or iterator body accesses private/internal members | Same as above — the state machine's `MoveNext` runs from the shim assembly |
+
+### Failed — flips `Success` to `false`
+
+| Condition | Notes |
+|-----------|-------|
+| File does not belong to any compiled assembly | Per-file entry with `Method` = `(file)`; only `Assets/` and `Packages/` sources resolve |
+| Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
+| Source file fails to parse | Per-file entry carrying the parse errors |
+| Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
+| Patch rejected at apply time (e.g. `[BurstCompile]`) | Not patchable by Harmony transplant |
 
 ## Convergence and lifecycle
 
-- Input is the real project source file. A later `uloop compile` (real compile + domain reload) converges to the same behavior as the patch.
-- Active Harmony patches and loaded shim assemblies are static state and disappear on domain reload by design. There is no persistence or automatic re-apply.
-- Field additions, field initializers, and new types are never reflected by hot reload.
+- The input is the real project source file, so a later `uloop compile` (real compile +
+  domain reload) lands the exact same edit permanently. There is nothing to undo first;
+  behavior converges by construction.
+- Patches and loaded shim assemblies are static Editor state and disappear on the next
+  domain reload. There is no persistence and no automatic re-apply.
+- Never reflected by hot reload: new fields, field initializer changes, new types, and
+  signature changes. Those always need `uloop compile`.
 
 ## Pause point interaction
 
-Hot-reload transplant discards the original IL and any prior transpiler output on that method. A source pause point on a hot-reloaded method will not fire until the patch is reverted (`--revert-all` or a later revert of that method) or a domain reload restores the original IL. Apply responses include this as a `Warnings` entry when any method was patched.
+A hot-reload transplant discards the original IL and any prior transpiler output on that
+method, so a source pause point on a hot-reloaded method stops firing until the patch is
+reverted (`--revert-all`) or a domain reload restores the original IL. Apply responses
+include this as a `Warnings` entry whenever any method was patched.
 
 ## Output
 
 Returns JSON with:
 
-- `Success` (boolean): `false` on validation failure or when any method outcome is `Failed`; skips alone do not force failure
+- `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
-- `Warnings` (array): Inlining risk, pause-point interaction, and other non-fatal notes
+- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), and the pause-point interaction above
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0b3740ce3bde94163865ae05e09dc3d5
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
@@ -10,6 +10,8 @@ using UnityEditor.PackageManager;
 
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
 using Debug = UnityEngine.Debug;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -26,6 +28,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public static async Task<TransformWorkerBootstrapResult> EnsureWorkerAsync(CancellationToken ct)
         {
+            // Resolver / PackageInfo / Application.dataPath all require the Unity main thread.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+
             ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
             if (paths == null)
             {
@@ -61,7 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 workerSourcePath,
                 workerDllPath,
                 cacheDirectory,
-                ct).ConfigureAwait(true);
+                ct).ConfigureAwait(false);
             if (!compileResult.Success)
             {
                 return compileResult;
@@ -108,7 +113,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 "\"" + paths.CompilerDllPath + "\" @\"" + responseFilePath + "\"",
                 cacheDirectory,
                 TimeSpan.FromMilliseconds(HotReloadConstants.WorkerProcessTimeoutMilliseconds),
-                ct).ConfigureAwait(true);
+                ct).ConfigureAwait(false);
 
             if (exitCode != 0)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 
 using Newtonsoft.Json;
 
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
 using Debug = UnityEngine.Debug;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -27,12 +29,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(!string.IsNullOrEmpty(input.sourcePath), "sourcePath must not be empty.");
 
             TransformWorkerBootstrapResult bootstrapResult =
-                await TransformWorkerBootstrap.EnsureWorkerAsync(ct).ConfigureAwait(true);
+                await TransformWorkerBootstrap.EnsureWorkerAsync(ct).ConfigureAwait(false);
             if (!bootstrapResult.Success)
             {
                 return TransformWorkerClientResult.Failure(bootstrapResult.ErrorMessage);
             }
 
+            // ExternalCompilerPathResolver reads EditorApplication.applicationPath.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
             ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
             if (paths == null)
             {
@@ -58,7 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     arguments,
                     bootstrapResult.WorkerDirectory,
                     TimeSpan.FromMilliseconds(HotReloadConstants.WorkerProcessTimeoutMilliseconds),
-                    ct).ConfigureAwait(true);
+                    ct).ConfigureAwait(false);
 
                 if (exitCode != 0)
                 {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/UnityCLILoop.FirstPartyTools.HotReload.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/UnityCLILoop.FirstPartyTools.HotReload.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "UnityCLILoop.FirstPartyTools.HotReload.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
-        "GUID:afe86dd49995e46baa33e099a4d2ee1d"
+        "GUID:afe86dd49995e46baa33e099a4d2ee1d",
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/UnityCLILoop.FirstPartyTools.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/UnityCLILoop.FirstPartyTools.Editor.asmdef
@@ -19,7 +19,8 @@
         "GUID:679888bc3e9c44c19ab0d62ff8701dcf",
         "GUID:9c34b9a25e1464dec91601291eade23f",
         "GUID:32708dd5a1f18474e8a4deddc56e8806",
-        "GUID:e3fd8b49afd6f4e3cae09011028922b4"
+        "GUID:e3fd8b49afd6f4e3cae09011028922b4",
+        "GUID:774ab7841db34070bf18932c90cf9ea6"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -66,6 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string TOOL_NAME_ENABLE_WATCH = "enable-watch";
         public const string TOOL_NAME_CLEAR_WATCH = "clear-watch";
         public const string TOOL_NAME_GET_WATCH_VALUES = "get-watch-values";
+        public const string TOOL_NAME_HOT_RELOAD = "hot-reload";
         public const string COMMAND_NAME_GET_TOOL_DETAILS = "get-tool-details";
         public const string COMMAND_NAME_GET_VERSION = "get-version";
         public const string COMMAND_NAME_GET_COMPILE_STATUS = "get-compile-status";

--- a/cli/common/tooldocs/skill_guidance.go
+++ b/cli/common/tooldocs/skill_guidance.go
@@ -22,6 +22,7 @@ var commandSkillNames = map[string]string{
 	"simulate-keyboard":    "uloop-simulate-keyboard",
 	"simulate-mouse-input": "uloop-simulate-mouse-input",
 	"simulate-mouse-ui":    "uloop-simulate-mouse-ui",
+	"hot-reload":           "uloop-hot-reload",
 
 	"launch": "uloop-launch",
 

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -741,6 +741,26 @@
           }
         }
       }
+    },
+    {
+      "name": "hot-reload",
+      "description": "Apply method-body hot reload to edited C# sources in a running Unity Editor without domain reload. Use after small method edits when you need PlayMode/EditMode feedback without uloop compile.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "Files": {
+            "type": "array",
+            "description": "Project-relative .cs paths whose method bodies should be hot-reloaded. Required when --revert-all is not set",
+            "items": {
+              "type": "string"
+            }
+          },
+          "RevertAll": {
+            "type": "boolean",
+            "description": "Remove every active hot-reload transplant and clear the patch ledger. When set, --files is ignored"
+          }
+        }
+      }
     }
   ]
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "b2ac9823a3c47b5fec9ec4fb5104c119d393e7fb"
+  "sharedInputsHash": "be4a33421c86ac76847440ec0ae0a71ffd0e4865"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d429ad0bf002a8f7cccbc2d58fdfd707d281f42f"
+  "sharedInputsHash": "82863563e5c0551929f1a636fb15fb5bbc7d0803"
 }

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -133,3 +133,27 @@ a pause point, represented by `UloopCapturedVariable` internally and exposed as
 `UnityObjectPath`, and `UnityObjectInstanceId`. The snapshot is taken before the resolved
 line executes, and `CapturedVariablesTruncated` reports whether the length or count cap
 clipped any evidence.
+
+### Hot reload
+
+The first-party tool `hot-reload` that replaces method bodies in a running Unity Editor
+from edited project source files without a domain reload. It transforms each editable
+method into a static shim, compiles that shim against publicized references, loads the
+shim assembly, and transplants the shim IL into the original method via a Harmony
+transpiler (`io.github.hatayama.uloop.hot-reload`). Patches are static Editor state and
+disappear on domain reload by design; a later `uloop compile` converges to the same
+source behavior.
+
+### Shim
+
+A generated static method that mirrors an edited user method body for hot reload. For an
+instance method, the shim is a static method whose first parameter is the original
+instance (`instance`) so IL argument slots match the original method and the body can be
+transplanted without rewriting call/load slots. Prefix wrappers are not generated.
+
+### Publicized reference
+
+A Cecil-rewritten copy of a project assembly under `Library/UloopHotReload/PublicizedRefs/`
+in which every type and member is public. Hot reload uses these copies only as compile-time
+references for shim compilation so private/internal member access type-checks; they are
+never loaded into the Editor domain as the runtime identity of the target types.


### PR DESCRIPTION
## Summary

- Expose the existing hot-reload orchestrator as the first-party `uloop hot-reload` tool (`--files`, `--revert-all`), with asmdef wiring into ToolContracts and the FirstPartyTools aggregate.
- Add a draft `uloop-hot-reload` skill, manually add the `hot-reload` block to `default-tools.json`, map skill guidance in Go, refresh shared-release stamps, and document hot reload / shim / publicized reference in the glossary.

**SKILL.md prose is a draft; Fable session will review the wording.**

## Live verification (To-Do 19)

PlayMode session against `Assets/Tests/Editor/HotReload/HotReloadCoreFixtures.cs` (edited `ReplaceableCompute` to `return delta + 777`, then restored):

- `uloop hot-reload --files ...` → `Success: true`, `PatchedTotal: 9`, pause-point interaction warning present
- `execute-dynamic-code` after patch → `ReplaceableCompute(3)` returned `780`
- `uloop hot-reload --revert-all` → `ClearedCount: 9`, `ActivePatchTotal: 0`
- `execute-dynamic-code` after revert → returned `-3` (original body)
- Fixture source restored; no verification edit left in the tree

## Test plan

- [x] `dist/darwin-arm64/uloop compile` → ErrorCount 0
- [x] `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value HotReload` → 40/40 Passed
- [x] `scripts/check-go-cli.sh` green
- [x] `cd cli/release-automation && go run ./cmd/sync-tool-docs --check --repository-root ../..` → no drift
- [x] `scripts/stamp-release-inputs.sh` run in this PR
- [x] Live PlayMode hot-reload / revert-all / source restore (above)

## User Impact

Agents can run `uloop hot-reload --files <edited.cs>` to apply method-body changes in a running Editor without a domain reload, and `uloop hot-reload --revert-all` to clear active transplants.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

