### PR TITLE
feat: rewrite inaccessible member access into accessor delegates in the hot reload worker

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -37,12 +38,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public class HotReloadE2EFixture : HotReloadE2EBase, IHotReloadE2EMarker
     {
         private int _secret = 10;
+        private Action _callback;
+        private int? Score { get; set; }
 
         public int SecretForAssert => _secret;
 
         public int Counter;
 
+        public HotReloadE2EFixture Next;
+
         private int this[int index] => _secret + index;
+
+        public int VisibleSibling()
+        {
+            return 1;
+        }
+
+        public static int VisibleStaticSibling()
+        {
+            return 2;
+        }
 
         // Sentinel body: hot reload must replace this with a private-touching shim that returns
         // _secret + delta + 100.
@@ -95,6 +110,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public int CountEnumerator(List<int>.Enumerator enumerator)
         {
             return 0;
+        }
+
+        // F-1: bare instance/static sibling calls — transplant shim must qualify receivers.
+        public int CallsBareSiblings()
+        {
+            return VisibleSibling() + VisibleStaticSibling();
+        }
+
+        // F-1: private field read plus bare visible sibling — delegation entry with qualified sibling.
+        public async Task<int> AsyncPrivateAndBareSibling()
+        {
+            await Task.Yield();
+            return _secret + VisibleSibling();
+        }
+
+        // F-2a: ?. over an inaccessible member — worker must skip (condition b).
+        public async Task<int> AsyncConditionalPrivateField()
+        {
+            await Task.Yield();
+            return Next?._secret ?? 0;
+        }
+
+        // F-2b: private delegate field invoke — delegation with FieldRef read then invoke.
+        public async Task AsyncInvokePrivateDelegate()
+        {
+            await Task.Yield();
+            _callback();
+        }
+
+        // F-3: private property ??= — worker must skip (no conditional-write rewrite shape).
+        public async Task AsyncNullCoalesceAssignPrivateProperty()
+        {
+            await Task.Yield();
+            Score ??= 5;
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -40,12 +40,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private int _secret = 10;
         private Action _callback;
         private int? Score { get; set; }
+        private int Value { get; set; }
 
         public int SecretForAssert => _secret;
 
         public int Counter;
 
         public HotReloadE2EFixture Next;
+
+        // Property getter receiver — compound writes must not double-evaluate this.
+        public HotReloadE2EFixture Current
+        {
+            get { return this; }
+        }
 
         private int this[int index] => _secret + index;
 
@@ -158,6 +165,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             await Task.Yield();
             Score ??= 5;
+        }
+
+        // Compound write through a property getter receiver — worker must skip (double-eval).
+        public async Task AsyncCompoundWriteViaPropertyReceiver()
+        {
+            await Task.Yield();
+            Current.Value += 1;
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -112,34 +112,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return 0;
         }
 
-        // F-1: bare instance/static sibling calls — transplant shim must qualify receivers.
+        // Bare instance/static sibling calls — the transplant shim must qualify receivers.
         public int CallsBareSiblings()
         {
             return VisibleSibling() + VisibleStaticSibling();
         }
 
-        // F-1: private field read plus bare visible sibling — delegation entry with qualified sibling.
+        // Private field read plus bare visible sibling — delegation entry with qualified sibling.
         public async Task<int> AsyncPrivateAndBareSibling()
         {
             await Task.Yield();
             return _secret + VisibleSibling();
         }
 
-        // F-2a: ?. over an inaccessible member — worker must skip (condition b).
+        // ?. over an inaccessible member — worker must skip (condition b).
         public async Task<int> AsyncConditionalPrivateField()
         {
             await Task.Yield();
             return Next?._secret ?? 0;
         }
 
-        // F-2b: private delegate field invoke — delegation with FieldRef read then invoke.
+        // Private delegate field invoke — delegation with FieldRef read then invoke.
         public async Task AsyncInvokePrivateDelegate()
         {
             await Task.Yield();
             _callback();
         }
 
-        // F-3: private property ??= — worker must skip (no conditional-write rewrite shape).
+        // Private property ??= — worker must skip (no conditional-write rewrite shape).
         public async Task AsyncNullCoalesceAssignPrivateProperty()
         {
             await Task.Yield();

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -70,15 +70,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return _secret;
         }
 
-        // Sync method + query syntax referencing a private field — must be Skipped (query clauses
-        // become display-class methods that JIT accessibility-check).
+        // Sync method + query syntax referencing a private field — worker emits a delegation
+        // entry (accessor rewrite); orchestrator leaves it unpatched until the delegation pass.
         public int QueryPrivate()
         {
             int[] values = { 1, 2, 3 };
             return (from value in values where value < _secret select value).Count();
         }
 
-        // Async body reading a private indexer — must be Skipped (MoveNext JIT-checks).
+        // Async body reading a private indexer — still Skipped at the worker (no rewrite shape).
         public async Task<int> AsyncReadPrivateIndexer()
         {
             await Task.Yield();

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -139,6 +139,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             _callback();
         }
 
+        // Receiver-qualified private delegate invoke (`this._callback()`) — same FieldRef shape.
+        public async Task AsyncInvokePrivateDelegateOnThis()
+        {
+            await Task.Yield();
+            this._callback();
+        }
+
+        // Parameter-receiver private delegate invoke (`other._callback()`) — FieldRef on other.
+        public async Task AsyncInvokePrivateDelegateOnOther(HotReloadE2EFixture other)
+        {
+            await Task.Yield();
+            other._callback();
+        }
+
         // Private property ??= — worker must skip (no conditional-write rewrite shape).
         public async Task AsyncNullCoalesceAssignPrivateProperty()
         {

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -198,6 +198,50 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a mixed transplant+delegation fixture compiles the shim (Harmony ref present),
+        /// transplants the sync private-access method, and reports delegation entries as Skipped
+        /// with the not-wired reason (delegation patcher lands in a later change).
+        /// </summary>
+        [Test]
+        public async Task Run_MixedTransplantAndDelegationFile_PatchesSyncAndSkipsDelegation()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "MixedTransplantDelegation.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(10 + 5 + 100));
+
+            bool foundDelegationSkip = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
+                    && outcome.Method.Contains(nameof(HotReloadE2EFixture.QueryPrivate))
+                    && outcome.Reason == HotReloadConstants.DelegationPatchNotWiredSkipReason)
+                {
+                    foundDelegationSkip = true;
+                }
+            }
+
+            Assert.That(
+                foundDelegationSkip,
+                Is.True,
+                "Expected QueryPrivate to be Skipped with the delegation-not-wired reason.\n"
+                + FormatOutcomes(result));
+        }
+
+        /// <summary>
         /// What: an edited body that calls a non-existent helper fails shim compile with the
         /// new-member hint (Failed, not a silent skip).
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -36,6 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Output.shimSource, Is.Not.Null.And.Not.Empty);
 
             bool foundCompute = false;
+            bool foundQueryPrivateDelegation = false;
             bool foundListEnumeratorFullName = false;
             foreach (TransformWorkerEntryDto entry in result.Output.entries)
             {
@@ -44,6 +45,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     foundCompute = true;
                     Assert.That(entry.shimMethodName, Does.Contain("__shim"));
                     Assert.That(entry.shimTypeName, Does.Contain("UloopHotReloadShims"));
+                    Assert.That(entry.patchKind, Is.EqualTo("transplant"));
+                }
+
+                if (entry.methodName == nameof(HotReloadE2EFixture.QueryPrivate))
+                {
+                    foundQueryPrivateDelegation = true;
+                    Assert.That(entry.patchKind, Is.EqualTo("delegation"));
+                    Assert.That(result.Output.shimSource, Does.Contain("__BindAccessors"));
                 }
 
                 if (entry.methodName == nameof(HotReloadE2EFixture.CountEnumerator)
@@ -57,6 +66,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(foundCompute, Is.True, "ComputeWithPrivate entry missing from worker output.");
             Assert.That(
+                foundQueryPrivateDelegation,
+                Is.True,
+                "QueryPrivate must be a delegation entry (accessor rewrite), not a worker skip.");
+            Assert.That(
                 foundListEnumeratorFullName,
                 Is.True,
                 "CountEnumerator parameterTypeFullNames must use Cecil nested-generic FullName: "
@@ -65,7 +78,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Output.skipped, Is.Not.Null, "Expected a skipped list from the worker.");
             AssertHasSkip(result, nameof(HotReloadE2EFixture.CallsBase), "base");
             AssertHasSkip(result, "ExplicitPing", "Explicit interface");
-            AssertHasSkip(result, nameof(HotReloadE2EFixture.QueryPrivate), "query");
             AssertHasSkip(result, nameof(HotReloadE2EFixture.AsyncReadPrivateIndexer), "private/internal");
         }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,8 +25,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// <summary>
         /// What: bootstrap compiles (or reuses a cached) worker.dll, then running the worker on the
         /// e2e fixture source returns shim entries and the expected skip reasons — including bare
-        /// sibling qualify, conditional-access skip, private delegate invoke, and null-coalescing
-        /// assignment skip.
+        /// sibling qualify, conditional-access skip, private delegate invoke (bare / this / other),
+        /// null-coalescing assignment skip, and property-receiver compound-write skip.
         /// </summary>
         [Test]
         public async Task BootstrapAndRun_OnE2EFixture_ReturnsEntriesAndExpectedSkips()
@@ -43,6 +44,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             bool foundCallsBareSiblings = false;
             bool foundAsyncPrivateAndBareSibling = false;
             bool foundAsyncInvokePrivateDelegate = false;
+            bool foundAsyncInvokePrivateDelegateOnThis = false;
+            bool foundAsyncInvokePrivateDelegateOnOther = false;
             foreach (TransformWorkerEntryDto entry in result.Output.entries)
             {
                 if (entry.methodName == nameof(HotReloadE2EFixture.ComputeWithPrivate))
@@ -64,24 +67,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 {
                     foundCallsBareSiblings = true;
                     Assert.That(entry.patchKind, Is.EqualTo("transplant"));
-                    Assert.That(result.Output.shimSource, Does.Contain("instance.VisibleSibling()"));
-                    Assert.That(
-                        result.Output.shimSource,
-                        Does.Contain(".VisibleStaticSibling()"));
+                    string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
+                    Assert.That(slice, Does.Contain("instance.VisibleSibling()"));
+                    Assert.That(slice, Does.Contain(".VisibleStaticSibling()"));
                 }
 
                 if (entry.methodName == nameof(HotReloadE2EFixture.AsyncPrivateAndBareSibling))
                 {
                     foundAsyncPrivateAndBareSibling = true;
                     Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
-                    Assert.That(result.Output.shimSource, Does.Contain("instance.VisibleSibling()"));
+                    string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
+                    Assert.That(slice, Does.Contain("instance.VisibleSibling()"));
                 }
 
                 if (entry.methodName == nameof(HotReloadE2EFixture.AsyncInvokePrivateDelegate))
                 {
                     foundAsyncInvokePrivateDelegate = true;
                     Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
-                    Assert.That(result.Output.shimSource, Does.Contain("__F__callback(instance)()"));
+                    string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
+                    Assert.That(slice, Does.Contain("__F__callback(instance)()"));
+                }
+
+                if (entry.methodName == nameof(HotReloadE2EFixture.AsyncInvokePrivateDelegateOnThis))
+                {
+                    foundAsyncInvokePrivateDelegateOnThis = true;
+                    Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
+                    string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
+                    Assert.That(slice, Does.Contain("__F__callback(instance)()"));
+                }
+
+                if (entry.methodName == nameof(HotReloadE2EFixture.AsyncInvokePrivateDelegateOnOther))
+                {
+                    foundAsyncInvokePrivateDelegateOnOther = true;
+                    Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
+                    string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
+                    Assert.That(slice, Does.Contain("__F__callback(other)()"));
                 }
 
                 if (entry.methodName == nameof(HotReloadE2EFixture.CountEnumerator)
@@ -111,6 +131,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.True,
                 "AsyncInvokePrivateDelegate must be a delegation entry with FieldRef invoke.");
             Assert.That(
+                foundAsyncInvokePrivateDelegateOnThis,
+                Is.True,
+                "AsyncInvokePrivateDelegateOnThis must be a delegation entry with FieldRef invoke.");
+            Assert.That(
+                foundAsyncInvokePrivateDelegateOnOther,
+                Is.True,
+                "AsyncInvokePrivateDelegateOnOther must be a delegation entry with FieldRef on other.");
+            Assert.That(
                 foundListEnumeratorFullName,
                 Is.True,
                 "CountEnumerator parameterTypeFullNames must use Cecil nested-generic FullName: "
@@ -122,6 +150,60 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasSkip(result, nameof(HotReloadE2EFixture.AsyncReadPrivateIndexer), "private/internal");
             AssertHasSkip(result, nameof(HotReloadE2EFixture.AsyncConditionalPrivateField), "conditional access");
             AssertHasSkip(result, nameof(HotReloadE2EFixture.AsyncNullCoalesceAssignPrivateProperty), "null-coalescing");
+            AssertHasSkip(
+                result,
+                nameof(HotReloadE2EFixture.AsyncCompoundWriteViaPropertyReceiver),
+                "receiver with possible side effects would be evaluated twice");
+        }
+
+        /// <summary>
+        /// What: extracts one shim method declaration from the aggregated shimSource so Contains
+        /// asserts cannot pass via text belonging to a different entry.
+        /// </summary>
+        private static string SliceShimMethod(string shimSource, string shimMethodName)
+        {
+            Assert.That(shimMethodName, Is.Not.Null.And.Not.Empty);
+            int nameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
+            Assert.That(
+                nameIndex,
+                Is.GreaterThanOrEqualTo(0),
+                "shimMethodName not found in shimSource: " + shimMethodName);
+
+            int declarationStart = shimSource.LastIndexOf(
+                "public static",
+                nameIndex,
+                StringComparison.Ordinal);
+            Assert.That(
+                declarationStart,
+                Is.GreaterThanOrEqualTo(0),
+                "shim method declaration start not found for: " + shimMethodName);
+
+            int openBrace = shimSource.IndexOf('{', nameIndex);
+            Assert.That(
+                openBrace,
+                Is.GreaterThanOrEqualTo(0),
+                "shim method body not found for: " + shimMethodName);
+
+            int depth = 0;
+            for (int index = openBrace; index < shimSource.Length; index++)
+            {
+                char character = shimSource[index];
+                if (character == '{')
+                {
+                    depth++;
+                }
+                else if (character == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return shimSource.Substring(declarationStart, index - declarationStart + 1);
+                    }
+                }
+            }
+
+            Assert.Fail("Unbalanced braces while slicing shim method: " + shimMethodName);
+            return null;
         }
 
         private static void AssertHasSkip(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -23,7 +23,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: bootstrap compiles (or reuses a cached) worker.dll, then running the worker on the
-        /// e2e fixture source returns shim entries and the expected skip reasons.
+        /// e2e fixture source returns shim entries and the expected skip reasons — including bare
+        /// sibling qualify (F-1), conditional-access skip (F-2a), private delegate invoke (F-2b),
+        /// and null-coalescing assignment skip (F-3).
         /// </summary>
         [Test]
         public async Task BootstrapAndRun_OnE2EFixture_ReturnsEntriesAndExpectedSkips()
@@ -38,6 +40,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             bool foundCompute = false;
             bool foundQueryPrivateDelegation = false;
             bool foundListEnumeratorFullName = false;
+            bool foundCallsBareSiblings = false;
+            bool foundAsyncPrivateAndBareSibling = false;
+            bool foundAsyncInvokePrivateDelegate = false;
             foreach (TransformWorkerEntryDto entry in result.Output.entries)
             {
                 if (entry.methodName == nameof(HotReloadE2EFixture.ComputeWithPrivate))
@@ -55,6 +60,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     Assert.That(result.Output.shimSource, Does.Contain("__BindAccessors"));
                 }
 
+                if (entry.methodName == nameof(HotReloadE2EFixture.CallsBareSiblings))
+                {
+                    foundCallsBareSiblings = true;
+                    Assert.That(entry.patchKind, Is.EqualTo("transplant"));
+                    Assert.That(result.Output.shimSource, Does.Contain("instance.VisibleSibling()"));
+                    Assert.That(
+                        result.Output.shimSource,
+                        Does.Contain(".VisibleStaticSibling()"));
+                }
+
+                if (entry.methodName == nameof(HotReloadE2EFixture.AsyncPrivateAndBareSibling))
+                {
+                    foundAsyncPrivateAndBareSibling = true;
+                    Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
+                    Assert.That(result.Output.shimSource, Does.Contain("instance.VisibleSibling()"));
+                }
+
+                if (entry.methodName == nameof(HotReloadE2EFixture.AsyncInvokePrivateDelegate))
+                {
+                    foundAsyncInvokePrivateDelegate = true;
+                    Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
+                    Assert.That(result.Output.shimSource, Does.Contain("__F__callback(instance)()"));
+                }
+
                 if (entry.methodName == nameof(HotReloadE2EFixture.CountEnumerator)
                     && entry.parameterTypeFullNames != null
                     && entry.parameterTypeFullNames.Length == 1
@@ -70,6 +99,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.True,
                 "QueryPrivate must be a delegation entry (accessor rewrite), not a worker skip.");
             Assert.That(
+                foundCallsBareSiblings,
+                Is.True,
+                "CallsBareSiblings must transplant with qualified bare sibling calls.");
+            Assert.That(
+                foundAsyncPrivateAndBareSibling,
+                Is.True,
+                "AsyncPrivateAndBareSibling must be a delegation entry.");
+            Assert.That(
+                foundAsyncInvokePrivateDelegate,
+                Is.True,
+                "AsyncInvokePrivateDelegate must be a delegation entry with FieldRef invoke.");
+            Assert.That(
                 foundListEnumeratorFullName,
                 Is.True,
                 "CountEnumerator parameterTypeFullNames must use Cecil nested-generic FullName: "
@@ -79,6 +120,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasSkip(result, nameof(HotReloadE2EFixture.CallsBase), "base");
             AssertHasSkip(result, "ExplicitPing", "Explicit interface");
             AssertHasSkip(result, nameof(HotReloadE2EFixture.AsyncReadPrivateIndexer), "private/internal");
+            AssertHasSkip(result, nameof(HotReloadE2EFixture.AsyncConditionalPrivateField), "conditional access");
+            AssertHasSkip(result, nameof(HotReloadE2EFixture.AsyncNullCoalesceAssignPrivateProperty), "null-coalescing");
         }
 
         private static void AssertHasSkip(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -51,7 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 if (entry.methodName == nameof(HotReloadE2EFixture.QueryPrivate))
                 {
                     foundQueryPrivateDelegation = true;
-                    Assert.That(entry.patchKind, Is.EqualTo("delegation"));
+                    Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
                     Assert.That(result.Output.shimSource, Does.Contain("__BindAccessors"));
                 }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -24,8 +24,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// <summary>
         /// What: bootstrap compiles (or reuses a cached) worker.dll, then running the worker on the
         /// e2e fixture source returns shim entries and the expected skip reasons — including bare
-        /// sibling qualify (F-1), conditional-access skip (F-2a), private delegate invoke (F-2b),
-        /// and null-coalescing assignment skip (F-3).
+        /// sibling qualify, conditional-access skip, private delegate invoke, and null-coalescing
+        /// assignment skip.
         /// </summary>
         [Test]
         public async Task BootstrapAndRun_OnE2EFixture_ReturnsEntriesAndExpectedSkips()

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -38,6 +38,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string NewMemberCompileHint =
             "Adding new members requires a real compile (uloop compile); hot reload only replaces existing method bodies.";
 
+        // PR-6: delegation shims compile and load, but the delegation patcher lands in PR-7.
+        // Keep a single present-tense reason so PR-7 can replace this constant and branch wholesale.
+        public const string DelegationPatchNotWiredSkipReason =
+            "Rewritten for delegation patching, which is not wired yet; method left unpatched.";
+
         /// <summary>
         /// Returns whether a ScriptAssemblies DLL is a project assembly that may be publicized.
         /// Engine / test-runner / system assemblies under ScriptAssemblies must stay untouched —

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -38,8 +38,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string NewMemberCompileHint =
             "Adding new members requires a real compile (uloop compile); hot reload only replaces existing method bodies.";
 
-        // PR-6: delegation shims compile and load, but the delegation patcher lands in PR-7.
-        // Keep a single present-tense reason so PR-7 can replace this constant and branch wholesale.
+        // Wire value for TransformWorkerEntryDto.patchKind when the worker rewrote inaccessible
+        // accesses into accessor delegates.
+        public const string PatchKindDelegation = "delegation";
+
+        // The delegation patcher is not wired yet: delegation shims compile and load so the
+        // wiring change only needs to bind accessors and patch. Keep a single present-tense
+        // reason so that change can replace this constant and branch wholesale.
         public const string DelegationPatchNotWiredSkipReason =
             "Rewritten for delegation patching, which is not wired yet; method left unpatched.";
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -237,7 +237,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string methodLabel = entry.typeMetadataName + "." + entry.methodName;
 
             // Only "delegation" takes the skip branch; null/empty/anything else is transplant.
-            if (entry.patchKind == "delegation")
+            if (entry.patchKind == HotReloadConstants.PatchKindDelegation)
             {
                 return HotReloadMethodOutcome.Skipped(
                     methodLabel,
@@ -403,7 +403,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             foreach (TransformWorkerEntryDto entry in entries)
             {
-                if (entry.patchKind == "delegation")
+                if (entry.patchKind == HotReloadConstants.PatchKindDelegation)
                 {
                     return true;
                 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -5,6 +5,8 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
+using HarmonyLib;
+
 using Mono.Cecil;
 
 using UnityEditor.Compilation;
@@ -183,7 +185,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // BuildShimReferencePaths reads Application.dataPath / platform; stay on main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
-            List<string> shimReferences = BuildShimReferencePaths(compilationAssembly, targetDllPath);
+            bool includeHarmonyReference = HasDelegationEntry(workerOutput.entries);
+            List<string> shimReferences = BuildShimReferencePaths(
+                compilationAssembly,
+                targetDllPath,
+                includeHarmonyReference);
             HotReloadShimCompileResult compileResult = await HotReloadShimCompiler.CompileAndLoadAsync(
                 workerOutput.shimSource,
                 shimReferences,
@@ -229,6 +235,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> warnings)
         {
             string methodLabel = entry.typeMetadataName + "." + entry.methodName;
+
+            // Only "delegation" takes the skip branch; null/empty/anything else is transplant.
+            if (entry.patchKind == "delegation")
+            {
+                return HotReloadMethodOutcome.Skipped(
+                    methodLabel,
+                    HotReloadConstants.DelegationPatchNotWiredSkipReason,
+                    filePath);
+            }
+
             string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
 
             HotReloadMethodMatchResult matchResult = HotReloadMethodMatcher.Resolve(
@@ -383,13 +399,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return paths.ToArray();
         }
 
+        private static bool HasDelegationEntry(TransformWorkerEntryDto[] entries)
+        {
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                if (entry.patchKind == "delegation")
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Publicize ScriptAssemblies references; leave engine/system DLLs untouched. Never include
-        /// the original (non-publicized) target assembly.
+        /// the original (non-publicized) target assembly. Harmony is added only when the worker
+        /// emitted at least one delegation entry so transplant-only compiles stay byte-identical.
         /// </summary>
         private static List<string> BuildShimReferencePaths(
             UnityCompilationAssembly compilationAssembly,
-            string targetDllPath)
+            string targetDllPath,
+            bool includeHarmonyReference)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string scriptAssembliesDirectory = Path.GetFullPath(
@@ -398,6 +429,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> references = new List<string>();
             string publicizedTarget = ReferencePublicizer.GetOrCreatePublicizedCopy(targetDllPath);
             references.Add(publicizedTarget);
+
+            if (includeHarmonyReference)
+            {
+                references.Add(typeof(Harmony).Assembly.Location);
+            }
 
             if (compilationAssembly.allReferences == null)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -92,6 +92,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 output.skipped ??= Array.Empty<TransformWorkerSkippedDto>();
                 output.parseErrors ??= Array.Empty<string>();
                 output.shimSource ??= string.Empty;
+                foreach (TransformWorkerEntryDto entry in output.entries)
+                {
+                    entry.patchKind ??= string.Empty;
+                }
+
                 return TransformWorkerClientResult.SuccessResult(output);
             }
             finally

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -34,6 +34,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string[] parameterTypeFullNames;
         public string shimTypeName;
         public string shimMethodName;
+
+        // "transplant" | "delegation". Null/empty is treated as transplant by the orchestrator.
+        public string patchKind;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -227,7 +227,7 @@ public static class TransformWorkerProgram
                 {
                     skipped.Add(new WorkerSkipped
                     {
-                        Method = FormatMethodLabel(typeSymbol, methodSymbol),
+                        Method = FormatMethodLabel(methodSymbol),
                         Reason = decision.SkipReason
                     });
                     continue;
@@ -517,7 +517,13 @@ public static class TransformWorkerProgram
         {
             if (assignment.Parent is InitializerExpressionSyntax)
             {
+                // Initializer assignments are always writes (including ImplicitElementAccess indexers).
                 ISymbol initializerSymbol = semanticModel.GetSymbolInfo(assignment.Left).Symbol;
+                if (initializerSymbol is IPropertySymbol initializerProperty)
+                {
+                    return AccessibilityRules.IsInaccessibleAccessor(initializerProperty.SetMethod);
+                }
+
                 return initializerSymbol != null
                     && AccessibilityRules.IsInaccessibleFromExternalAssembly(initializerSymbol);
             }
@@ -574,11 +580,18 @@ public static class TransformWorkerProgram
 
         if (node is ElementAccessExpressionSyntax elementAccess)
         {
+            // Assignment-left ElementAccess is owned by the assignment branch (write context).
+            if (elementAccess.Parent is AssignmentExpressionSyntax parentAssignment
+                && parentAssignment.Left == elementAccess)
+            {
+                return false;
+            }
+
             ISymbol symbol = semanticModel.GetSymbolInfo(elementAccess).Symbol;
             if (symbol is IPropertySymbol indexer)
             {
-                return AccessibilityRules.IsInaccessibleAccessor(indexer.GetMethod)
-                    || AccessibilityRules.IsInaccessibleAccessor(indexer.SetMethod);
+                // Standalone ElementAccess is a read.
+                return AccessibilityRules.IsInaccessibleAccessor(indexer.GetMethod);
             }
 
             return symbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol);
@@ -650,6 +663,8 @@ public static class TransformWorkerProgram
 
     internal static class NameofRules
     {
+        // Why text-only: nameof is a language keyword with a null symbol; a user-defined method
+        // literally named "nameof" would also match, but that pathological case is ignored in practice.
         public static bool IsNameofInvocation(InvocationExpressionSyntax invocation)
         {
             return invocation.Expression is IdentifierNameSyntax identifier
@@ -687,7 +702,7 @@ public static class TransformWorkerProgram
         return ShimMethodFactory.ToShimMethod(rewritten, methodSymbol);
     }
 
-    private static string FormatMethodLabel(INamedTypeSymbol typeSymbol, IMethodSymbol methodSymbol)
+    private static string FormatMethodLabel(IMethodSymbol methodSymbol)
     {
         return AccessorPlan.BuildMemberKey(methodSymbol);
     }
@@ -1440,9 +1455,13 @@ internal static class AccessorEligibility
         if (node is AssignmentExpressionSyntax assignment
             && assignment.Parent is InitializerExpressionSyntax)
         {
+            // Initializer assignments are always writes (including ImplicitElementAccess indexers).
             ISymbol initializerSymbol = semanticModel.GetSymbolInfo(assignment.Left).Symbol;
-            if (initializerSymbol != null
-                && AccessibilityRules.IsInaccessibleFromExternalAssembly(initializerSymbol))
+            bool inaccessibleWrite = initializerSymbol is IPropertySymbol initializerProperty
+                ? AccessibilityRules.IsInaccessibleAccessor(initializerProperty.SetMethod)
+                : initializerSymbol != null
+                    && AccessibilityRules.IsInaccessibleFromExternalAssembly(initializerSymbol);
+            if (inaccessibleWrite)
             {
                 rejectReason =
                     "inaccessible member assignment in an object/collection initializer has no "
@@ -1460,11 +1479,18 @@ internal static class AccessorEligibility
 
         if (node is ElementAccessExpressionSyntax elementAccess)
         {
+            // Assignment-left ElementAccess is owned by the assignment branch (write context).
+            if (elementAccess.Parent is AssignmentExpressionSyntax parentElementAssignment
+                && parentElementAssignment.Left == elementAccess)
+            {
+                return false;
+            }
+
             ISymbol symbol = semanticModel.GetSymbolInfo(elementAccess).Symbol;
             if (symbol is IPropertySymbol indexer && indexer.IsIndexer)
             {
-                if (AccessibilityRules.IsInaccessibleAccessor(indexer.GetMethod)
-                    || AccessibilityRules.IsInaccessibleAccessor(indexer.SetMethod))
+                // Standalone ElementAccess is a read — only the getter matters.
+                if (AccessibilityRules.IsInaccessibleAccessor(indexer.GetMethod))
                 {
                     rejectReason =
                         "inaccessible indexer access has no accessor rewrite shape (condition b).";
@@ -1551,10 +1577,10 @@ internal static class AccessorEligibility
 
     private static bool IsInaccessibleBindingTarget(ISymbol bound)
     {
+        // Member binding only appears in read/invoke contexts (x?.P = v is not valid C#).
         if (bound is IPropertySymbol propertySymbol)
         {
-            return AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod)
-                || AccessibilityRules.IsInaccessibleAccessor(propertySymbol.SetMethod);
+            return AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod);
         }
 
         return AccessibilityRules.IsInaccessibleFromExternalAssembly(bound);
@@ -1780,6 +1806,29 @@ internal static class AccessorEligibility
         out string rejectReason)
     {
         rejectReason = null;
+
+        // Why accessibility first: shape gates (indexer/static/ref-return) must not reject fully
+        // public writes such as dict[key]=value or Time.timeScale=0f. The read-side path already
+        // pre-filters with IsInaccessibleAccessor/IsInaccessibleFromExternalAssembly before shape
+        // checks — keep that order here for symmetry.
+        bool setterInaccessible = AccessibilityRules.IsInaccessibleAccessor(propertySymbol.SetMethod);
+        bool getterInaccessible = needsGetter
+            && AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod);
+        if (!setterInaccessible && !getterInaccessible)
+        {
+            return false;
+        }
+
+        // Compound assignment with a private getter and a public setter has no rewrite shape:
+        // RewritePropertyAssignment only fires when the setter is inaccessible.
+        if (getterInaccessible && !setterInaccessible)
+        {
+            rejectReason =
+                "compound assignment reading an inaccessible getter with an accessible setter "
+                + "has no accessor rewrite shape (condition b).";
+            return false;
+        }
+
         if (propertySymbol.IsIndexer)
         {
             rejectReason = "inaccessible indexer access has no accessor rewrite shape (condition b).";
@@ -1797,14 +1846,6 @@ internal static class AccessorEligibility
         {
             rejectReason =
                 "inaccessible ref-returning properties have no accessor rewrite shape (condition b).";
-            return false;
-        }
-
-        bool setterInaccessible = AccessibilityRules.IsInaccessibleAccessor(propertySymbol.SetMethod);
-        bool getterInaccessible = needsGetter
-            && AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod);
-        if (!setterInaccessible && !getterInaccessible)
-        {
             return false;
         }
 
@@ -2017,9 +2058,12 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             return original;
         }
 
-        // nameof(...) must keep a member reference shape (qualify only; never accessor calls).
-        bool insideNameof = TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node);
-        if (_accessorPlan != null && !insideNameof)
+        // nameof(...) and assignment left sides must keep a member-reference shape: qualify only,
+        // never rewrite to an accessor read (Func<> call results are not assignable).
+        bool suppressAccessorRead = TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node)
+            || (node.Parent is AssignmentExpressionSyntax assignmentLeft
+                && assignmentLeft.Left == node);
+        if (_accessorPlan != null && !suppressAccessorRead)
         {
             ExpressionSyntax accessorRead = TryRewriteInaccessibleRead(
                 symbol,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -1571,10 +1571,17 @@ internal static class AccessorEligibility
 
         if (node is MemberAccessExpressionSyntax memberAccess)
         {
+            // Method-group invocation targets are owned by the invocation branch; delegate-typed
+            // field invokes (`this._cb()` / `other._cb()`) register as field reads here.
             if (memberAccess.Parent is InvocationExpressionSyntax parentInvocation
                 && parentInvocation.Expression == memberAccess)
             {
-                return false;
+                ISymbol invocationTarget = semanticModel.GetSymbolInfo(memberAccess).Symbol
+                    ?? semanticModel.GetSymbolInfo(memberAccess.Name).Symbol;
+                if (invocationTarget is IMethodSymbol)
+                {
+                    return false;
+                }
             }
 
             if (memberAccess.Parent is AssignmentExpressionSyntax parentAssignment
@@ -2140,7 +2147,14 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             return base.VisitMemberAccessExpression(node);
         }
 
-        if (node.Parent is InvocationExpressionSyntax invocation && invocation.Expression == node)
+        ISymbol symbol = _semanticModel.GetSymbolInfo(node).Symbol
+            ?? _semanticModel.GetSymbolInfo(node.Name).Symbol;
+
+        // Method-group invocation targets stay with VisitInvocationExpression; field/property
+        // delegate invokes (`this._cb()`) must rewrite here so the call becomes `__F__(recv)()`.
+        if (node.Parent is InvocationExpressionSyntax invocation
+            && invocation.Expression == node
+            && symbol is IMethodSymbol)
         {
             return base.VisitMemberAccessExpression(node);
         }
@@ -2150,8 +2164,6 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             return base.VisitMemberAccessExpression(node);
         }
 
-        ISymbol symbol = _semanticModel.GetSymbolInfo(node).Symbol
-            ?? _semanticModel.GetSymbolInfo(node.Name).Symbol;
         ExpressionSyntax rewritten = TryRewriteInaccessibleRead(symbol, node.Expression, node);
         if (rewritten != null)
         {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -1671,6 +1671,7 @@ internal static class AccessorEligibility
         if (leftSymbol is IPropertySymbol propertySymbol)
         {
             return TryRegisterPropertyWrite(
+                semanticModel,
                 assignment,
                 propertySymbol,
                 plan,
@@ -1857,6 +1858,7 @@ internal static class AccessorEligibility
     }
 
     private static bool TryRegisterPropertyWrite(
+        SemanticModel semanticModel,
         AssignmentExpressionSyntax assignment,
         IPropertySymbol propertySymbol,
         AccessorPlan plan,
@@ -1911,7 +1913,7 @@ internal static class AccessorEligibility
         }
 
         // Compound/get+set rewrite embeds the receiver twice; reject side-effecting receivers.
-        if (needsGetter && !IsSideEffectFreeAssignmentReceiver(assignment.Left))
+        if (needsGetter && !IsSideEffectFreeAssignmentReceiver(semanticModel, assignment.Left))
         {
             rejectReason =
                 "receiver with possible side effects would be evaluated twice (condition b).";
@@ -1979,10 +1981,13 @@ internal static class AccessorEligibility
     }
 
     /// <summary>
-    /// What: whether an assignment left's receiver is limited to this/identifier/member-access
-    /// chains (no invocations, element access, conditionals, etc.).
+    /// What: whether an assignment left's receiver chain is free of re-evaluable members
+    /// (properties/methods). Only this/locals/parameters/fields (and type/namespace qualifiers)
+    /// are allowed — FieldRef re-reads the same storage, so field links are idempotent.
     /// </summary>
-    private static bool IsSideEffectFreeAssignmentReceiver(ExpressionSyntax left)
+    private static bool IsSideEffectFreeAssignmentReceiver(
+        SemanticModel semanticModel,
+        ExpressionSyntax left)
     {
         ExpressionSyntax receiver = left is MemberAccessExpressionSyntax memberAccess
             ? memberAccess.Expression
@@ -1996,12 +2001,40 @@ internal static class AccessorEligibility
         ExpressionSyntax current = receiver;
         while (current is MemberAccessExpressionSyntax nested)
         {
+            ISymbol linkSymbol = semanticModel.GetSymbolInfo(nested.Name).Symbol
+                ?? semanticModel.GetSymbolInfo(nested).Symbol;
+            if (!IsSideEffectFreeReceiverLink(linkSymbol))
+            {
+                return false;
+            }
+
             current = nested.Expression;
         }
 
-        return current is IdentifierNameSyntax
-            || current is ThisExpressionSyntax
-            || current is BaseExpressionSyntax;
+        if (current is ThisExpressionSyntax || current is BaseExpressionSyntax)
+        {
+            return true;
+        }
+
+        if (current is IdentifierNameSyntax)
+        {
+            ISymbol headSymbol = semanticModel.GetSymbolInfo(current).Symbol;
+            return headSymbol is ILocalSymbol
+                || headSymbol is IParameterSymbol
+                || headSymbol is IFieldSymbol
+                || headSymbol is ITypeSymbol
+                || headSymbol is INamespaceSymbol;
+        }
+
+        return false;
+    }
+
+    private static bool IsSideEffectFreeReceiverLink(ISymbol linkSymbol)
+    {
+        // Fields re-read the same storage; type/namespace qualifiers are not evaluated.
+        return linkSymbol is IFieldSymbol
+            || linkSymbol is ITypeSymbol
+            || linkSymbol is INamespaceSymbol;
     }
 
     public static bool IsNameHandledByParent(SimpleNameSyntax node)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -217,18 +217,18 @@ public static class TransformWorkerProgram
                     continue;
                 }
 
-                string skipReason = EvaluateSkipReason(
+                MethodTransformDecision decision = DecideMethodTransform(
                     typeDeclaration,
                     typeSymbol,
                     methodDeclaration,
                     methodSymbol,
                     semanticModel);
-                if (skipReason != null)
+                if (decision.SkipReason != null)
                 {
                     skipped.Add(new WorkerSkipped
                     {
                         Method = FormatMethodLabel(typeSymbol, methodSymbol),
-                        Reason = skipReason
+                        Reason = decision.SkipReason
                     });
                     continue;
                 }
@@ -255,8 +255,13 @@ public static class TransformWorkerProgram
                     methodDeclaration,
                     methodSymbol,
                     typeSymbol,
-                    semanticModel);
+                    semanticModel,
+                    decision.AccessorPlan);
                 currentShimType.AddMethod(rewrittenMethod, shimMethodName);
+                if (decision.AccessorPlan != null)
+                {
+                    currentShimType.MergeAccessors(decision.AccessorPlan);
+                }
 
                 entries.Add(new WorkerEntry
                 {
@@ -266,7 +271,8 @@ public static class TransformWorkerProgram
                         .Select(CecilTypeNames.ToParameterTypeFullName)
                         .ToArray(),
                     ShimTypeName = currentShimType.ShimTypeName,
-                    ShimMethodName = shimMethodName
+                    ShimMethodName = shimMethodName,
+                    PatchKind = decision.PatchKind
                 });
             }
         }
@@ -291,12 +297,74 @@ public static class TransformWorkerProgram
                 || typeDeclaration is RecordDeclarationSyntax);
     }
 
-    private static string EvaluateSkipReason(
+    private static MethodTransformDecision DecideMethodTransform(
         TypeDeclarationSyntax typeDeclaration,
         INamedTypeSymbol typeSymbol,
         MethodDeclarationSyntax methodDeclaration,
         IMethodSymbol methodSymbol,
         SemanticModel semanticModel)
+    {
+        string hardSkip = EvaluateHardSkipReason(
+            typeDeclaration,
+            typeSymbol,
+            methodDeclaration,
+            methodSymbol);
+        if (hardSkip != null)
+        {
+            return MethodTransformDecision.Skip(hardSkip);
+        }
+
+        SyntaxNode bodyNode = (SyntaxNode)methodDeclaration.Body ?? methodDeclaration.ExpressionBody;
+        if (bodyNode == null)
+        {
+            return MethodTransformDecision.Skip("Methods without a body (abstract/extern) are skipped.");
+        }
+
+        if (ContainsBaseExpression(bodyNode))
+        {
+            return MethodTransformDecision.Skip(
+                "Methods that call base. members are skipped; C# cannot express base calls outside the type.");
+        }
+
+        bool closureInaccessible = SubtreeHasInaccessibleMemberAccess(
+            semanticModel,
+            FindClosureBodies(bodyNode));
+        bool asyncIteratorInaccessible = IsAsyncOrIterator(methodDeclaration, bodyNode)
+            && SubtreeHasInaccessibleMemberAccess(semanticModel, new[] { bodyNode });
+
+        if (!closureInaccessible && !asyncIteratorInaccessible)
+        {
+            return MethodTransformDecision.Transplant();
+        }
+
+        // Condition (a): only the v1 private-access skip reasons are eligible for accessor rewrite.
+        string v1Reason = closureInaccessible
+            ? "Lambda, local-function, or query-expression bodies that access private/internal members "
+                + "are skipped in v1 (closure methods JIT-compile normally and fail accessibility checks)."
+            : "Async or iterator methods whose bodies access private/internal members are skipped in v1 "
+                + "(state-machine MoveNext JIT-compiles normally and fails accessibility checks).";
+
+        if (!AccessorEligibility.TryBuildPlan(
+                semanticModel,
+                methodDeclaration,
+                methodSymbol,
+                typeSymbol,
+                bodyNode,
+                out AccessorPlan accessorPlan,
+                out string accessorRejectReason))
+        {
+            return MethodTransformDecision.Skip(
+                v1Reason + " Accessor rewrite unavailable: " + accessorRejectReason);
+        }
+
+        return MethodTransformDecision.Delegation(accessorPlan);
+    }
+
+    private static string EvaluateHardSkipReason(
+        TypeDeclarationSyntax typeDeclaration,
+        INamedTypeSymbol typeSymbol,
+        MethodDeclarationSyntax methodDeclaration,
+        IMethodSymbol methodSymbol)
     {
         // A nested type inside a partial outer type still has an incomplete single-file model.
         for (TypeDeclarationSyntax declaration = typeDeclaration;
@@ -326,30 +394,6 @@ public static class TransformWorkerProgram
         if (methodDeclaration.ExplicitInterfaceSpecifier != null)
         {
             return "Explicit interface implementations are skipped in v1.";
-        }
-
-        SyntaxNode bodyNode = (SyntaxNode)methodDeclaration.Body ?? methodDeclaration.ExpressionBody;
-        if (bodyNode == null)
-        {
-            return "Methods without a body (abstract/extern) are skipped.";
-        }
-
-        if (ContainsBaseExpression(bodyNode))
-        {
-            return "Methods that call base. members are skipped; C# cannot express base calls outside the type.";
-        }
-
-        if (SubtreeHasInaccessibleMemberAccess(semanticModel, FindClosureBodies(bodyNode)))
-        {
-            return "Lambda, local-function, or query-expression bodies that access private/internal members "
-                + "are skipped in v1 (closure methods JIT-compile normally and fail accessibility checks).";
-        }
-
-        if (IsAsyncOrIterator(methodDeclaration, bodyNode)
-            && SubtreeHasInaccessibleMemberAccess(semanticModel, new[] { bodyNode }))
-        {
-            return "Async or iterator methods whose bodies access private/internal members are skipped in v1 "
-                + "(state-machine MoveNext JIT-compiles normally and fails accessibility checks).";
         }
 
         return null;
@@ -470,10 +514,13 @@ public static class TransformWorkerProgram
         MethodDeclarationSyntax methodDeclaration,
         IMethodSymbol methodSymbol,
         INamedTypeSymbol targetType,
-        SemanticModel semanticModel)
+        SemanticModel semanticModel,
+        AccessorPlan accessorPlan)
     {
-        InstanceMemberQualifier qualifier = new InstanceMemberQualifier(semanticModel, targetType);
-        MethodDeclarationSyntax rewritten = (MethodDeclarationSyntax)qualifier.Visit(methodDeclaration);
+        // Why a single rewriter: rewriting the tree invalidates SemanticModel for new nodes.
+        // Qualify + accessor rewrite both classify symbols on the original tree in one Visit pass.
+        ShimBodyRewriter rewriter = new ShimBodyRewriter(semanticModel, targetType, accessorPlan);
+        MethodDeclarationSyntax rewritten = (MethodDeclarationSyntax)rewriter.Visit(methodDeclaration);
         return ShimMethodFactory.ToShimMethod(rewritten, methodSymbol);
     }
 
@@ -557,20 +604,852 @@ internal static class AccessibilityRules
             || accessibility == Accessibility.ProtectedAndInternal
             || accessibility == Accessibility.ProtectedOrInternal;
     }
+
+    /// <summary>
+    /// What: whether a type can appear in an accessor signature / as a type mention in a shim
+    /// that will JIT outside Harmony skip-visibility.
+    /// </summary>
+    public static bool IsExternallyVisibleType(ITypeSymbol typeSymbol)
+    {
+        if (typeSymbol == null || typeSymbol.TypeKind == TypeKind.Error)
+        {
+            return false;
+        }
+
+        if (typeSymbol is ITypeParameterSymbol)
+        {
+            return true;
+        }
+
+        if (typeSymbol is IArrayTypeSymbol arrayType)
+        {
+            return IsExternallyVisibleType(arrayType.ElementType);
+        }
+
+        if (typeSymbol is IPointerTypeSymbol pointerType)
+        {
+            return IsExternallyVisibleType(pointerType.PointedAtType);
+        }
+
+        if (typeSymbol is INamedTypeSymbol namedType)
+        {
+            if (IsInaccessibleFromExternalAssembly(namedType))
+            {
+                return false;
+            }
+
+            foreach (ITypeSymbol typeArgument in namedType.TypeArguments)
+            {
+                if (!IsExternallyVisibleType(typeArgument))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return !IsInaccessibleFromExternalAssembly(typeSymbol);
+    }
 }
 
 /// <summary>
-/// Qualifies bare instance/static member references so a static shim can host the original body.
+/// What: per-shim-type registry of Harmony accessor delegates to emit and bind.
 /// </summary>
-internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
+internal sealed class AccessorPlan
+{
+    private readonly List<AccessorEntry> _entries = new List<AccessorEntry>();
+    private readonly Dictionary<string, AccessorEntry> _byKey =
+        new Dictionary<string, AccessorEntry>(StringComparer.Ordinal);
+
+    public IReadOnlyList<AccessorEntry> Entries => _entries;
+
+    public AccessorEntry GetOrAddField(IFieldSymbol fieldSymbol)
+    {
+        string key = "F:" + MemberKey(fieldSymbol);
+        if (_byKey.TryGetValue(key, out AccessorEntry existing))
+        {
+            return existing;
+        }
+
+        string fieldName = AllocateName("__F_" + SanitizeIdentifier(fieldSymbol.Name));
+        AccessorEntry entry = AccessorEntry.ForField(fieldSymbol, fieldName);
+        _byKey[key] = entry;
+        _entries.Add(entry);
+        return entry;
+    }
+
+    public AccessorEntry GetOrAddMethod(IMethodSymbol methodSymbol)
+    {
+        string key = "M:" + MemberKey(methodSymbol);
+        if (_byKey.TryGetValue(key, out AccessorEntry existing))
+        {
+            return existing;
+        }
+
+        string fieldName = AllocateName("__M_" + SanitizeIdentifier(methodSymbol.Name));
+        AccessorEntry entry = AccessorEntry.ForMethod(methodSymbol, fieldName);
+        _byKey[key] = entry;
+        _entries.Add(entry);
+        return entry;
+    }
+
+    public AccessorEntry GetOrAddPropertyGetter(IPropertySymbol propertySymbol)
+    {
+        string key = "PG:" + MemberKey(propertySymbol);
+        if (_byKey.TryGetValue(key, out AccessorEntry existing))
+        {
+            return existing;
+        }
+
+        string fieldName = AllocateName("__P_get_" + SanitizeIdentifier(propertySymbol.Name));
+        AccessorEntry entry = AccessorEntry.ForPropertyGetter(propertySymbol, fieldName);
+        _byKey[key] = entry;
+        _entries.Add(entry);
+        return entry;
+    }
+
+    public AccessorEntry GetOrAddPropertySetter(IPropertySymbol propertySymbol)
+    {
+        string key = "PS:" + MemberKey(propertySymbol);
+        if (_byKey.TryGetValue(key, out AccessorEntry existing))
+        {
+            return existing;
+        }
+
+        string fieldName = AllocateName("__P_set_" + SanitizeIdentifier(propertySymbol.Name));
+        AccessorEntry entry = AccessorEntry.ForPropertySetter(propertySymbol, fieldName);
+        _byKey[key] = entry;
+        _entries.Add(entry);
+        return entry;
+    }
+
+    public void MergeFrom(AccessorPlan other)
+    {
+        foreach (AccessorEntry entry in other._entries)
+        {
+            if (_byKey.ContainsKey(entry.RegistryKey))
+            {
+                continue;
+            }
+
+            _byKey[entry.RegistryKey] = entry;
+            _entries.Add(entry);
+        }
+    }
+
+    private string AllocateName(string preferred)
+    {
+        if (!_entries.Any(entry => entry.DelegateFieldName == preferred))
+        {
+            return preferred;
+        }
+
+        int suffix = 2;
+        while (_entries.Any(entry => entry.DelegateFieldName == preferred + suffix))
+        {
+            suffix++;
+        }
+
+        return preferred + suffix;
+    }
+
+    private static string MemberKey(ISymbol symbol)
+    {
+        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+    }
+
+    private static string SanitizeIdentifier(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return "member";
+        }
+
+        StringBuilder builder = new StringBuilder(name.Length);
+        foreach (char character in name)
+        {
+            if (char.IsLetterOrDigit(character) || character == '_')
+            {
+                builder.Append(character);
+            }
+            else
+            {
+                builder.Append('_');
+            }
+        }
+
+        return builder.Length == 0 ? "member" : builder.ToString();
+    }
+}
+
+internal enum AccessorKind
+{
+    FieldRef,
+    MethodDelegate,
+    PropertyGetter,
+    PropertySetter
+}
+
+/// <summary>
+/// What: one Harmony accessor delegate field plus the statements that bind it in __BindAccessors.
+/// </summary>
+internal sealed class AccessorEntry
+{
+    public AccessorKind Kind { get; private set; }
+
+    public string RegistryKey { get; private set; }
+
+    public string DelegateFieldName { get; private set; }
+
+    public IFieldSymbol FieldSymbol { get; private set; }
+
+    public IMethodSymbol MethodSymbol { get; private set; }
+
+    public IPropertySymbol PropertySymbol { get; private set; }
+
+    public static AccessorEntry ForField(IFieldSymbol fieldSymbol, string delegateFieldName)
+    {
+        return new AccessorEntry
+        {
+            Kind = AccessorKind.FieldRef,
+            RegistryKey = "F:" + fieldSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            DelegateFieldName = delegateFieldName,
+            FieldSymbol = fieldSymbol
+        };
+    }
+
+    public static AccessorEntry ForMethod(IMethodSymbol methodSymbol, string delegateFieldName)
+    {
+        return new AccessorEntry
+        {
+            Kind = AccessorKind.MethodDelegate,
+            RegistryKey = "M:" + methodSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            DelegateFieldName = delegateFieldName,
+            MethodSymbol = methodSymbol
+        };
+    }
+
+    public static AccessorEntry ForPropertyGetter(IPropertySymbol propertySymbol, string delegateFieldName)
+    {
+        return new AccessorEntry
+        {
+            Kind = AccessorKind.PropertyGetter,
+            RegistryKey = "PG:" + propertySymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            DelegateFieldName = delegateFieldName,
+            PropertySymbol = propertySymbol
+        };
+    }
+
+    public static AccessorEntry ForPropertySetter(IPropertySymbol propertySymbol, string delegateFieldName)
+    {
+        return new AccessorEntry
+        {
+            Kind = AccessorKind.PropertySetter,
+            RegistryKey = "PS:" + propertySymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            DelegateFieldName = delegateFieldName,
+            PropertySymbol = propertySymbol
+        };
+    }
+
+    public bool TryGetVisibilityFailure(out string reason)
+    {
+        foreach (ITypeSymbol typeSymbol in EnumerateSignatureTypes())
+        {
+            if (!AccessibilityRules.IsExternallyVisibleType(typeSymbol))
+            {
+                reason = "accessor signature type is not visible from an external assembly: "
+                    + typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                return true;
+            }
+        }
+
+        reason = null;
+        return false;
+    }
+
+    public IEnumerable<ITypeSymbol> EnumerateSignatureTypes()
+    {
+        switch (Kind)
+        {
+            case AccessorKind.FieldRef:
+                yield return FieldSymbol.ContainingType;
+                yield return FieldSymbol.Type;
+                yield break;
+            case AccessorKind.MethodDelegate:
+                if (!MethodSymbol.IsStatic)
+                {
+                    yield return MethodSymbol.ContainingType;
+                }
+
+                foreach (IParameterSymbol parameter in MethodSymbol.Parameters)
+                {
+                    yield return parameter.Type;
+                }
+
+                if (!MethodSymbol.ReturnsVoid)
+                {
+                    yield return MethodSymbol.ReturnType;
+                }
+
+                yield break;
+            case AccessorKind.PropertyGetter:
+            case AccessorKind.PropertySetter:
+                if (!PropertySymbol.IsStatic)
+                {
+                    yield return PropertySymbol.ContainingType;
+                }
+
+                yield return PropertySymbol.Type;
+                yield break;
+        }
+    }
+
+    public FieldDeclarationSyntax EmitFieldDeclaration()
+    {
+        TypeSyntax fieldType = SyntaxFactory.ParseTypeName(BuildDelegateTypeDisplayString());
+        return SyntaxFactory.FieldDeclaration(
+                SyntaxFactory.VariableDeclaration(fieldType)
+                    .WithVariables(
+                        SyntaxFactory.SingletonSeparatedList(
+                            SyntaxFactory.VariableDeclarator(DelegateFieldName))))
+            .WithModifiers(
+                SyntaxFactory.TokenList(
+                    SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+                    SyntaxFactory.Token(SyntaxKind.StaticKeyword)));
+    }
+
+    public StatementSyntax EmitBindStatement()
+    {
+        string statement = Kind switch
+        {
+            AccessorKind.FieldRef => BuildFieldRefBindStatement(),
+            AccessorKind.MethodDelegate => BuildMethodDelegateBindStatement(
+                MethodSymbol.Name,
+                MethodSymbol),
+            AccessorKind.PropertyGetter => BuildMethodDelegateBindStatement(
+                PropertySymbol.GetMethod.Name,
+                PropertySymbol.GetMethod),
+            AccessorKind.PropertySetter => BuildMethodDelegateBindStatement(
+                PropertySymbol.SetMethod.Name,
+                PropertySymbol.SetMethod),
+            _ => throw new InvalidOperationException("Unknown accessor kind.")
+        };
+
+        return SyntaxFactory.ParseStatement(statement);
+    }
+
+    private string BuildDelegateTypeDisplayString()
+    {
+        switch (Kind)
+        {
+            case AccessorKind.FieldRef:
+                return "global::HarmonyLib.AccessTools.FieldRef<"
+                    + TypeDisplay(FieldSymbol.ContainingType) + ", "
+                    + TypeDisplay(FieldSymbol.Type) + ">";
+            case AccessorKind.MethodDelegate:
+                return BuildFuncOrActionType(MethodSymbol);
+            case AccessorKind.PropertyGetter:
+                return BuildFuncOrActionType(PropertySymbol.GetMethod);
+            case AccessorKind.PropertySetter:
+                return BuildFuncOrActionType(PropertySymbol.SetMethod);
+            default:
+                throw new InvalidOperationException("Unknown accessor kind.");
+        }
+    }
+
+    private static string BuildFuncOrActionType(IMethodSymbol methodSymbol)
+    {
+        List<string> typeArguments = new List<string>();
+        if (!methodSymbol.IsStatic)
+        {
+            typeArguments.Add(TypeDisplay(methodSymbol.ContainingType));
+        }
+
+        foreach (IParameterSymbol parameter in methodSymbol.Parameters)
+        {
+            typeArguments.Add(TypeDisplay(parameter.Type));
+        }
+
+        if (methodSymbol.ReturnsVoid)
+        {
+            if (typeArguments.Count == 0)
+            {
+                return "global::System.Action";
+            }
+
+            return "global::System.Action<" + string.Join(", ", typeArguments) + ">";
+        }
+
+        typeArguments.Add(TypeDisplay(methodSymbol.ReturnType));
+        return "global::System.Func<" + string.Join(", ", typeArguments) + ">";
+    }
+
+    private string BuildFieldRefBindStatement()
+    {
+        return DelegateFieldName + " = global::HarmonyLib.AccessTools.FieldRefAccess<"
+            + TypeDisplay(FieldSymbol.ContainingType) + ", "
+            + TypeDisplay(FieldSymbol.Type) + ">(\""
+            + EscapeStringLiteral(FieldSymbol.Name) + "\");";
+    }
+
+    private string BuildMethodDelegateBindStatement(string metadataName, IMethodSymbol methodSymbol)
+    {
+        string declaringType = TypeDisplay(methodSymbol.ContainingType);
+        string delegateType = BuildFuncOrActionType(methodSymbol);
+        string typeArray = BuildTypeArrayLiteral(methodSymbol);
+        return DelegateFieldName + " = global::HarmonyLib.AccessTools.MethodDelegate<"
+            + delegateType + ">(global::HarmonyLib.AccessTools.Method(typeof("
+            + declaringType + "), \"" + EscapeStringLiteral(metadataName) + "\", "
+            + typeArray + "), null, false, null);";
+    }
+
+    private static string BuildTypeArrayLiteral(IMethodSymbol methodSymbol)
+    {
+        if (methodSymbol.Parameters.Length == 0)
+        {
+            return "new global::System.Type[] { }";
+        }
+
+        IEnumerable<string> typeofs = methodSymbol.Parameters.Select(
+            parameter => "typeof(" + TypeDisplay(parameter.Type) + ")");
+        return "new global::System.Type[] { " + string.Join(", ", typeofs) + " }";
+    }
+
+    private static string TypeDisplay(ITypeSymbol typeSymbol)
+    {
+        return typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+    }
+
+    private static string EscapeStringLiteral(string value)
+    {
+        return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+}
+
+/// <summary>
+/// What: decides whether an async/iterator/closure private-access skip can be rescued by
+/// rewriting inaccessible member accesses into Harmony accessor delegates (conditions b/c).
+/// </summary>
+internal static class AccessorEligibility
+{
+    public static bool TryBuildPlan(
+        SemanticModel semanticModel,
+        MethodDeclarationSyntax methodDeclaration,
+        IMethodSymbol methodSymbol,
+        INamedTypeSymbol typeSymbol,
+        SyntaxNode bodyNode,
+        out AccessorPlan plan,
+        out string rejectReason)
+    {
+        plan = null;
+        rejectReason = null;
+
+        if (!AccessibilityRules.IsExternallyVisibleType(typeSymbol))
+        {
+            rejectReason = "containing type is not visible from an external assembly (condition c).";
+            return false;
+        }
+
+        if (!AreMethodSignatureTypesVisible(methodSymbol, out rejectReason))
+        {
+            return false;
+        }
+
+        if (!AreBodyTypeUsagesVisible(semanticModel, methodDeclaration, out rejectReason))
+        {
+            return false;
+        }
+
+        AccessorPlan built = new AccessorPlan();
+        foreach (SyntaxNode node in bodyNode.DescendantNodesAndSelf())
+        {
+            if (!TryRegisterInaccessibleAccess(semanticModel, node, built, out rejectReason))
+            {
+                if (rejectReason != null)
+                {
+                    return false;
+                }
+            }
+        }
+
+        foreach (AccessorEntry entry in built.Entries)
+        {
+            if (entry.TryGetVisibilityFailure(out rejectReason))
+            {
+                rejectReason = rejectReason + " (condition c).";
+                return false;
+            }
+        }
+
+        if (NeedsPropertyIncrementRewrite(semanticModel, bodyNode))
+        {
+            rejectReason =
+                "inaccessible property increment/decrement has no accessor rewrite shape (condition b).";
+            return false;
+        }
+
+        plan = built;
+        rejectReason = null;
+        return true;
+    }
+
+    private static bool AreMethodSignatureTypesVisible(IMethodSymbol methodSymbol, out string rejectReason)
+    {
+        if (!AccessibilityRules.IsExternallyVisibleType(methodSymbol.ReturnType))
+        {
+            rejectReason = "method return type is not visible from an external assembly (condition c).";
+            return false;
+        }
+
+        foreach (IParameterSymbol parameter in methodSymbol.Parameters)
+        {
+            if (!AccessibilityRules.IsExternallyVisibleType(parameter.Type))
+            {
+                rejectReason =
+                    "method parameter type is not visible from an external assembly (condition c).";
+                return false;
+            }
+        }
+
+        rejectReason = null;
+        return true;
+    }
+
+    private static bool AreBodyTypeUsagesVisible(
+        SemanticModel semanticModel,
+        MethodDeclarationSyntax methodDeclaration,
+        out string rejectReason)
+    {
+        foreach (SyntaxNode node in methodDeclaration.DescendantNodesAndSelf())
+        {
+            ITypeSymbol typeSymbol = null;
+            if (node is TypeSyntax typeSyntax)
+            {
+                typeSymbol = semanticModel.GetTypeInfo(typeSyntax).Type
+                    ?? semanticModel.GetSymbolInfo(typeSyntax).Symbol as ITypeSymbol;
+            }
+            else if (node is VariableDeclarationSyntax variableDeclaration
+                && variableDeclaration.Type.IsVar)
+            {
+                // var locals still materialize a type in the shim; an internal inferred type fails (c).
+                typeSymbol = semanticModel.GetTypeInfo(variableDeclaration.Type).Type;
+            }
+            else if (node is ImplicitObjectCreationExpressionSyntax implicitObjectCreation)
+            {
+                typeSymbol = semanticModel.GetTypeInfo(implicitObjectCreation).Type;
+            }
+
+            if (typeSymbol == null || typeSymbol.TypeKind == TypeKind.Error)
+            {
+                continue;
+            }
+
+            if (!AccessibilityRules.IsExternallyVisibleType(typeSymbol))
+            {
+                rejectReason = "body uses a type that is not visible from an external assembly: "
+                    + typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                    + " (condition c).";
+                return false;
+            }
+        }
+
+        rejectReason = null;
+        return true;
+    }
+
+    private static bool NeedsPropertyIncrementRewrite(SemanticModel semanticModel, SyntaxNode bodyNode)
+    {
+        foreach (SyntaxNode node in bodyNode.DescendantNodes())
+        {
+            ExpressionSyntax operand = null;
+            if (node is PostfixUnaryExpressionSyntax postfix)
+            {
+                operand = postfix.Operand;
+            }
+            else if (node is PrefixUnaryExpressionSyntax prefix
+                && (prefix.IsKind(SyntaxKind.PreIncrementExpression)
+                    || prefix.IsKind(SyntaxKind.PreDecrementExpression)))
+            {
+                operand = prefix.Operand;
+            }
+
+            if (operand == null)
+            {
+                continue;
+            }
+
+            ISymbol symbol = semanticModel.GetSymbolInfo(operand).Symbol;
+            if (symbol is IPropertySymbol propertySymbol
+                && AccessibilityRules.IsInaccessibleFromExternalAssembly(propertySymbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns false with null rejectReason when the node is not an inaccessible access site.
+    /// Returns false with a reason when the site is inaccessible but not rewriteable (condition b).
+    /// Returns true when the site was registered (or was already present).
+    /// </summary>
+    private static bool TryRegisterInaccessibleAccess(
+        SemanticModel semanticModel,
+        SyntaxNode node,
+        AccessorPlan plan,
+        out string rejectReason)
+    {
+        rejectReason = null;
+
+        if (node is InvocationExpressionSyntax invocation)
+        {
+            return TryRegisterInvocation(semanticModel, invocation, plan, out rejectReason);
+        }
+
+        if (node is ElementAccessExpressionSyntax elementAccess)
+        {
+            ISymbol symbol = semanticModel.GetSymbolInfo(elementAccess).Symbol;
+            if (symbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol))
+            {
+                rejectReason = "inaccessible indexer access has no accessor rewrite shape (condition b).";
+                return false;
+            }
+
+            return false;
+        }
+
+        if (node is MemberBindingExpressionSyntax
+            || node is ConditionalAccessExpressionSyntax)
+        {
+            // ?. chains are not in the rewrite shapes; only fail when they touch inaccessible members.
+            foreach (SyntaxNode child in node.DescendantNodesAndSelf())
+            {
+                if (child is not SimpleNameSyntax)
+                {
+                    continue;
+                }
+
+                ISymbol bound = semanticModel.GetSymbolInfo(child).Symbol;
+                if (bound != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(bound)
+                    && bound is not INamespaceSymbol && bound is not ITypeSymbol)
+                {
+                    rejectReason =
+                        "inaccessible member access via conditional access has no rewrite shape (condition b).";
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
+        if (node is MemberAccessExpressionSyntax memberAccess)
+        {
+            if (memberAccess.Parent is InvocationExpressionSyntax parentInvocation
+                && parentInvocation.Expression == memberAccess)
+            {
+                return false;
+            }
+
+            return TryRegisterMemberSymbol(
+                semanticModel.GetSymbolInfo(memberAccess).Symbol
+                ?? semanticModel.GetSymbolInfo(memberAccess.Name).Symbol,
+                plan,
+                out rejectReason);
+        }
+
+        if (node is IdentifierNameSyntax or GenericNameSyntax)
+        {
+            SimpleNameSyntax name = (SimpleNameSyntax)node;
+            if (IsNameHandledByParent(name))
+            {
+                return false;
+            }
+
+            return TryRegisterMemberSymbol(
+                semanticModel.GetSymbolInfo(name).Symbol,
+                plan,
+                out rejectReason);
+        }
+
+        return false;
+    }
+
+    private static bool TryRegisterInvocation(
+        SemanticModel semanticModel,
+        InvocationExpressionSyntax invocation,
+        AccessorPlan plan,
+        out string rejectReason)
+    {
+        rejectReason = null;
+        ISymbol symbol = semanticModel.GetSymbolInfo(invocation).Symbol;
+        if (symbol is not IMethodSymbol methodSymbol)
+        {
+            return false;
+        }
+
+        if (methodSymbol.MethodKind == MethodKind.PropertyGet
+            || methodSymbol.MethodKind == MethodKind.PropertySet
+            || methodSymbol.MethodKind == MethodKind.EventAdd
+            || methodSymbol.MethodKind == MethodKind.EventRemove)
+        {
+            return false;
+        }
+
+        if (!AccessibilityRules.IsInaccessibleFromExternalAssembly(methodSymbol))
+        {
+            return false;
+        }
+
+        if (methodSymbol.IsExtensionMethod)
+        {
+            rejectReason = "inaccessible extension method calls are not rewritten (condition b).";
+            return false;
+        }
+
+        foreach (IParameterSymbol parameter in methodSymbol.Parameters)
+        {
+            if (parameter.RefKind == RefKind.Ref || parameter.RefKind == RefKind.Out)
+            {
+                rejectReason =
+                    "inaccessible method calls with ref/out parameters are not rewritten (condition b).";
+                return false;
+            }
+        }
+
+        plan.GetOrAddMethod(methodSymbol);
+        return true;
+    }
+
+    private static bool TryRegisterMemberSymbol(
+        ISymbol symbol,
+        AccessorPlan plan,
+        out string rejectReason)
+    {
+        rejectReason = null;
+        if (symbol == null || !AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol))
+        {
+            return false;
+        }
+
+        if (symbol is IFieldSymbol fieldSymbol)
+        {
+            if (fieldSymbol.IsStatic)
+            {
+                rejectReason = "inaccessible static field access has no accessor rewrite shape (condition b).";
+                return false;
+            }
+
+            plan.GetOrAddField(fieldSymbol);
+            return true;
+        }
+
+        if (symbol is IPropertySymbol propertySymbol)
+        {
+            if (propertySymbol.IsIndexer)
+            {
+                rejectReason = "inaccessible indexer access has no accessor rewrite shape (condition b).";
+                return false;
+            }
+
+            if (propertySymbol.IsStatic)
+            {
+                rejectReason =
+                    "inaccessible static property access has no accessor rewrite shape (condition b).";
+                return false;
+            }
+
+            // Reads and writes are registered by the rewriter as needed; eligibility requires that
+            // both accessors exist when the property is used, so register both when present.
+            if (propertySymbol.GetMethod != null)
+            {
+                plan.GetOrAddPropertyGetter(propertySymbol);
+            }
+
+            if (propertySymbol.SetMethod != null)
+            {
+                plan.GetOrAddPropertySetter(propertySymbol);
+            }
+
+            if (propertySymbol.GetMethod == null && propertySymbol.SetMethod == null)
+            {
+                rejectReason = "inaccessible property has no getter or setter to bind (condition b).";
+                return false;
+            }
+
+            return true;
+        }
+
+        if (symbol is IEventSymbol)
+        {
+            rejectReason = "inaccessible event add/remove is out of scope for accessor rewrite (condition b).";
+            return false;
+        }
+
+        if (symbol is IMethodSymbol)
+        {
+            // Method group without invocation (e.g. assigned to a delegate) has no rewrite shape.
+            rejectReason =
+                "inaccessible method group (non-invocation) has no accessor rewrite shape (condition b).";
+            return false;
+        }
+
+        rejectReason = "inaccessible member kind is not field/method/property access (condition b).";
+        return false;
+    }
+
+    private static bool IsNameHandledByParent(SimpleNameSyntax node)
+    {
+        if (node.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == node)
+        {
+            return true;
+        }
+
+        if (node.Parent is QualifiedNameSyntax qualifiedName && qualifiedName.Right == node)
+        {
+            return true;
+        }
+
+        if (node.Parent is MemberBindingExpressionSyntax memberBinding && memberBinding.Name == node)
+        {
+            return true;
+        }
+
+        if (node.Parent is InvocationExpressionSyntax invocation && invocation.Expression == node)
+        {
+            return true;
+        }
+
+        if (node.Parent is AssignmentExpressionSyntax assignment
+            && assignment.Left == node
+            && assignment.Parent is InitializerExpressionSyntax)
+        {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+/// <summary>
+/// Qualifies bare instance/static member references and, when an accessor plan is supplied,
+/// rewrites inaccessible field/method/property accesses into Harmony accessor delegate calls.
+/// </summary>
+internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
 {
     private readonly SemanticModel _semanticModel;
     private readonly INamedTypeSymbol _targetType;
+    private readonly AccessorPlan _accessorPlan;
 
-    public InstanceMemberQualifier(SemanticModel semanticModel, INamedTypeSymbol targetType)
+    public ShimBodyRewriter(
+        SemanticModel semanticModel,
+        INamedTypeSymbol targetType,
+        AccessorPlan accessorPlan)
     {
         _semanticModel = semanticModel;
         _targetType = targetType;
+        _accessorPlan = accessorPlan;
     }
 
     public override SyntaxNode VisitThisExpression(ThisExpressionSyntax node)
@@ -589,12 +1468,110 @@ internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
         return VisitName(node, node);
     }
 
+    public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        if (_accessorPlan == null)
+        {
+            return base.VisitInvocationExpression(node);
+        }
+
+        ISymbol symbol = _semanticModel.GetSymbolInfo(node).Symbol;
+        if (symbol is not IMethodSymbol methodSymbol
+            || methodSymbol.MethodKind != MethodKind.Ordinary
+            || !AccessibilityRules.IsInaccessibleFromExternalAssembly(methodSymbol)
+            || methodSymbol.IsExtensionMethod)
+        {
+            return base.VisitInvocationExpression(node);
+        }
+
+        AccessorEntry entry = _accessorPlan.GetOrAddMethod(methodSymbol);
+        List<ArgumentSyntax> arguments = new List<ArgumentSyntax>();
+        if (!methodSymbol.IsStatic)
+        {
+            ExpressionSyntax receiver = ExtractReceiver(node.Expression);
+            arguments.Add(SyntaxFactory.Argument(VisitReceiver(receiver)));
+        }
+
+        foreach (ArgumentSyntax argument in node.ArgumentList.Arguments)
+        {
+            arguments.Add((ArgumentSyntax)Visit(argument));
+        }
+
+        return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.IdentifierName(entry.DelegateFieldName),
+                SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)))
+            .WithTriviaFrom(node);
+    }
+
+    public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
+    {
+        if (_accessorPlan == null)
+        {
+            return base.VisitAssignmentExpression(node);
+        }
+
+        ISymbol leftSymbol = _semanticModel.GetSymbolInfo(node.Left).Symbol;
+        if (leftSymbol is IPropertySymbol propertySymbol
+            && AccessibilityRules.IsInaccessibleFromExternalAssembly(propertySymbol)
+            && !propertySymbol.IsIndexer
+            && !propertySymbol.IsStatic)
+        {
+            return RewritePropertyAssignment(node, propertySymbol);
+        }
+
+        if (leftSymbol is IFieldSymbol fieldSymbol
+            && AccessibilityRules.IsInaccessibleFromExternalAssembly(fieldSymbol)
+            && !fieldSymbol.IsStatic)
+        {
+            AccessorEntry entry = _accessorPlan.GetOrAddField(fieldSymbol);
+            ExpressionSyntax receiver = ExtractReceiver(node.Left);
+            ExpressionSyntax fieldRefCall = CreateDelegateInvocation(
+                entry.DelegateFieldName,
+                new[] { VisitReceiver(receiver) });
+            return node
+                .WithLeft(fieldRefCall)
+                .WithRight((ExpressionSyntax)Visit(node.Right))
+                .WithTriviaFrom(node);
+        }
+
+        return base.VisitAssignmentExpression(node);
+    }
+
+    public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+    {
+        if (_accessorPlan == null)
+        {
+            return base.VisitMemberAccessExpression(node);
+        }
+
+        if (node.Parent is InvocationExpressionSyntax invocation && invocation.Expression == node)
+        {
+            return base.VisitMemberAccessExpression(node);
+        }
+
+        if (node.Parent is AssignmentExpressionSyntax assignment && assignment.Left == node)
+        {
+            return base.VisitMemberAccessExpression(node);
+        }
+
+        ISymbol symbol = _semanticModel.GetSymbolInfo(node).Symbol
+            ?? _semanticModel.GetSymbolInfo(node.Name).Symbol;
+        ExpressionSyntax rewritten = TryRewriteInaccessibleRead(symbol, node.Expression, node);
+        if (rewritten != null)
+        {
+            return rewritten;
+        }
+
+        return base.VisitMemberAccessExpression(node);
+    }
+
     private SyntaxNode VisitName(SimpleNameSyntax node, SyntaxNode original)
     {
         if (IsMemberAccessNameSide(node)
             || IsQualifiedNameRightSide(node)
             || IsMemberBindingName(node)
-            || IsObjectOrCollectionInitializerMemberName(node))
+            || IsObjectOrCollectionInitializerMemberName(node)
+            || IsInvocationTarget(node))
         {
             return original;
         }
@@ -603,6 +1580,18 @@ internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
         if (symbol == null)
         {
             return original;
+        }
+
+        if (_accessorPlan != null)
+        {
+            ExpressionSyntax accessorRead = TryRewriteInaccessibleRead(
+                symbol,
+                SyntaxFactory.IdentifierName(TransformWorkerProgramMarker.InstanceParameterName),
+                node);
+            if (accessorRead != null)
+            {
+                return accessorRead;
+            }
         }
 
         (bool owned, bool isStatic, INamedTypeSymbol containingType) ownership = ResolveOwnedMember(symbol);
@@ -629,6 +1618,118 @@ internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
             .WithTriviaFrom(node);
     }
 
+    private ExpressionSyntax TryRewriteInaccessibleRead(
+        ISymbol symbol,
+        ExpressionSyntax receiverSyntax,
+        SyntaxNode triviaSource)
+    {
+        if (symbol is IFieldSymbol fieldSymbol
+            && AccessibilityRules.IsInaccessibleFromExternalAssembly(fieldSymbol)
+            && !fieldSymbol.IsStatic)
+        {
+            AccessorEntry entry = _accessorPlan.GetOrAddField(fieldSymbol);
+            return CreateDelegateInvocation(
+                    entry.DelegateFieldName,
+                    new[] { VisitReceiver(receiverSyntax) })
+                .WithTriviaFrom(triviaSource);
+        }
+
+        if (symbol is IPropertySymbol propertySymbol
+            && AccessibilityRules.IsInaccessibleFromExternalAssembly(propertySymbol)
+            && !propertySymbol.IsIndexer
+            && !propertySymbol.IsStatic
+            && propertySymbol.GetMethod != null)
+        {
+            AccessorEntry entry = _accessorPlan.GetOrAddPropertyGetter(propertySymbol);
+            return CreateDelegateInvocation(
+                    entry.DelegateFieldName,
+                    new[] { VisitReceiver(receiverSyntax) })
+                .WithTriviaFrom(triviaSource);
+        }
+
+        return null;
+    }
+
+    private SyntaxNode RewritePropertyAssignment(
+        AssignmentExpressionSyntax node,
+        IPropertySymbol propertySymbol)
+    {
+        ExpressionSyntax receiver = ExtractReceiver(node.Left);
+        ExpressionSyntax visitedReceiver = VisitReceiver(receiver);
+        ExpressionSyntax visitedRight = (ExpressionSyntax)Visit(node.Right);
+        AccessorEntry setter = _accessorPlan.GetOrAddPropertySetter(propertySymbol);
+
+        if (node.IsKind(SyntaxKind.SimpleAssignmentExpression))
+        {
+            return CreateDelegateInvocation(
+                    setter.DelegateFieldName,
+                    new[] { visitedReceiver, visitedRight })
+                .WithTriviaFrom(node);
+        }
+
+        AccessorEntry getter = _accessorPlan.GetOrAddPropertyGetter(propertySymbol);
+        ExpressionSyntax getCall = CreateDelegateInvocation(
+            getter.DelegateFieldName,
+            new[] { visitedReceiver });
+        SyntaxKind binaryKind = GetCompoundAssignmentBinaryKind(node.Kind());
+        ExpressionSyntax combined = SyntaxFactory.BinaryExpression(binaryKind, getCall, visitedRight);
+        return CreateDelegateInvocation(
+                setter.DelegateFieldName,
+                new[] { visitedReceiver, combined })
+            .WithTriviaFrom(node);
+    }
+
+    private static SyntaxKind GetCompoundAssignmentBinaryKind(SyntaxKind assignmentKind)
+    {
+        return assignmentKind switch
+        {
+            SyntaxKind.AddAssignmentExpression => SyntaxKind.AddExpression,
+            SyntaxKind.SubtractAssignmentExpression => SyntaxKind.SubtractExpression,
+            SyntaxKind.MultiplyAssignmentExpression => SyntaxKind.MultiplyExpression,
+            SyntaxKind.DivideAssignmentExpression => SyntaxKind.DivideExpression,
+            SyntaxKind.ModuloAssignmentExpression => SyntaxKind.ModuloExpression,
+            SyntaxKind.AndAssignmentExpression => SyntaxKind.BitwiseAndExpression,
+            SyntaxKind.ExclusiveOrAssignmentExpression => SyntaxKind.ExclusiveOrExpression,
+            SyntaxKind.OrAssignmentExpression => SyntaxKind.BitwiseOrExpression,
+            SyntaxKind.LeftShiftAssignmentExpression => SyntaxKind.LeftShiftExpression,
+            SyntaxKind.RightShiftAssignmentExpression => SyntaxKind.RightShiftExpression,
+            _ => SyntaxKind.AddExpression
+        };
+    }
+
+    private static ExpressionSyntax CreateDelegateInvocation(
+        string delegateFieldName,
+        IReadOnlyList<ExpressionSyntax> arguments)
+    {
+        SeparatedSyntaxList<ArgumentSyntax> argumentList = SyntaxFactory.SeparatedList(
+            arguments.Select(SyntaxFactory.Argument));
+        return SyntaxFactory.InvocationExpression(
+            SyntaxFactory.IdentifierName(delegateFieldName),
+            SyntaxFactory.ArgumentList(argumentList));
+    }
+
+    private ExpressionSyntax ExtractReceiver(ExpressionSyntax expression)
+    {
+        if (expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            return memberAccess.Expression;
+        }
+
+        return SyntaxFactory.IdentifierName(TransformWorkerProgramMarker.InstanceParameterName);
+    }
+
+    // Why not Visit synthetic nodes: GetSymbolInfo requires nodes from the original SemanticModel
+    // tree. Bare-member rewrite invents IdentifierName("instance"), which must not be re-visited.
+    private ExpressionSyntax VisitReceiver(ExpressionSyntax receiver)
+    {
+        if (receiver.SyntaxTree != _semanticModel.SyntaxTree)
+        {
+            return receiver;
+        }
+
+        return (ExpressionSyntax)Visit(receiver);
+    }
+
     private (bool owned, bool isStatic, INamedTypeSymbol containingType) ResolveOwnedMember(ISymbol symbol)
     {
         INamedTypeSymbol containingType;
@@ -636,7 +1737,6 @@ internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
 
         if (symbol is IMethodSymbol methodSymbol)
         {
-            // Extension methods live on unrelated static classes; leave them alone.
             if (methodSymbol.IsExtensionMethod)
             {
                 return (false, false, null);
@@ -707,6 +1807,12 @@ internal sealed class InstanceMemberQualifier : CSharpSyntaxRewriter
     {
         return node.Parent is MemberBindingExpressionSyntax memberBinding
             && memberBinding.Name == node;
+    }
+
+    private static bool IsInvocationTarget(SimpleNameSyntax node)
+    {
+        return node.Parent is InvocationExpressionSyntax invocation
+            && invocation.Expression == node;
     }
 
     // `new T { _field = 1 }` must keep the bare member name; qualifying to instance._field is
@@ -790,6 +1896,7 @@ internal static class ShimMethodFactory
 internal sealed class ShimTypeBuilder
 {
     private readonly List<MethodDeclarationSyntax> _methods = new List<MethodDeclarationSyntax>();
+    private readonly AccessorPlan _accessors = new AccessorPlan();
 
     public ShimTypeBuilder(
         string shimTypeName,
@@ -813,7 +1920,50 @@ internal sealed class ShimTypeBuilder
         _methods.Add(named);
     }
 
+    public void MergeAccessors(AccessorPlan plan)
+    {
+        _accessors.MergeFrom(plan);
+    }
+
     public IReadOnlyList<MethodDeclarationSyntax> Methods => _methods;
+
+    public IReadOnlyList<AccessorEntry> Accessors => _accessors.Entries;
+
+    public IEnumerable<MemberDeclarationSyntax> EmitMembers()
+    {
+        foreach (AccessorEntry accessor in _accessors.Entries)
+        {
+            yield return accessor.EmitFieldDeclaration();
+        }
+
+        if (_accessors.Entries.Count > 0)
+        {
+            yield return EmitBindAccessorsMethod();
+        }
+
+        foreach (MethodDeclarationSyntax method in _methods)
+        {
+            yield return method;
+        }
+    }
+
+    private MethodDeclarationSyntax EmitBindAccessorsMethod()
+    {
+        List<StatementSyntax> statements = new List<StatementSyntax>();
+        foreach (AccessorEntry accessor in _accessors.Entries)
+        {
+            statements.Add(accessor.EmitBindStatement());
+        }
+
+        return SyntaxFactory.MethodDeclaration(
+                SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
+                "__BindAccessors")
+            .WithModifiers(
+                SyntaxFactory.TokenList(
+                    SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+                    SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
+            .WithBody(SyntaxFactory.Block(statements));
+    }
 }
 
 internal static class ShimSourceEmitter
@@ -836,7 +1986,7 @@ internal static class ShimSourceEmitter
                     SyntaxFactory.TokenList(
                         SyntaxFactory.Token(SyntaxKind.PublicKeyword),
                         SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
-                .WithMembers(SyntaxFactory.List<MemberDeclarationSyntax>(shimType.Methods));
+                .WithMembers(SyntaxFactory.List(shimType.EmitMembers()));
 
             if (string.IsNullOrEmpty(shimType.NamespaceName))
             {
@@ -993,6 +2143,43 @@ internal sealed class WorkerEntry
     public string ShimTypeName { get; set; }
 
     public string ShimMethodName { get; set; }
+
+    // "transplant" | "delegation" — see PatchKinds.
+    public string PatchKind { get; set; }
+}
+
+internal static class PatchKinds
+{
+    public const string Transplant = "transplant";
+    public const string Delegation = "delegation";
+}
+
+internal sealed class MethodTransformDecision
+{
+    public string SkipReason { get; private set; }
+
+    public string PatchKind { get; private set; }
+
+    public AccessorPlan AccessorPlan { get; private set; }
+
+    public static MethodTransformDecision Skip(string reason)
+    {
+        return new MethodTransformDecision { SkipReason = reason };
+    }
+
+    public static MethodTransformDecision Transplant()
+    {
+        return new MethodTransformDecision { PatchKind = PatchKinds.Transplant };
+    }
+
+    public static MethodTransformDecision Delegation(AccessorPlan accessorPlan)
+    {
+        return new MethodTransformDecision
+        {
+            PatchKind = PatchKinds.Delegation,
+            AccessorPlan = accessorPlan
+        };
+    }
 }
 
 internal sealed class WorkerSkipped

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -251,17 +251,18 @@ public static class TransformWorkerProgram
                 string shimMethodName = methodSymbol.Name + "__shim" + globalShimMethodCounter;
                 globalShimMethodCounter++;
 
+                // Eligibility uses a disposable plan; the rewriter lazily GetOrAdd-s into the
+                // shim-type-level plan so AllocateName stays unique across methods in the type.
+                AccessorPlan rewritePlan = decision.UsesDelegation
+                    ? currentShimType.AccessorPlan
+                    : null;
                 MethodDeclarationSyntax rewrittenMethod = RewriteMethodBody(
                     methodDeclaration,
                     methodSymbol,
                     typeSymbol,
                     semanticModel,
-                    decision.AccessorPlan);
+                    rewritePlan);
                 currentShimType.AddMethod(rewrittenMethod, shimMethodName);
-                if (decision.AccessorPlan != null)
-                {
-                    currentShimType.MergeAccessors(decision.AccessorPlan);
-                }
 
                 entries.Add(new WorkerEntry
                 {
@@ -350,14 +351,21 @@ public static class TransformWorkerProgram
                 methodSymbol,
                 typeSymbol,
                 bodyNode,
-                out AccessorPlan accessorPlan,
+                out AccessorPlan disposablePlan,
                 out string accessorRejectReason))
         {
             return MethodTransformDecision.Skip(
                 v1Reason + " Accessor rewrite unavailable: " + accessorRejectReason);
         }
 
-        return MethodTransformDecision.Delegation(accessorPlan);
+        // Safety net: detection said "needs accessors" but eligibility found nothing to rewrite
+        // (e.g. local-function-only async body). Transplant is correct — the body is unchanged.
+        if (disposablePlan.Entries.Count == 0)
+        {
+            return MethodTransformDecision.Transplant();
+        }
+
+        return MethodTransformDecision.Delegation();
     }
 
     private static string EvaluateHardSkipReason(
@@ -485,13 +493,12 @@ public static class TransformWorkerProgram
 
             foreach (SyntaxNode node in root.DescendantNodesAndSelf())
             {
-                if (!IsInaccessibleAccessCandidateNode(node))
+                if (NameofRules.IsInsideNameofArgument(node))
                 {
                     continue;
                 }
 
-                ISymbol symbol = semanticModel.GetSymbolInfo(node).Symbol;
-                if (symbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol))
+                if (HasInaccessibleAccessAtNode(semanticModel, node))
                 {
                     return true;
                 }
@@ -501,13 +508,169 @@ public static class TransformWorkerProgram
         return false;
     }
 
-    private static bool IsInaccessibleAccessCandidateNode(SyntaxNode node)
+    /// <summary>
+    /// What: site-aware inaccessible access detection (property get vs set, ctor, etc.).
+    /// </summary>
+    private static bool HasInaccessibleAccessAtNode(SemanticModel semanticModel, SyntaxNode node)
     {
-        return node is IdentifierNameSyntax
-            || node is GenericNameSyntax
-            || node is ElementAccessExpressionSyntax
-            || node is ObjectCreationExpressionSyntax
-            || node is ImplicitObjectCreationExpressionSyntax;
+        if (node is AssignmentExpressionSyntax assignment)
+        {
+            if (assignment.Parent is InitializerExpressionSyntax)
+            {
+                ISymbol initializerSymbol = semanticModel.GetSymbolInfo(assignment.Left).Symbol;
+                return initializerSymbol != null
+                    && AccessibilityRules.IsInaccessibleFromExternalAssembly(initializerSymbol);
+            }
+
+            ISymbol leftSymbol = semanticModel.GetSymbolInfo(assignment.Left).Symbol;
+            if (leftSymbol is IPropertySymbol propertySymbol)
+            {
+                bool needsGetter = !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression);
+                if (needsGetter && AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod))
+                {
+                    return true;
+                }
+
+                return AccessibilityRules.IsInaccessibleAccessor(propertySymbol.SetMethod);
+            }
+
+            return leftSymbol != null
+                && AccessibilityRules.IsInaccessibleFromExternalAssembly(leftSymbol);
+        }
+
+        if (node is PostfixUnaryExpressionSyntax postfix
+            && (postfix.IsKind(SyntaxKind.PostIncrementExpression)
+                || postfix.IsKind(SyntaxKind.PostDecrementExpression)))
+        {
+            return IsInaccessibleIncrementOperand(semanticModel, postfix.Operand);
+        }
+
+        if (node is PrefixUnaryExpressionSyntax prefix
+            && (prefix.IsKind(SyntaxKind.PreIncrementExpression)
+                || prefix.IsKind(SyntaxKind.PreDecrementExpression)))
+        {
+            return IsInaccessibleIncrementOperand(semanticModel, prefix.Operand);
+        }
+
+        if (node is ObjectCreationExpressionSyntax or ImplicitObjectCreationExpressionSyntax)
+        {
+            ISymbol ctorSymbol = semanticModel.GetSymbolInfo(node).Symbol;
+            return ctorSymbol != null
+                && AccessibilityRules.IsInaccessibleFromExternalAssembly(ctorSymbol);
+        }
+
+        if (node is InvocationExpressionSyntax invocation)
+        {
+            if (NameofRules.IsNameofInvocation(invocation))
+            {
+                return false;
+            }
+
+            ISymbol symbol = semanticModel.GetSymbolInfo(invocation).Symbol;
+            return symbol is IMethodSymbol methodSymbol
+                && methodSymbol.MethodKind == MethodKind.Ordinary
+                && AccessibilityRules.IsInaccessibleFromExternalAssembly(methodSymbol);
+        }
+
+        if (node is ElementAccessExpressionSyntax elementAccess)
+        {
+            ISymbol symbol = semanticModel.GetSymbolInfo(elementAccess).Symbol;
+            if (symbol is IPropertySymbol indexer)
+            {
+                return AccessibilityRules.IsInaccessibleAccessor(indexer.GetMethod)
+                    || AccessibilityRules.IsInaccessibleAccessor(indexer.SetMethod);
+            }
+
+            return symbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol);
+        }
+
+        if (node is IdentifierNameSyntax or GenericNameSyntax)
+        {
+            SimpleNameSyntax name = (SimpleNameSyntax)node;
+            if (AccessorEligibility.IsNameHandledByParent(name))
+            {
+                return false;
+            }
+
+            if (name.Parent is AssignmentExpressionSyntax parentAssignment
+                && parentAssignment.Left == name)
+            {
+                return false;
+            }
+
+            ISymbol symbol = semanticModel.GetSymbolInfo(name).Symbol;
+            if (symbol is IPropertySymbol propertySymbol)
+            {
+                return AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod);
+            }
+
+            return symbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol);
+        }
+
+        if (node is MemberAccessExpressionSyntax memberAccess)
+        {
+            if (memberAccess.Parent is InvocationExpressionSyntax parentInvocation
+                && parentInvocation.Expression == memberAccess)
+            {
+                return false;
+            }
+
+            if (memberAccess.Parent is AssignmentExpressionSyntax parentAssignment
+                && parentAssignment.Left == memberAccess)
+            {
+                return false;
+            }
+
+            ISymbol symbol = semanticModel.GetSymbolInfo(memberAccess).Symbol
+                ?? semanticModel.GetSymbolInfo(memberAccess.Name).Symbol;
+            if (symbol is IPropertySymbol propertySymbol)
+            {
+                return AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod);
+            }
+
+            return symbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol);
+        }
+
+        return false;
+    }
+
+    private static bool IsInaccessibleIncrementOperand(
+        SemanticModel semanticModel,
+        ExpressionSyntax operand)
+    {
+        ISymbol symbol = semanticModel.GetSymbolInfo(operand).Symbol;
+        if (symbol is IPropertySymbol propertySymbol)
+        {
+            return AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod)
+                || AccessibilityRules.IsInaccessibleAccessor(propertySymbol.SetMethod);
+        }
+
+        return symbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol);
+    }
+
+    internal static class NameofRules
+    {
+        public static bool IsNameofInvocation(InvocationExpressionSyntax invocation)
+        {
+            return invocation.Expression is IdentifierNameSyntax identifier
+                && identifier.Identifier.ValueText == "nameof";
+        }
+
+        public static bool IsInsideNameofArgument(SyntaxNode node)
+        {
+            for (SyntaxNode current = node; current != null; current = current.Parent)
+            {
+                if (current is ArgumentSyntax
+                    && current.Parent is ArgumentListSyntax argumentList
+                    && argumentList.Parent is InvocationExpressionSyntax invocation
+                    && IsNameofInvocation(invocation))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 
     private static MethodDeclarationSyntax RewriteMethodBody(
@@ -526,7 +689,7 @@ public static class TransformWorkerProgram
 
     private static string FormatMethodLabel(INamedTypeSymbol typeSymbol, IMethodSymbol methodSymbol)
     {
-        return typeSymbol.ToDisplayString(FullyQualifiedTypeFormat) + "." + methodSymbol.Name;
+        return AccessorPlan.BuildMemberKey(methodSymbol);
     }
 
     private static List<UsingDirectiveSyntax> CollectUsingsForType(
@@ -569,6 +732,15 @@ internal static class AccessibilityRules
             return false;
         }
 
+        // Local functions / lambdas are emitted into the shim assembly itself, so they have no
+        // cross-assembly accessibility problem and must not be treated as accessor targets.
+        if (symbol is IMethodSymbol methodKindSymbol
+            && (methodKindSymbol.MethodKind == MethodKind.LocalFunction
+                || methodKindSymbol.MethodKind == MethodKind.AnonymousFunction))
+        {
+            return false;
+        }
+
         if (symbol is ITypeSymbol typeSymbol)
         {
             return HasInaccessibleAccessibility(typeSymbol.DeclaredAccessibility)
@@ -594,6 +766,20 @@ internal static class AccessibilityRules
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// What: accessibility of a property get/set accessor method (not the property declaration).
+    /// Missing accessors are treated as inaccessible so write-only/read-only misuse fails closed.
+    /// </summary>
+    public static bool IsInaccessibleAccessor(IMethodSymbol accessorMethod)
+    {
+        if (accessorMethod == null)
+        {
+            return true;
+        }
+
+        return IsInaccessibleFromExternalAssembly(accessorMethod);
     }
 
     private static bool HasInaccessibleAccessibility(Accessibility accessibility)
@@ -666,14 +852,14 @@ internal sealed class AccessorPlan
 
     public AccessorEntry GetOrAddField(IFieldSymbol fieldSymbol)
     {
-        string key = "F:" + MemberKey(fieldSymbol);
+        string key = "F:" + BuildMemberKey(fieldSymbol);
         if (_byKey.TryGetValue(key, out AccessorEntry existing))
         {
             return existing;
         }
 
         string fieldName = AllocateName("__F_" + SanitizeIdentifier(fieldSymbol.Name));
-        AccessorEntry entry = AccessorEntry.ForField(fieldSymbol, fieldName);
+        AccessorEntry entry = AccessorEntry.ForField(fieldSymbol, fieldName, key);
         _byKey[key] = entry;
         _entries.Add(entry);
         return entry;
@@ -681,14 +867,14 @@ internal sealed class AccessorPlan
 
     public AccessorEntry GetOrAddMethod(IMethodSymbol methodSymbol)
     {
-        string key = "M:" + MemberKey(methodSymbol);
+        string key = "M:" + BuildMemberKey(methodSymbol);
         if (_byKey.TryGetValue(key, out AccessorEntry existing))
         {
             return existing;
         }
 
         string fieldName = AllocateName("__M_" + SanitizeIdentifier(methodSymbol.Name));
-        AccessorEntry entry = AccessorEntry.ForMethod(methodSymbol, fieldName);
+        AccessorEntry entry = AccessorEntry.ForMethod(methodSymbol, fieldName, key);
         _byKey[key] = entry;
         _entries.Add(entry);
         return entry;
@@ -696,14 +882,14 @@ internal sealed class AccessorPlan
 
     public AccessorEntry GetOrAddPropertyGetter(IPropertySymbol propertySymbol)
     {
-        string key = "PG:" + MemberKey(propertySymbol);
+        string key = "PG:" + BuildMemberKey(propertySymbol);
         if (_byKey.TryGetValue(key, out AccessorEntry existing))
         {
             return existing;
         }
 
         string fieldName = AllocateName("__P_get_" + SanitizeIdentifier(propertySymbol.Name));
-        AccessorEntry entry = AccessorEntry.ForPropertyGetter(propertySymbol, fieldName);
+        AccessorEntry entry = AccessorEntry.ForPropertyGetter(propertySymbol, fieldName, key);
         _byKey[key] = entry;
         _entries.Add(entry);
         return entry;
@@ -711,31 +897,17 @@ internal sealed class AccessorPlan
 
     public AccessorEntry GetOrAddPropertySetter(IPropertySymbol propertySymbol)
     {
-        string key = "PS:" + MemberKey(propertySymbol);
+        string key = "PS:" + BuildMemberKey(propertySymbol);
         if (_byKey.TryGetValue(key, out AccessorEntry existing))
         {
             return existing;
         }
 
         string fieldName = AllocateName("__P_set_" + SanitizeIdentifier(propertySymbol.Name));
-        AccessorEntry entry = AccessorEntry.ForPropertySetter(propertySymbol, fieldName);
+        AccessorEntry entry = AccessorEntry.ForPropertySetter(propertySymbol, fieldName, key);
         _byKey[key] = entry;
         _entries.Add(entry);
         return entry;
-    }
-
-    public void MergeFrom(AccessorPlan other)
-    {
-        foreach (AccessorEntry entry in other._entries)
-        {
-            if (_byKey.ContainsKey(entry.RegistryKey))
-            {
-                continue;
-            }
-
-            _byKey[entry.RegistryKey] = entry;
-            _entries.Add(entry);
-        }
     }
 
     private string AllocateName(string preferred)
@@ -754,9 +926,36 @@ internal sealed class AccessorPlan
         return preferred + suffix;
     }
 
-    private static string MemberKey(ISymbol symbol)
+    /// <summary>
+    /// What: stable identity for a member across overloads and same-named members on different
+    /// types — containing type FQ + name + (parameter type FQs).
+    /// </summary>
+    public static string BuildMemberKey(ISymbol symbol)
     {
-        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        string typePart = symbol.ContainingType == null
+            ? string.Empty
+            : symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        string name = symbol.Name;
+
+        if (symbol is IMethodSymbol methodSymbol)
+        {
+            string args = string.Join(
+                ",",
+                methodSymbol.Parameters.Select(
+                    parameter => parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+            return typePart + "." + name + "(" + args + ")";
+        }
+
+        if (symbol is IPropertySymbol propertySymbol)
+        {
+            string args = string.Join(
+                ",",
+                propertySymbol.Parameters.Select(
+                    parameter => parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+            return typePart + "." + name + "(" + args + ")";
+        }
+
+        return typePart + "." + name + "()";
     }
 
     private static string SanitizeIdentifier(string name)
@@ -808,45 +1007,57 @@ internal sealed class AccessorEntry
 
     public IPropertySymbol PropertySymbol { get; private set; }
 
-    public static AccessorEntry ForField(IFieldSymbol fieldSymbol, string delegateFieldName)
+    public static AccessorEntry ForField(
+        IFieldSymbol fieldSymbol,
+        string delegateFieldName,
+        string registryKey)
     {
         return new AccessorEntry
         {
             Kind = AccessorKind.FieldRef,
-            RegistryKey = "F:" + fieldSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            RegistryKey = registryKey,
             DelegateFieldName = delegateFieldName,
             FieldSymbol = fieldSymbol
         };
     }
 
-    public static AccessorEntry ForMethod(IMethodSymbol methodSymbol, string delegateFieldName)
+    public static AccessorEntry ForMethod(
+        IMethodSymbol methodSymbol,
+        string delegateFieldName,
+        string registryKey)
     {
         return new AccessorEntry
         {
             Kind = AccessorKind.MethodDelegate,
-            RegistryKey = "M:" + methodSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            RegistryKey = registryKey,
             DelegateFieldName = delegateFieldName,
             MethodSymbol = methodSymbol
         };
     }
 
-    public static AccessorEntry ForPropertyGetter(IPropertySymbol propertySymbol, string delegateFieldName)
+    public static AccessorEntry ForPropertyGetter(
+        IPropertySymbol propertySymbol,
+        string delegateFieldName,
+        string registryKey)
     {
         return new AccessorEntry
         {
             Kind = AccessorKind.PropertyGetter,
-            RegistryKey = "PG:" + propertySymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            RegistryKey = registryKey,
             DelegateFieldName = delegateFieldName,
             PropertySymbol = propertySymbol
         };
     }
 
-    public static AccessorEntry ForPropertySetter(IPropertySymbol propertySymbol, string delegateFieldName)
+    public static AccessorEntry ForPropertySetter(
+        IPropertySymbol propertySymbol,
+        string delegateFieldName,
+        string registryKey)
     {
         return new AccessorEntry
         {
             Kind = AccessorKind.PropertySetter,
-            RegistryKey = "PS:" + propertySymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            RegistryKey = registryKey,
             DelegateFieldName = delegateFieldName,
             PropertySymbol = propertySymbol
         };
@@ -870,6 +1081,7 @@ internal sealed class AccessorEntry
 
     public IEnumerable<ITypeSymbol> EnumerateSignatureTypes()
     {
+        // Bind statements always emit typeof(ContainingType), including for static members.
         switch (Kind)
         {
             case AccessorKind.FieldRef:
@@ -877,11 +1089,7 @@ internal sealed class AccessorEntry
                 yield return FieldSymbol.Type;
                 yield break;
             case AccessorKind.MethodDelegate:
-                if (!MethodSymbol.IsStatic)
-                {
-                    yield return MethodSymbol.ContainingType;
-                }
-
+                yield return MethodSymbol.ContainingType;
                 foreach (IParameterSymbol parameter in MethodSymbol.Parameters)
                 {
                     yield return parameter.Type;
@@ -895,11 +1103,7 @@ internal sealed class AccessorEntry
                 yield break;
             case AccessorKind.PropertyGetter:
             case AccessorKind.PropertySetter:
-                if (!PropertySymbol.IsStatic)
-                {
-                    yield return PropertySymbol.ContainingType;
-                }
-
+                yield return PropertySymbol.ContainingType;
                 yield return PropertySymbol.Type;
                 yield break;
         }
@@ -1064,6 +1268,11 @@ internal static class AccessorEligibility
         AccessorPlan built = new AccessorPlan();
         foreach (SyntaxNode node in bodyNode.DescendantNodesAndSelf())
         {
+            if (TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
+            {
+                continue;
+            }
+
             if (!TryRegisterInaccessibleAccess(semanticModel, node, built, out rejectReason))
             {
                 if (rejectReason != null)
@@ -1123,6 +1332,11 @@ internal static class AccessorEligibility
     {
         foreach (SyntaxNode node in methodDeclaration.DescendantNodesAndSelf())
         {
+            if (TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
+            {
+                continue;
+            }
+
             ITypeSymbol typeSymbol = null;
             if (node is TypeSyntax typeSyntax)
             {
@@ -1132,7 +1346,6 @@ internal static class AccessorEligibility
             else if (node is VariableDeclarationSyntax variableDeclaration
                 && variableDeclaration.Type.IsVar)
             {
-                // var locals still materialize a type in the shim; an internal inferred type fails (c).
                 typeSymbol = semanticModel.GetTypeInfo(variableDeclaration.Type).Type;
             }
             else if (node is ImplicitObjectCreationExpressionSyntax implicitObjectCreation)
@@ -1162,8 +1375,15 @@ internal static class AccessorEligibility
     {
         foreach (SyntaxNode node in bodyNode.DescendantNodes())
         {
+            if (TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
+            {
+                continue;
+            }
+
             ExpressionSyntax operand = null;
-            if (node is PostfixUnaryExpressionSyntax postfix)
+            if (node is PostfixUnaryExpressionSyntax postfix
+                && (postfix.IsKind(SyntaxKind.PostIncrementExpression)
+                    || postfix.IsKind(SyntaxKind.PostDecrementExpression)))
             {
                 operand = postfix.Operand;
             }
@@ -1181,7 +1401,8 @@ internal static class AccessorEligibility
 
             ISymbol symbol = semanticModel.GetSymbolInfo(operand).Symbol;
             if (symbol is IPropertySymbol propertySymbol
-                && AccessibilityRules.IsInaccessibleFromExternalAssembly(propertySymbol))
+                && (AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod)
+                    || AccessibilityRules.IsInaccessibleAccessor(propertySymbol.SetMethod)))
             {
                 return true;
             }
@@ -1203,6 +1424,35 @@ internal static class AccessorEligibility
     {
         rejectReason = null;
 
+        if (node is ObjectCreationExpressionSyntax or ImplicitObjectCreationExpressionSyntax)
+        {
+            ISymbol ctorSymbol = semanticModel.GetSymbolInfo(node).Symbol;
+            if (ctorSymbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(ctorSymbol))
+            {
+                rejectReason =
+                    "inaccessible constructor call has no accessor rewrite shape (condition b).";
+                return false;
+            }
+
+            return false;
+        }
+
+        if (node is AssignmentExpressionSyntax assignment
+            && assignment.Parent is InitializerExpressionSyntax)
+        {
+            ISymbol initializerSymbol = semanticModel.GetSymbolInfo(assignment.Left).Symbol;
+            if (initializerSymbol != null
+                && AccessibilityRules.IsInaccessibleFromExternalAssembly(initializerSymbol))
+            {
+                rejectReason =
+                    "inaccessible member assignment in an object/collection initializer has no "
+                    + "accessor rewrite shape (condition b).";
+                return false;
+            }
+
+            return false;
+        }
+
         if (node is InvocationExpressionSyntax invocation)
         {
             return TryRegisterInvocation(semanticModel, invocation, plan, out rejectReason);
@@ -1211,7 +1461,17 @@ internal static class AccessorEligibility
         if (node is ElementAccessExpressionSyntax elementAccess)
         {
             ISymbol symbol = semanticModel.GetSymbolInfo(elementAccess).Symbol;
-            if (symbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol))
+            if (symbol is IPropertySymbol indexer && indexer.IsIndexer)
+            {
+                if (AccessibilityRules.IsInaccessibleAccessor(indexer.GetMethod)
+                    || AccessibilityRules.IsInaccessibleAccessor(indexer.SetMethod))
+                {
+                    rejectReason =
+                        "inaccessible indexer access has no accessor rewrite shape (condition b).";
+                    return false;
+                }
+            }
+            else if (symbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol))
             {
                 rejectReason = "inaccessible indexer access has no accessor rewrite shape (condition b).";
                 return false;
@@ -1220,28 +1480,29 @@ internal static class AccessorEligibility
             return false;
         }
 
-        if (node is MemberBindingExpressionSyntax
-            || node is ConditionalAccessExpressionSyntax)
+        if (node is MemberBindingExpressionSyntax memberBinding)
         {
-            // ?. chains are not in the rewrite shapes; only fail when they touch inaccessible members.
-            foreach (SyntaxNode child in node.DescendantNodesAndSelf())
+            ISymbol bound = semanticModel.GetSymbolInfo(memberBinding.Name).Symbol;
+            if (bound != null
+                && bound is not INamespaceSymbol
+                && bound is not ITypeSymbol
+                && IsInaccessibleBindingTarget(bound))
             {
-                if (child is not SimpleNameSyntax)
-                {
-                    continue;
-                }
-
-                ISymbol bound = semanticModel.GetSymbolInfo(child).Symbol;
-                if (bound != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(bound)
-                    && bound is not INamespaceSymbol && bound is not ITypeSymbol)
-                {
-                    rejectReason =
-                        "inaccessible member access via conditional access has no rewrite shape (condition b).";
-                    return false;
-                }
+                rejectReason =
+                    "inaccessible member access via conditional access has no rewrite shape (condition b).";
+                return false;
             }
 
             return false;
+        }
+
+        if (node is AssignmentExpressionSyntax propertyOrFieldAssignment)
+        {
+            return TryRegisterAssignment(
+                semanticModel,
+                propertyOrFieldAssignment,
+                plan,
+                out rejectReason);
         }
 
         if (node is MemberAccessExpressionSyntax memberAccess)
@@ -1252,7 +1513,13 @@ internal static class AccessorEligibility
                 return false;
             }
 
-            return TryRegisterMemberSymbol(
+            if (memberAccess.Parent is AssignmentExpressionSyntax parentAssignment
+                && parentAssignment.Left == memberAccess)
+            {
+                return false;
+            }
+
+            return TryRegisterPropertyOrFieldRead(
                 semanticModel.GetSymbolInfo(memberAccess).Symbol
                 ?? semanticModel.GetSymbolInfo(memberAccess.Name).Symbol,
                 plan,
@@ -1267,10 +1534,70 @@ internal static class AccessorEligibility
                 return false;
             }
 
-            return TryRegisterMemberSymbol(
+            if (name.Parent is AssignmentExpressionSyntax parentAssignment
+                && parentAssignment.Left == name)
+            {
+                return false;
+            }
+
+            return TryRegisterPropertyOrFieldRead(
                 semanticModel.GetSymbolInfo(name).Symbol,
                 plan,
                 out rejectReason);
+        }
+
+        return false;
+    }
+
+    private static bool IsInaccessibleBindingTarget(ISymbol bound)
+    {
+        if (bound is IPropertySymbol propertySymbol)
+        {
+            return AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod)
+                || AccessibilityRules.IsInaccessibleAccessor(propertySymbol.SetMethod);
+        }
+
+        return AccessibilityRules.IsInaccessibleFromExternalAssembly(bound);
+    }
+
+    private static bool TryRegisterAssignment(
+        SemanticModel semanticModel,
+        AssignmentExpressionSyntax assignment,
+        AccessorPlan plan,
+        out string rejectReason)
+    {
+        rejectReason = null;
+        ISymbol leftSymbol = semanticModel.GetSymbolInfo(assignment.Left).Symbol;
+        if (leftSymbol is IFieldSymbol fieldSymbol)
+        {
+            if (!AccessibilityRules.IsInaccessibleFromExternalAssembly(fieldSymbol))
+            {
+                return false;
+            }
+
+            if (fieldSymbol.IsStatic)
+            {
+                rejectReason = "inaccessible static field access has no accessor rewrite shape (condition b).";
+                return false;
+            }
+
+            plan.GetOrAddField(fieldSymbol);
+            return true;
+        }
+
+        if (leftSymbol is IPropertySymbol propertySymbol)
+        {
+            return TryRegisterPropertyWrite(
+                propertySymbol,
+                needsGetter: !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression),
+                plan,
+                out rejectReason);
+        }
+
+        if (leftSymbol is IEventSymbol)
+        {
+            rejectReason = "inaccessible event add/remove is out of scope for accessor rewrite (condition b).";
+            return false;
         }
 
         return false;
@@ -1283,16 +1610,18 @@ internal static class AccessorEligibility
         out string rejectReason)
     {
         rejectReason = null;
+        if (TransformWorkerProgram.NameofRules.IsNameofInvocation(invocation))
+        {
+            return false;
+        }
+
         ISymbol symbol = semanticModel.GetSymbolInfo(invocation).Symbol;
         if (symbol is not IMethodSymbol methodSymbol)
         {
             return false;
         }
 
-        if (methodSymbol.MethodKind == MethodKind.PropertyGet
-            || methodSymbol.MethodKind == MethodKind.PropertySet
-            || methodSymbol.MethodKind == MethodKind.EventAdd
-            || methodSymbol.MethodKind == MethodKind.EventRemove)
+        if (methodSymbol.MethodKind != MethodKind.Ordinary)
         {
             return false;
         }
@@ -1308,33 +1637,64 @@ internal static class AccessorEligibility
             return false;
         }
 
+        if (methodSymbol.IsGenericMethod)
+        {
+            rejectReason = "inaccessible generic method calls are not rewritten (condition b).";
+            return false;
+        }
+
+        if (methodSymbol.ReturnsByRef || methodSymbol.ReturnsByRefReadonly)
+        {
+            rejectReason =
+                "inaccessible methods that return by ref have no accessor rewrite shape (condition b).";
+            return false;
+        }
+
         foreach (IParameterSymbol parameter in methodSymbol.Parameters)
         {
-            if (parameter.RefKind == RefKind.Ref || parameter.RefKind == RefKind.Out)
+            if (parameter.RefKind != RefKind.None)
             {
                 rejectReason =
-                    "inaccessible method calls with ref/out parameters are not rewritten (condition b).";
+                    "inaccessible method calls with ref/out/in parameters are not rewritten (condition b).";
                 return false;
             }
+        }
+
+        foreach (ArgumentSyntax argument in invocation.ArgumentList.Arguments)
+        {
+            if (argument.NameColon != null)
+            {
+                rejectReason =
+                    "inaccessible method calls with named arguments are not rewritten (condition b).";
+                return false;
+            }
+        }
+
+        if (invocation.ArgumentList.Arguments.Count != methodSymbol.Parameters.Length)
+        {
+            rejectReason =
+                "inaccessible method calls with omitted optional or expanded params arguments "
+                + "are not rewritten (condition b).";
+            return false;
         }
 
         plan.GetOrAddMethod(methodSymbol);
         return true;
     }
 
-    private static bool TryRegisterMemberSymbol(
+    private static bool TryRegisterPropertyOrFieldRead(
         ISymbol symbol,
         AccessorPlan plan,
         out string rejectReason)
     {
         rejectReason = null;
-        if (symbol == null || !AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol))
-        {
-            return false;
-        }
-
         if (symbol is IFieldSymbol fieldSymbol)
         {
+            if (!AccessibilityRules.IsInaccessibleFromExternalAssembly(fieldSymbol))
+            {
+                return false;
+            }
+
             if (fieldSymbol.IsStatic)
             {
                 rejectReason = "inaccessible static field access has no accessor rewrite shape (condition b).";
@@ -1347,38 +1707,12 @@ internal static class AccessorEligibility
 
         if (symbol is IPropertySymbol propertySymbol)
         {
-            if (propertySymbol.IsIndexer)
+            if (!AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod))
             {
-                rejectReason = "inaccessible indexer access has no accessor rewrite shape (condition b).";
                 return false;
             }
 
-            if (propertySymbol.IsStatic)
-            {
-                rejectReason =
-                    "inaccessible static property access has no accessor rewrite shape (condition b).";
-                return false;
-            }
-
-            // Reads and writes are registered by the rewriter as needed; eligibility requires that
-            // both accessors exist when the property is used, so register both when present.
-            if (propertySymbol.GetMethod != null)
-            {
-                plan.GetOrAddPropertyGetter(propertySymbol);
-            }
-
-            if (propertySymbol.SetMethod != null)
-            {
-                plan.GetOrAddPropertySetter(propertySymbol);
-            }
-
-            if (propertySymbol.GetMethod == null && propertySymbol.SetMethod == null)
-            {
-                rejectReason = "inaccessible property has no getter or setter to bind (condition b).";
-                return false;
-            }
-
-            return true;
+            return TryRegisterPropertyRead(propertySymbol, plan, out rejectReason);
         }
 
         if (symbol is IEventSymbol)
@@ -1387,19 +1721,119 @@ internal static class AccessorEligibility
             return false;
         }
 
-        if (symbol is IMethodSymbol)
+        if (symbol is IMethodSymbol methodSymbol
+            && AccessibilityRules.IsInaccessibleFromExternalAssembly(methodSymbol))
         {
-            // Method group without invocation (e.g. assigned to a delegate) has no rewrite shape.
             rejectReason =
                 "inaccessible method group (non-invocation) has no accessor rewrite shape (condition b).";
             return false;
         }
 
-        rejectReason = "inaccessible member kind is not field/method/property access (condition b).";
+        if (symbol != null
+            && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol)
+            && symbol is not INamespaceSymbol
+            && symbol is not ITypeSymbol
+            && symbol is not ILocalSymbol
+            && symbol is not IParameterSymbol)
+        {
+            rejectReason = "inaccessible member kind is not field/method/property access (condition b).";
+            return false;
+        }
+
         return false;
     }
 
-    private static bool IsNameHandledByParent(SimpleNameSyntax node)
+    private static bool TryRegisterPropertyRead(
+        IPropertySymbol propertySymbol,
+        AccessorPlan plan,
+        out string rejectReason)
+    {
+        rejectReason = null;
+        if (propertySymbol.IsIndexer)
+        {
+            rejectReason = "inaccessible indexer access has no accessor rewrite shape (condition b).";
+            return false;
+        }
+
+        if (propertySymbol.IsStatic)
+        {
+            rejectReason =
+                "inaccessible static property access has no accessor rewrite shape (condition b).";
+            return false;
+        }
+
+        if (propertySymbol.ReturnsByRef || propertySymbol.ReturnsByRefReadonly)
+        {
+            rejectReason =
+                "inaccessible ref-returning properties have no accessor rewrite shape (condition b).";
+            return false;
+        }
+
+        plan.GetOrAddPropertyGetter(propertySymbol);
+        return true;
+    }
+
+    private static bool TryRegisterPropertyWrite(
+        IPropertySymbol propertySymbol,
+        bool needsGetter,
+        AccessorPlan plan,
+        out string rejectReason)
+    {
+        rejectReason = null;
+        if (propertySymbol.IsIndexer)
+        {
+            rejectReason = "inaccessible indexer access has no accessor rewrite shape (condition b).";
+            return false;
+        }
+
+        if (propertySymbol.IsStatic)
+        {
+            rejectReason =
+                "inaccessible static property access has no accessor rewrite shape (condition b).";
+            return false;
+        }
+
+        if (propertySymbol.ReturnsByRef || propertySymbol.ReturnsByRefReadonly)
+        {
+            rejectReason =
+                "inaccessible ref-returning properties have no accessor rewrite shape (condition b).";
+            return false;
+        }
+
+        bool setterInaccessible = AccessibilityRules.IsInaccessibleAccessor(propertySymbol.SetMethod);
+        bool getterInaccessible = needsGetter
+            && AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod);
+        if (!setterInaccessible && !getterInaccessible)
+        {
+            return false;
+        }
+
+        if (setterInaccessible)
+        {
+            if (propertySymbol.SetMethod == null)
+            {
+                rejectReason = "inaccessible property has no setter to bind (condition b).";
+                return false;
+            }
+
+            plan.GetOrAddPropertySetter(propertySymbol);
+        }
+
+        if (getterInaccessible)
+        {
+            if (propertySymbol.GetMethod == null)
+            {
+                rejectReason = "inaccessible property has no getter to bind (condition b).";
+                return false;
+            }
+
+            plan.GetOrAddPropertyGetter(propertySymbol);
+        }
+
+        return true;
+    }
+
+    public static bool IsNameHandledByParent(SimpleNameSyntax node)
     {
         if (node.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == node)
         {
@@ -1417,13 +1851,6 @@ internal static class AccessorEligibility
         }
 
         if (node.Parent is InvocationExpressionSyntax invocation && invocation.Expression == node)
-        {
-            return true;
-        }
-
-        if (node.Parent is AssignmentExpressionSyntax assignment
-            && assignment.Left == node
-            && assignment.Parent is InitializerExpressionSyntax)
         {
             return true;
         }
@@ -1470,7 +1897,9 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
 
     public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
     {
-        if (_accessorPlan == null)
+        if (_accessorPlan == null
+            || TransformWorkerProgram.NameofRules.IsNameofInvocation(node)
+            || TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
         {
             return base.VisitInvocationExpression(node);
         }
@@ -1505,16 +1934,22 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
 
     public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
     {
-        if (_accessorPlan == null)
+        // Object/collection initializer member names must stay bare identifiers.
+        if (node.Parent is InitializerExpressionSyntax)
+        {
+            return base.VisitAssignmentExpression(node);
+        }
+
+        if (_accessorPlan == null || TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
         {
             return base.VisitAssignmentExpression(node);
         }
 
         ISymbol leftSymbol = _semanticModel.GetSymbolInfo(node.Left).Symbol;
         if (leftSymbol is IPropertySymbol propertySymbol
-            && AccessibilityRules.IsInaccessibleFromExternalAssembly(propertySymbol)
             && !propertySymbol.IsIndexer
-            && !propertySymbol.IsStatic)
+            && !propertySymbol.IsStatic
+            && AccessibilityRules.IsInaccessibleAccessor(propertySymbol.SetMethod))
         {
             return RewritePropertyAssignment(node, propertySymbol);
         }
@@ -1539,7 +1974,7 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
 
     public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
     {
-        if (_accessorPlan == null)
+        if (_accessorPlan == null || TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
         {
             return base.VisitMemberAccessExpression(node);
         }
@@ -1582,7 +2017,9 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             return original;
         }
 
-        if (_accessorPlan != null)
+        // nameof(...) must keep a member reference shape (qualify only; never accessor calls).
+        bool insideNameof = TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node);
+        if (_accessorPlan != null && !insideNameof)
         {
             ExpressionSyntax accessorRead = TryRewriteInaccessibleRead(
                 symbol,
@@ -1635,10 +2072,9 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         }
 
         if (symbol is IPropertySymbol propertySymbol
-            && AccessibilityRules.IsInaccessibleFromExternalAssembly(propertySymbol)
             && !propertySymbol.IsIndexer
             && !propertySymbol.IsStatic
-            && propertySymbol.GetMethod != null)
+            && AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod))
         {
             AccessorEntry entry = _accessorPlan.GetOrAddPropertyGetter(propertySymbol);
             return CreateDelegateInvocation(
@@ -1896,7 +2332,6 @@ internal static class ShimMethodFactory
 internal sealed class ShimTypeBuilder
 {
     private readonly List<MethodDeclarationSyntax> _methods = new List<MethodDeclarationSyntax>();
-    private readonly AccessorPlan _accessors = new AccessorPlan();
 
     public ShimTypeBuilder(
         string shimTypeName,
@@ -1906,6 +2341,7 @@ internal sealed class ShimTypeBuilder
         ShimTypeName = shimTypeName;
         NamespaceName = namespaceName ?? string.Empty;
         Usings = usings ?? new List<UsingDirectiveSyntax>();
+        AccessorPlan = new AccessorPlan();
     }
 
     public string ShimTypeName { get; }
@@ -1914,29 +2350,28 @@ internal sealed class ShimTypeBuilder
 
     public List<UsingDirectiveSyntax> Usings { get; }
 
+    /// <summary>
+    /// Shim-type-level accessor registry — shared across all delegation methods in this type so
+    /// AllocateName stays unique and overloads cannot collide after a per-method merge.
+    /// </summary>
+    public AccessorPlan AccessorPlan { get; }
+
     public void AddMethod(MethodDeclarationSyntax shimMethod, string shimMethodName)
     {
         MethodDeclarationSyntax named = shimMethod.WithIdentifier(SyntaxFactory.Identifier(shimMethodName));
         _methods.Add(named);
     }
 
-    public void MergeAccessors(AccessorPlan plan)
-    {
-        _accessors.MergeFrom(plan);
-    }
-
     public IReadOnlyList<MethodDeclarationSyntax> Methods => _methods;
-
-    public IReadOnlyList<AccessorEntry> Accessors => _accessors.Entries;
 
     public IEnumerable<MemberDeclarationSyntax> EmitMembers()
     {
-        foreach (AccessorEntry accessor in _accessors.Entries)
+        foreach (AccessorEntry accessor in AccessorPlan.Entries)
         {
             yield return accessor.EmitFieldDeclaration();
         }
 
-        if (_accessors.Entries.Count > 0)
+        if (AccessorPlan.Entries.Count > 0)
         {
             yield return EmitBindAccessorsMethod();
         }
@@ -1950,7 +2385,7 @@ internal sealed class ShimTypeBuilder
     private MethodDeclarationSyntax EmitBindAccessorsMethod()
     {
         List<StatementSyntax> statements = new List<StatementSyntax>();
-        foreach (AccessorEntry accessor in _accessors.Entries)
+        foreach (AccessorEntry accessor in AccessorPlan.Entries)
         {
             statements.Add(accessor.EmitBindStatement());
         }
@@ -2160,7 +2595,7 @@ internal sealed class MethodTransformDecision
 
     public string PatchKind { get; private set; }
 
-    public AccessorPlan AccessorPlan { get; private set; }
+    public bool UsesDelegation => PatchKind == PatchKinds.Delegation;
 
     public static MethodTransformDecision Skip(string reason)
     {
@@ -2172,13 +2607,9 @@ internal sealed class MethodTransformDecision
         return new MethodTransformDecision { PatchKind = PatchKinds.Transplant };
     }
 
-    public static MethodTransformDecision Delegation(AccessorPlan accessorPlan)
+    public static MethodTransformDecision Delegation()
     {
-        return new MethodTransformDecision
-        {
-            PatchKind = PatchKinds.Delegation,
-            AccessorPlan = accessorPlan
-        };
+        return new MethodTransformDecision { PatchKind = PatchKinds.Delegation };
     }
 }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -597,6 +597,21 @@ public static class TransformWorkerProgram
             return symbol != null && AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol);
         }
 
+        if (node is MemberBindingExpressionSyntax memberBinding)
+        {
+            // ?.Member — visibility of the bound member (not the receiver).
+            ISymbol bound = semanticModel.GetSymbolInfo(memberBinding.Name).Symbol;
+            if (bound is IPropertySymbol propertySymbol)
+            {
+                return AccessibilityRules.IsInaccessibleAccessor(propertySymbol.GetMethod);
+            }
+
+            return bound != null
+                && bound is not INamespaceSymbol
+                && bound is not ITypeSymbol
+                && AccessibilityRules.IsInaccessibleFromExternalAssembly(bound);
+        }
+
         if (node is IdentifierNameSyntax or GenericNameSyntax)
         {
             SimpleNameSyntax name = (SimpleNameSyntax)node;
@@ -609,6 +624,18 @@ public static class TransformWorkerProgram
                 && parentAssignment.Left == name)
             {
                 return false;
+            }
+
+            // Invocation-target exclusion applies only to method groups; delegate-typed fields
+            // invoked as `_cb()` must be detected as field reads.
+            if (name.Parent is InvocationExpressionSyntax parentInvocation
+                && parentInvocation.Expression == name)
+            {
+                ISymbol invocationTarget = semanticModel.GetSymbolInfo(name).Symbol;
+                if (invocationTarget is IMethodSymbol)
+                {
+                    return false;
+                }
             }
 
             ISymbol symbol = semanticModel.GetSymbolInfo(name).Symbol;
@@ -625,7 +652,12 @@ public static class TransformWorkerProgram
             if (memberAccess.Parent is InvocationExpressionSyntax parentInvocation
                 && parentInvocation.Expression == memberAccess)
             {
-                return false;
+                ISymbol invocationTarget = semanticModel.GetSymbolInfo(memberAccess).Symbol
+                    ?? semanticModel.GetSymbolInfo(memberAccess.Name).Symbol;
+                if (invocationTarget is IMethodSymbol)
+                {
+                    return false;
+                }
             }
 
             if (memberAccess.Parent is AssignmentExpressionSyntax parentAssignment
@@ -773,8 +805,9 @@ internal static class AccessibilityRules
                 return true;
             }
 
+            // Recurse through nested containing types (same rule as the type-symbol branch).
             if (symbol.ContainingType != null
-                && HasInaccessibleAccessibility(symbol.ContainingType.DeclaredAccessibility))
+                && IsInaccessibleFromExternalAssembly(symbol.ContainingType))
             {
                 return true;
             }
@@ -1217,10 +1250,15 @@ internal sealed class AccessorEntry
         string declaringType = TypeDisplay(methodSymbol.ContainingType);
         string delegateType = BuildFuncOrActionType(methodSymbol);
         string typeArray = BuildTypeArrayLiteral(methodSymbol);
+        // virtualCall must stay true for virtual/override/abstract instance members so a derived
+        // override is dispatched; non-virtual private/internal targets keep false (exact method).
+        bool virtualCall = !methodSymbol.IsStatic
+            && (methodSymbol.IsVirtual || methodSymbol.IsOverride || methodSymbol.IsAbstract);
+        string virtualCallLiteral = virtualCall ? "true" : "false";
         return DelegateFieldName + " = global::HarmonyLib.AccessTools.MethodDelegate<"
             + delegateType + ">(global::HarmonyLib.AccessTools.Method(typeof("
             + declaringType + "), \"" + EscapeStringLiteral(metadataName) + "\", "
-            + typeArray + "), null, false, null);";
+            + typeArray + "), null, " + virtualCallLiteral + ", null);";
     }
 
     private static string BuildTypeArrayLiteral(IMethodSymbol methodSymbol)
@@ -1566,6 +1604,18 @@ internal static class AccessorEligibility
                 return false;
             }
 
+            // Method-group invocation targets are owned by the invocation branch; delegate-typed
+            // field invokes (`_cb()`) register as field reads here.
+            if (name.Parent is InvocationExpressionSyntax parentInvocation
+                && parentInvocation.Expression == name)
+            {
+                ISymbol invocationTarget = semanticModel.GetSymbolInfo(name).Symbol;
+                if (invocationTarget is IMethodSymbol)
+                {
+                    return false;
+                }
+            }
+
             return TryRegisterPropertyOrFieldRead(
                 semanticModel.GetSymbolInfo(name).Symbol,
                 plan,
@@ -1614,8 +1664,8 @@ internal static class AccessorEligibility
         if (leftSymbol is IPropertySymbol propertySymbol)
         {
             return TryRegisterPropertyWrite(
+                assignment,
                 propertySymbol,
-                needsGetter: !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression),
                 plan,
                 out rejectReason);
         }
@@ -1800,12 +1850,13 @@ internal static class AccessorEligibility
     }
 
     private static bool TryRegisterPropertyWrite(
+        AssignmentExpressionSyntax assignment,
         IPropertySymbol propertySymbol,
-        bool needsGetter,
         AccessorPlan plan,
         out string rejectReason)
     {
         rejectReason = null;
+        bool needsGetter = !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression);
 
         // Why accessibility first: shape gates (indexer/static/ref-return) must not reject fully
         // public writes such as dict[key]=value or Time.timeScale=0f. The read-side path already
@@ -1819,6 +1870,21 @@ internal static class AccessorEligibility
             return false;
         }
 
+        if (assignment.IsKind(SyntaxKind.CoalesceAssignmentExpression))
+        {
+            rejectReason =
+                "null-coalescing assignment writes conditionally and has no accessor rewrite shape "
+                + "(condition b).";
+            return false;
+        }
+
+        if (needsGetter && !IsSupportedCompoundAssignmentKind(assignment.Kind()))
+        {
+            rejectReason =
+                "unsupported compound assignment kind has no accessor rewrite shape (condition b).";
+            return false;
+        }
+
         // Compound assignment with a private getter and a public setter has no rewrite shape:
         // RewritePropertyAssignment only fires when the setter is inaccessible.
         if (getterInaccessible && !setterInaccessible)
@@ -1826,6 +1892,22 @@ internal static class AccessorEligibility
             rejectReason =
                 "compound assignment reading an inaccessible getter with an accessible setter "
                 + "has no accessor rewrite shape (condition b).";
+            return false;
+        }
+
+        // Setter delegates are void — consuming the assignment expression value cannot compile.
+        if (assignment.Parent is not ExpressionStatementSyntax)
+        {
+            rejectReason =
+                "assignment value is consumed; the setter delegate returns void (condition b).";
+            return false;
+        }
+
+        // Compound/get+set rewrite embeds the receiver twice; reject side-effecting receivers.
+        if (needsGetter && !IsSideEffectFreeAssignmentReceiver(assignment.Left))
+        {
+            rejectReason =
+                "receiver with possible side effects would be evaluated twice (condition b).";
             return false;
         }
 
@@ -1874,6 +1956,47 @@ internal static class AccessorEligibility
         return true;
     }
 
+    private static bool IsSupportedCompoundAssignmentKind(SyntaxKind kind)
+    {
+        return kind == SyntaxKind.AddAssignmentExpression
+            || kind == SyntaxKind.SubtractAssignmentExpression
+            || kind == SyntaxKind.MultiplyAssignmentExpression
+            || kind == SyntaxKind.DivideAssignmentExpression
+            || kind == SyntaxKind.ModuloAssignmentExpression
+            || kind == SyntaxKind.AndAssignmentExpression
+            || kind == SyntaxKind.ExclusiveOrAssignmentExpression
+            || kind == SyntaxKind.OrAssignmentExpression
+            || kind == SyntaxKind.LeftShiftAssignmentExpression
+            || kind == SyntaxKind.RightShiftAssignmentExpression
+            || kind == SyntaxKind.UnsignedRightShiftAssignmentExpression;
+    }
+
+    /// <summary>
+    /// What: whether an assignment left's receiver is limited to this/identifier/member-access
+    /// chains (no invocations, element access, conditionals, etc.).
+    /// </summary>
+    private static bool IsSideEffectFreeAssignmentReceiver(ExpressionSyntax left)
+    {
+        ExpressionSyntax receiver = left is MemberAccessExpressionSyntax memberAccess
+            ? memberAccess.Expression
+            : null;
+        if (receiver == null)
+        {
+            // Bare member — implicit this.
+            return true;
+        }
+
+        ExpressionSyntax current = receiver;
+        while (current is MemberAccessExpressionSyntax nested)
+        {
+            current = nested.Expression;
+        }
+
+        return current is IdentifierNameSyntax
+            || current is ThisExpressionSyntax
+            || current is BaseExpressionSyntax;
+    }
+
     public static bool IsNameHandledByParent(SimpleNameSyntax node)
     {
         if (node.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == node)
@@ -1891,11 +2014,8 @@ internal static class AccessorEligibility
             return true;
         }
 
-        if (node.Parent is InvocationExpressionSyntax invocation && invocation.Expression == node)
-        {
-            return true;
-        }
-
+        // Invocation targets are NOT handled here: method groups are skipped by the caller after
+        // a symbol check; delegate-typed field invokes must reach the field-read path.
         return false;
     }
 }
@@ -2046,14 +2166,21 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         if (IsMemberAccessNameSide(node)
             || IsQualifiedNameRightSide(node)
             || IsMemberBindingName(node)
-            || IsObjectOrCollectionInitializerMemberName(node)
-            || IsInvocationTarget(node))
+            || IsObjectOrCollectionInitializerMemberName(node))
         {
             return original;
         }
 
         ISymbol symbol = _semanticModel.GetSymbolInfo(node).Symbol;
         if (symbol == null)
+        {
+            return original;
+        }
+
+        // Local/anonymous functions are emitted into the shim assembly — keep bare calls.
+        if (symbol is IMethodSymbol methodSymbol
+            && (methodSymbol.MethodKind == MethodKind.LocalFunction
+                || methodSymbol.MethodKind == MethodKind.AnonymousFunction))
         {
             return original;
         }
@@ -2173,7 +2300,10 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             SyntaxKind.OrAssignmentExpression => SyntaxKind.BitwiseOrExpression,
             SyntaxKind.LeftShiftAssignmentExpression => SyntaxKind.LeftShiftExpression,
             SyntaxKind.RightShiftAssignmentExpression => SyntaxKind.RightShiftExpression,
-            _ => SyntaxKind.AddExpression
+            SyntaxKind.UnsignedRightShiftAssignmentExpression => SyntaxKind.UnsignedRightShiftExpression,
+            // Eligibility must reject unsupported compounds (including ??=) before rewrite.
+            _ => throw new System.InvalidOperationException(
+                "Unsupported compound assignment kind reached property rewrite: " + assignmentKind)
         };
     }
 
@@ -2287,12 +2417,6 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
     {
         return node.Parent is MemberBindingExpressionSyntax memberBinding
             && memberBinding.Name == node;
-    }
-
-    private static bool IsInvocationTarget(SimpleNameSyntax node)
-    {
-        return node.Parent is InvocationExpressionSyntax invocation
-            && invocation.Expression == node;
     }
 
     // `new T { _field = 1 }` must keep the bare member name; qualifying to instance._field is


### PR DESCRIPTION
## Summary

- Extend the hot-reload transform worker with an accessor-delegate rewrite path so async/iterator/closure methods that v1 skipped solely for private/internal access can emit JIT-legal shim bodies (`patchKind: "delegation"`, `__BindAccessors`, FieldRef/MethodDelegate fields).
- Keep the sync transplant path unchanged. Orchestrator compiles mixed transplant+delegation shim sources (Harmony reference only when a delegation entry is present) but intentionally leaves delegation methods unpatched until the delegation pass lands.
- Update worker/orchestrator EditMode coverage for the new patchKind contract and add a mixed-file assert (sync transplant succeeds; delegation reports the not-wired skip reason).

## Notes

- SKILL.md skip-table wording is intentionally left unchanged here; it will be updated when the delegation patcher is wired.
- Delegation entries are compiled into the shim but intentionally left unpatched until the delegation pass lands (`HotReloadConstants.DelegationPatchNotWiredSkipReason`).

## Test plan

- [x] `dist/darwin-arm64/uloop compile` — ErrorCount=0 / WarningCount=0
- [x] `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value HotReload` — 47/47 passed
- [x] Worker unit probes (dotnet direct): async+private field/method → delegation + `__BindAccessors`; advisor probe1/probe2/probe3 expectations
- [ ] CI on this PR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

