### PR TITLE
feat: wire delegation patching and accessor binding into hot reload

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -86,10 +86,11 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 
 ## Pause point interaction
 
-A hot-reload transplant discards the original IL and any prior transpiler output on that
-method, so a source pause point on a hot-reloaded method stops firing until the patch is
-reverted (`--revert-all`) or a domain reload restores the original IL. Apply responses
-include this as a `Warnings` entry whenever any method was patched.
+Both patch shapes discard the original IL and any prior transpiler output on the patched
+method — delegation replaces the body with a forward to the shim — so a source pause point
+on a hot-reloaded method stops firing until the patch is reverted (`--revert-all`) or a
+domain reload restores the original IL. Apply responses include this as a `Warnings` entry
+whenever any method was patched.
 
 ## Output
 

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -34,14 +34,14 @@ consume exactly one value token.
 ## How it works
 
 1. Resolves each file to its compiled assembly via `CompilationPipeline`.
-2. Rewrites each editable method body into a static shim in an out-of-process Roslyn worker.
-3. Compiles the shims against publicized reference copies and loads the result into the Editor domain.
-4. Transplants each shim's IL into the original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`).
+2. Rewrites each editable method body into a static shim in an out-of-process Roslyn worker. When an async, iterator, lambda, local-function, or LINQ-query body touches private/internal members, those accesses are rewritten to accessor delegates so the body can compile and run from the shim assembly (the delegation shape below).
+3. Compiles the shims against publicized reference copies, loads the result into the Editor domain, and binds every shim type's accessor delegates (`__BindAccessors`) before any patch is applied.
+4. Patches each original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`) in one of two shapes: transplant copies the shim's IL into the original method, while delegation rewrites the original to forward its arguments to the shim, which runs as normally compiled code.
 
 Re-running on the same method replaces its previous patch; `ActivePatchTotal` tracks the
 ledger across runs.
 
-## Scope and limits (v1)
+## Scope and limits
 
 Only ordinary method declarations are scanned. Property and indexer accessors, constructors,
 finalizers, operators, and event accessors are never scanned: edits to them produce **no
@@ -54,7 +54,7 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Condition | Why |
 |-----------|-----|
 | Method on a `partial` type (including a type nested inside a partial outer type) | A single file cannot provide a complete semantic model |
-| Method on a struct (value type) | Value-type transplant is out of v1 scope |
+| Method on a struct (value type) | Value-type patching is out of scope |
 | Generic method, or method on a generic type | Harmony cannot safely patch open generics |
 | Explicit interface implementation | Dotted metadata names cannot be expressed as shim identifiers |
 | No body (`abstract` / `extern`) | Nothing to transplant |

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -9,8 +9,9 @@ description: "Apply method-body hot reload to edited C# sources in a running Uni
 Replaces method bodies in the running Editor (EditMode or PlayMode) directly from edited
 project source files — no domain reload, no attributes, no source markers. Private/internal
 member access, static methods, return values, async methods, and iterators all work within
-the v1 limits below. Methods that cannot be patched are reported per method as `Skipped` or
-`Failed`; one unpatchable method never aborts the rest of the run.
+the limits below — including private access inside async, iterator, lambda, local-function,
+and LINQ-query bodies. Methods that cannot be patched are reported per method as `Skipped`
+or `Failed`; one unpatchable method never aborts the rest of the run.
 
 ## Usage
 
@@ -28,7 +29,7 @@ consume exactly one value token.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
-| `--revert-all` | flag | - | Remove every active hot-reload transplant and clear the patch ledger. When set, `--files` is ignored |
+| `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 
 ## How it works
 
@@ -58,8 +59,8 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Explicit interface implementation | Dotted metadata names cannot be expressed as shim identifiers |
 | No body (`abstract` / `extern`) | Nothing to transplant |
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
-| Lambda, local function, or LINQ query in the body accesses private/internal members | Closure bodies run from the shim assembly, where that access fails runtime accessibility checks; only the named method's IL is transplanted |
-| `async` or iterator body accesses private/internal members | Same as above — the state machine's `MoveNext` runs from the shim assembly |
+| Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
+| An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`
 
@@ -71,6 +72,7 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
 | Patch rejected at apply time (e.g. `[BurstCompile]`) | Not patchable by Harmony transplant |
+| Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 
 ## Convergence and lifecycle
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -86,10 +86,11 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 
 ## Pause point interaction
 
-A hot-reload transplant discards the original IL and any prior transpiler output on that
-method, so a source pause point on a hot-reloaded method stops firing until the patch is
-reverted (`--revert-all`) or a domain reload restores the original IL. Apply responses
-include this as a `Warnings` entry whenever any method was patched.
+Both patch shapes discard the original IL and any prior transpiler output on the patched
+method — delegation replaces the body with a forward to the shim — so a source pause point
+on a hot-reloaded method stops firing until the patch is reverted (`--revert-all`) or a
+domain reload restores the original IL. Apply responses include this as a `Warnings` entry
+whenever any method was patched.
 
 ## Output
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -34,14 +34,14 @@ consume exactly one value token.
 ## How it works
 
 1. Resolves each file to its compiled assembly via `CompilationPipeline`.
-2. Rewrites each editable method body into a static shim in an out-of-process Roslyn worker.
-3. Compiles the shims against publicized reference copies and loads the result into the Editor domain.
-4. Transplants each shim's IL into the original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`).
+2. Rewrites each editable method body into a static shim in an out-of-process Roslyn worker. When an async, iterator, lambda, local-function, or LINQ-query body touches private/internal members, those accesses are rewritten to accessor delegates so the body can compile and run from the shim assembly (the delegation shape below).
+3. Compiles the shims against publicized reference copies, loads the result into the Editor domain, and binds every shim type's accessor delegates (`__BindAccessors`) before any patch is applied.
+4. Patches each original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`) in one of two shapes: transplant copies the shim's IL into the original method, while delegation rewrites the original to forward its arguments to the shim, which runs as normally compiled code.
 
 Re-running on the same method replaces its previous patch; `ActivePatchTotal` tracks the
 ledger across runs.
 
-## Scope and limits (v1)
+## Scope and limits
 
 Only ordinary method declarations are scanned. Property and indexer accessors, constructors,
 finalizers, operators, and event accessors are never scanned: edits to them produce **no
@@ -54,7 +54,7 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Condition | Why |
 |-----------|-----|
 | Method on a `partial` type (including a type nested inside a partial outer type) | A single file cannot provide a complete semantic model |
-| Method on a struct (value type) | Value-type transplant is out of v1 scope |
+| Method on a struct (value type) | Value-type patching is out of scope |
 | Generic method, or method on a generic type | Harmony cannot safely patch open generics |
 | Explicit interface implementation | Dotted metadata names cannot be expressed as shim identifiers |
 | No body (`abstract` / `extern`) | Nothing to transplant |

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -9,8 +9,9 @@ description: "Apply method-body hot reload to edited C# sources in a running Uni
 Replaces method bodies in the running Editor (EditMode or PlayMode) directly from edited
 project source files — no domain reload, no attributes, no source markers. Private/internal
 member access, static methods, return values, async methods, and iterators all work within
-the v1 limits below. Methods that cannot be patched are reported per method as `Skipped` or
-`Failed`; one unpatchable method never aborts the rest of the run.
+the limits below — including private access inside async, iterator, lambda, local-function,
+and LINQ-query bodies. Methods that cannot be patched are reported per method as `Skipped`
+or `Failed`; one unpatchable method never aborts the rest of the run.
 
 ## Usage
 
@@ -28,7 +29,7 @@ consume exactly one value token.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
-| `--revert-all` | flag | - | Remove every active hot-reload transplant and clear the patch ledger. When set, `--files` is ignored |
+| `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 
 ## How it works
 
@@ -58,8 +59,8 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Explicit interface implementation | Dotted metadata names cannot be expressed as shim identifiers |
 | No body (`abstract` / `extern`) | Nothing to transplant |
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
-| Lambda, local function, or LINQ query in the body accesses private/internal members | Closure bodies run from the shim assembly, where that access fails runtime accessibility checks; only the named method's IL is transplanted |
-| `async` or iterator body accesses private/internal members | Same as above — the state machine's `MoveNext` runs from the shim assembly |
+| Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
+| An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`
 
@@ -71,6 +72,7 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
 | Patch rejected at apply time (e.g. `[BurstCompile]`) | Not patchable by Harmony transplant |
+| Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 
 ## Convergence and lifecycle
 

--- a/Assets/Tests/Editor/HotReload/HotReloadCoreFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCoreFixtures.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
     /// <summary>
@@ -8,6 +10,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public class HotReloadCoreFixture
     {
         public int VoidHits;
+
+        // Public surface the JIT-legal delegation shim may touch (no private/internal access).
+        public int PublicSeed = 10;
 
         public int Add(int left, int right)
         {
@@ -32,6 +37,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         // Sentinel return proves the original body ran before a transplant replaces it.
         public int ReplaceableCompute(int delta)
         {
+            return -1 * delta;
+        }
+
+        // Delegation target: sentinel proves the original async body ran before forwarding.
+        public async Task<int> ReplaceableComputeAsync(int delta)
+        {
+            await Task.Yield();
             return -1 * delta;
         }
     }
@@ -61,6 +73,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public static int ReplaceableCompute__shim1(HotReloadCoreFixture instance, int delta)
         {
             return delta + 99;
+        }
+
+        // JIT-legal async shim: touches only public fixture members so normal JIT succeeds.
+        public static async Task<int> ReplaceableComputeAsync__shim0(
+            HotReloadCoreFixture instance,
+            int delta)
+        {
+            await Task.Yield();
+            return instance.PublicSeed + delta + 1;
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -173,5 +174,56 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             await Task.Yield();
             Current.Value += 1;
         }
+
+        private void BumpSecretBy(int amount)
+        {
+            _secret += amount;
+        }
+
+        private int HiddenScore { get; set; } = 3;
+
+        // v2 e2e (1): async body with private field write + private method call.
+        public async Task<int> AsyncPrivateFieldAndMethod(int delta)
+        {
+            await Task.Yield();
+            return _secret + delta;
+        }
+
+        // v2 e2e (2): iterator body with the same private accesses.
+        public IEnumerator IteratePrivate(int delta)
+        {
+            yield return _secret + delta;
+        }
+
+        // v2 e2e (3): lambda capture reading a private field.
+        public int LambdaPrivate(int threshold)
+        {
+            Func<int, bool> pred = v => v < _secret;
+            return pred(threshold) ? 1 : 0;
+        }
+
+        // v2 e2e (4): private property read/write round-trip.
+        public int PropertyPrivateRoundTrip(int value)
+        {
+            HiddenScore = value;
+            return HiddenScore;
+        }
+
+        // v2 e2e (5): async body that names an internal type — must stay Skipped (condition c).
+        public async Task<int> AsyncUsesInternalType()
+        {
+            await Task.Yield();
+            HotReloadE2EInternalToken token = new HotReloadE2EInternalToken { N = 1 };
+            return token.N;
+        }
+    }
+
+    /// <summary>
+    /// Internal type used only by <see cref="HotReloadE2EFixture.AsyncUsesInternalType"/> to
+    /// pin the v2 "type as type" skip (accessor delegates cannot rescue type mentions).
+    /// </summary>
+    internal class HotReloadE2EInternalToken
+    {
+        public int N;
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -406,6 +406,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: BindShimAccessors invokes each type's public static parameterless
+        /// __BindAccessors, skips types without one, and records a throwing binder as a failure
+        /// keyed by the shim type's short name with the cause message and a compile-and-retry
+        /// hint.
+        /// </summary>
+        [Test]
+        public void BindShimAccessors_ThrowingBinder_IsReportedByShimTypeName()
+        {
+            int callsBefore = HotReloadBindProbeShim.BindCalls;
+
+            Dictionary<string, string> failures = HotReloadOrchestrator.BindShimAccessors(
+                typeof(HotReloadBindFailShim).Assembly);
+
+            Assert.That(HotReloadBindProbeShim.BindCalls, Is.EqualTo(callsBefore + 1));
+            Assert.That(failures.Count, Is.EqualTo(1));
+            Assert.That(failures.ContainsKey(nameof(HotReloadBindFailShim)), Is.True);
+            Assert.That(failures[nameof(HotReloadBindFailShim)], Does.Contain("no such member"));
+            Assert.That(
+                failures[nameof(HotReloadBindFailShim)],
+                Does.Contain("Run 'uloop compile' and retry."));
+        }
+
+        /// <summary>
         /// What: an edited body that calls a non-existent helper fails shim compile with the
         /// new-member hint (Failed, not a silent skip).
         /// </summary>
@@ -636,6 +659,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 }
 ";
+        }
+    }
+
+    /// <summary>
+    /// Shim-shaped fixture whose binder throws, so the BindShimAccessors failure path can be
+    /// pinned without fabricating a shim assembly that compiles but fails to bind.
+    /// </summary>
+    internal static class HotReloadBindFailShim
+    {
+        public static void __BindAccessors()
+        {
+            throw new System.MissingMethodException("no such member");
+        }
+    }
+
+    /// <summary>
+    /// Shim-shaped fixture whose binder succeeds; counts invocations so the test can prove a
+    /// healthy binder is invoked and leaves no failure entry.
+    /// </summary>
+    internal static class HotReloadBindProbeShim
+    {
+        public static int BindCalls;
+
+        public static void __BindAccessors()
+        {
+            BindCalls++;
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -229,6 +230,183 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: hot-reloading an async body that writes a private field and calls a private
+        /// method applies a delegation patch and changes the await result.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedAsyncPrivateFieldAndMethod_PatchesBehavior()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "AsyncPrivateFieldAndMethod.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    asyncPrivateFieldAndMethod:
+                    "public async Task<int> AsyncPrivateFieldAndMethod(int delta)\n        {\n"
+                    + "            await Task.Yield();\n"
+                    + "            _secret += delta;\n"
+                    + "            BumpSecretBy(1);\n"
+                    + "            return _secret;\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.AsyncPrivateFieldAndMethod));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(await fixture.AsyncPrivateFieldAndMethod(5), Is.EqualTo(10 + 5 + 1));
+            Assert.That(fixture.SecretForAssert, Is.EqualTo(10 + 5 + 1));
+        }
+
+        /// <summary>
+        /// What: hot-reloading an iterator body with private field write + private method call
+        /// applies a delegation patch and changes the yielded value.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedIteratorPrivateAccess_PatchesBehavior()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "IteratePrivate.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    iteratePrivateMethod:
+                    "public IEnumerator IteratePrivate(int delta)\n        {\n"
+                    + "            _secret += delta;\n"
+                    + "            BumpSecretBy(1);\n"
+                    + "            yield return _secret;\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.IteratePrivate));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            IEnumerator enumerator = fixture.IteratePrivate(5);
+            Assert.That(enumerator.MoveNext(), Is.True);
+            Assert.That(enumerator.Current, Is.EqualTo(10 + 5 + 1));
+            Assert.That(fixture.SecretForAssert, Is.EqualTo(10 + 5 + 1));
+        }
+
+        /// <summary>
+        /// What: hot-reloading a method whose lambda captures a private field applies a
+        /// delegation patch and changes the returned value.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedLambdaPrivateCapture_PatchesBehavior()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "LambdaPrivate.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    lambdaPrivateMethod:
+                    "public int LambdaPrivate(int threshold)\n        {\n"
+                    + "            System.Func<int, bool> pred = v => v < (_secret + 100);\n"
+                    + "            return pred(threshold) ? 7 : 0;\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.LambdaPrivate));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.LambdaPrivate(5), Is.EqualTo(7));
+        }
+
+        /// <summary>
+        /// What: hot-reloading a method that reads/writes a private property applies a
+        /// delegation patch and changes the round-trip result.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedPrivatePropertyRoundTrip_PatchesBehavior()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "PropertyPrivateRoundTrip.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    propertyPrivateRoundTripMethod:
+                    "public int PropertyPrivateRoundTrip(int value)\n        {\n"
+                    + "            HiddenScore = value + 100;\n"
+                    + "            return HiddenScore;\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.PropertyPrivateRoundTrip));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.PropertyPrivateRoundTrip(5), Is.EqualTo(105));
+        }
+
+        /// <summary>
+        /// What: an async body that names an internal type as a local stays Skipped with a
+        /// type-visibility reason (accessor delegates cannot rescue type mentions).
+        /// </summary>
+        [Test]
+        public async Task Run_AsyncUsesInternalType_IsSkippedWithTypeVisibilityReason()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "AsyncUsesInternalType.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    asyncUsesInternalTypeMethod:
+                    "public async Task<int> AsyncUsesInternalType()\n        {\n"
+                    + "            await Task.Yield();\n"
+                    + "            HotReloadE2EInternalToken token = new HotReloadE2EInternalToken { N = 99 };\n"
+                    + "            return token.N;\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+
+            bool found = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
+                    && outcome.Method.Contains(nameof(HotReloadE2EFixture.AsyncUsesInternalType))
+                    && (outcome.Reason.Contains("not visible")
+                        || outcome.Reason.Contains("condition c")))
+                {
+                    found = true;
+                }
+            }
+
+            Assert.That(
+                found,
+                Is.True,
+                "Expected AsyncUsesInternalType to be Skipped for an inaccessible type mention.\n"
+                + FormatOutcomes(result));
+        }
+
+        /// <summary>
         /// What: an edited body that calls a non-existent helper fails shim compile with the
         /// new-member hint (Failed, not a silent skip).
         /// </summary>
@@ -331,7 +509,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string computeWithPrivateMethod,
             string sumGridMethod = null,
             string callsMissingHelperMethod = null,
-            string queryPrivateMethod = null)
+            string queryPrivateMethod = null,
+            string asyncPrivateFieldAndMethod = null,
+            string iteratePrivateMethod = null,
+            string lambdaPrivateMethod = null,
+            string propertyPrivateRoundTripMethod = null,
+            string asyncUsesInternalTypeMethod = null)
         {
             string sumGrid = sumGridMethod ??
                 "public int SumGrid(int[,] grid)\n        {\n            return -1;\n        }";
@@ -340,8 +523,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string queryPrivate = queryPrivateMethod ??
                 "public int QueryPrivate()\n        {\n            int[] values = { 1, 2, 3 };\n"
                 + "            return (from value in values where value < _secret select value).Count();\n        }";
+            string asyncPrivate = asyncPrivateFieldAndMethod ??
+                "public async Task<int> AsyncPrivateFieldAndMethod(int delta)\n        {\n"
+                + "            await Task.Yield();\n"
+                + "            return _secret + delta;\n"
+                + "        }";
+            string iteratePrivate = iteratePrivateMethod ??
+                "public IEnumerator IteratePrivate(int delta)\n        {\n"
+                + "            yield return _secret + delta;\n"
+                + "        }";
+            string lambdaPrivate = lambdaPrivateMethod ??
+                "public int LambdaPrivate(int threshold)\n        {\n"
+                + "            System.Func<int, bool> pred = v => v < _secret;\n"
+                + "            return pred(threshold) ? 1 : 0;\n"
+                + "        }";
+            string propertyPrivate = propertyPrivateRoundTripMethod ??
+                "public int PropertyPrivateRoundTrip(int value)\n        {\n"
+                + "            HiddenScore = value;\n"
+                + "            return HiddenScore;\n"
+                + "        }";
+            string asyncInternal = asyncUsesInternalTypeMethod ??
+                "public async Task<int> AsyncUsesInternalType()\n        {\n"
+                + "            await Task.Yield();\n"
+                + "            HotReloadE2EInternalToken token = new HotReloadE2EInternalToken { N = 1 };\n"
+                + "            return token.N;\n"
+                + "        }";
 
-            return @"using System.Collections.Generic;
+            return @"using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -375,6 +584,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private int this[int index] => _secret + index;
 
+        private int HiddenScore { get; set; } = 3;
+
+        private void BumpSecretBy(int amount)
+        {
+            _secret += amount;
+        }
+
         " + computeWithPrivateMethod + @"
 
         public int CallsBase()
@@ -403,6 +619,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             return 0;
         }
+
+        " + asyncPrivate + @"
+
+        " + iteratePrivate + @"
+
+        " + lambdaPrivate + @"
+
+        " + propertyPrivate + @"
+
+        " + asyncInternal + @"
+    }
+
+    internal class HotReloadE2EInternalToken
+    {
+        public int N;
     }
 }
 ";

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -392,8 +392,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
                     && outcome.Method.Contains(nameof(HotReloadE2EFixture.AsyncUsesInternalType))
-                    && (outcome.Reason.Contains("not visible")
-                        || outcome.Reason.Contains("condition c")))
+                    && outcome.Reason.Contains("not visible"))
                 {
                     found = true;
                 }

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -198,19 +198,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a mixed transplant+delegation fixture compiles the shim (Harmony ref present),
-        /// transplants the sync private-access method, and reports delegation entries as Skipped
-        /// with the not-wired reason (delegation patcher lands in a later change).
+        /// What: a mixed transplant+delegation fixture patches both the sync private-access
+        /// method (transplant) and the LINQ private-access method (delegation).
         /// </summary>
         [Test]
-        public async Task Run_MixedTransplantAndDelegationFile_PatchesSyncAndSkipsDelegation()
+        public async Task Run_MixedTransplantAndDelegationFile_PatchesBoth()
         {
             string fixturePath = ResolveE2EFixturePath();
             string editedPath = WriteEditedSource(
                 "MixedTransplantDelegation.cs",
                 BuildFixtureSource(
                     computeWithPrivateMethod:
-                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
+                    queryPrivateMethod:
+                    "public int QueryPrivate()\n        {\n            int[] values = { 1, 2, 3 };\n"
+                    + "            return (from value in values where value < _secret select value).Count() + 100;\n        }"));
 
             HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
                 new[] { fixturePath },
@@ -219,26 +221,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             AssertNoFileLevelFailure(result);
             AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.QueryPrivate));
 
             HotReloadE2EFixture fixture = new HotReloadE2EFixture();
             Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(10 + 5 + 100));
-
-            bool foundDelegationSkip = false;
-            foreach (HotReloadMethodOutcome outcome in result.Methods)
-            {
-                if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
-                    && outcome.Method.Contains(nameof(HotReloadE2EFixture.QueryPrivate))
-                    && outcome.Reason == HotReloadConstants.DelegationPatchNotWiredSkipReason)
-                {
-                    foundDelegationSkip = true;
-                }
-            }
-
-            Assert.That(
-                foundDelegationSkip,
-                Is.True,
-                "Expected QueryPrivate to be Skipped with the delegation-not-wired reason.\n"
-                + FormatOutcomes(result));
+            Assert.That(fixture.QueryPrivate(), Is.EqualTo(3 + 100));
         }
 
         /// <summary>
@@ -343,12 +330,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private static string BuildFixtureSource(
             string computeWithPrivateMethod,
             string sumGridMethod = null,
-            string callsMissingHelperMethod = null)
+            string callsMissingHelperMethod = null,
+            string queryPrivateMethod = null)
         {
             string sumGrid = sumGridMethod ??
                 "public int SumGrid(int[,] grid)\n        {\n            return -1;\n        }";
             string callsMissingHelper = callsMissingHelperMethod ??
                 "public int CallsMissingHelper(int value)\n        {\n            return value;\n        }";
+            string queryPrivate = queryPrivateMethod ??
+                "public int QueryPrivate()\n        {\n            int[] values = { 1, 2, 3 };\n"
+                + "            return (from value in values where value < _secret select value).Count();\n        }";
 
             return @"using System.Collections.Generic;
 using System.Linq;
@@ -398,11 +389,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return _secret;
         }
 
-        public int QueryPrivate()
-        {
-            int[] values = { 1, 2, 3 };
-            return (from value in values where value < _secret select value).Count();
-        }
+        " + queryPrivate + @"
 
         public async Task<int> AsyncReadPrivateIndexer()
         {

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 
 using HarmonyLib;
 using NUnit.Framework;
@@ -33,7 +34,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadCoreFixture fixture = new HotReloadCoreFixture();
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(-5), "Precondition: original sentinel body.");
 
-            HotReloadPatchResult result = HotReloadPatcher.Apply(original, shim);
+            HotReloadPatchResult result = HotReloadPatcher.Apply(
+                original, shim, HotReloadPatchShape.Transplant);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(47));
         }
@@ -50,7 +52,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.StaticPing__shim0));
 
             Assert.That(HotReloadCoreFixture.StaticPing(), Is.EqualTo("original"));
-            HotReloadPatchResult result = HotReloadPatcher.Apply(original, shim);
+            HotReloadPatchResult result = HotReloadPatcher.Apply(
+                original, shim, HotReloadPatchShape.Transplant);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(HotReloadCoreFixture.StaticPing(), Is.EqualTo("patched"));
         }
@@ -70,7 +73,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             fixture.VoidBump();
             Assert.That(fixture.VoidHits, Is.EqualTo(-1), "Precondition: original void body.");
 
-            HotReloadPatchResult result = HotReloadPatcher.Apply(original, shim);
+            HotReloadPatchResult result = HotReloadPatcher.Apply(
+                original, shim, HotReloadPatchShape.Transplant);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             fixture.VoidBump();
             Assert.That(fixture.VoidHits, Is.EqualTo(7));
@@ -88,7 +92,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
 
             HotReloadCoreFixture fixture = new HotReloadCoreFixture();
-            Assert.That(HotReloadPatcher.Apply(original, shim).Success, Is.True);
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                Is.True);
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(47));
 
             HotReloadPatcher.RevertAll();
@@ -110,10 +116,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim1));
 
             HotReloadCoreFixture fixture = new HotReloadCoreFixture();
-            Assert.That(HotReloadPatcher.Apply(original, shim0).Success, Is.True);
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim0, HotReloadPatchShape.Transplant).Success,
+                Is.True);
             Assert.That(fixture.ReplaceableCompute(1), Is.EqualTo(43));
 
-            Assert.That(HotReloadPatcher.Apply(original, shim1).Success, Is.True);
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim1, HotReloadPatchShape.Transplant).Success,
+                Is.True);
             Assert.That(fixture.ReplaceableCompute(1), Is.EqualTo(100));
 
             Patches patchInfo = Harmony.GetPatchInfo(original);
@@ -135,9 +145,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             MethodInfo shim = AccessTools.Method(
                 typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
 
-            HotReloadPatchResult result = HotReloadPatcher.Apply(original, shim);
+            HotReloadPatchResult result = HotReloadPatcher.Apply(
+                original, shim, HotReloadPatchShape.Transplant);
             Assert.That(result.Success, Is.False);
             Assert.That(result.FailureReason, Is.EqualTo(HotReloadPatchFailureReason.UnpatchableValueType));
+        }
+
+        /// <summary>
+        /// What: a JIT-legal async shim applied via Delegation changes the await result, and
+        /// RevertAll restores the original sentinel body.
+        /// </summary>
+        [Test]
+        public async Task Apply_DelegationAsyncShim_ChangesBehaviorAndReverts()
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableComputeAsync));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadHandwrittenShims),
+                nameof(HotReloadHandwrittenShims.ReplaceableComputeAsync__shim0));
+
+            HotReloadCoreFixture fixture = new HotReloadCoreFixture();
+            Assert.That(
+                await fixture.ReplaceableComputeAsync(5),
+                Is.EqualTo(-5),
+                "Precondition: original async sentinel body.");
+
+            HotReloadPatchResult result = HotReloadPatcher.Apply(
+                original, shim, HotReloadPatchShape.Delegation);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(await fixture.ReplaceableComputeAsync(5), Is.EqualTo(10 + 5 + 1));
+
+            HotReloadPatcher.RevertAll();
+            Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(0));
+            Assert.That(await fixture.ReplaceableComputeAsync(5), Is.EqualTo(-5));
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -92,11 +92,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "The target assembly is not currently loaded in this AppDomain. Ensure the code path "
             + "that loads it has run, then retry.";
 
-        // Transplant discards the original IL and any prior transpiler output on that method,
-        // so a source pause point on a hot-reloaded method stops firing until domain reload
-        // (or until the method is reverted and re-armed).
+        // Both patch shapes discard the original IL and any prior transpiler output on that
+        // method (delegation replaces the body with a forward to the shim), so a source pause
+        // point on a hot-reloaded method stops firing until domain reload (or until the method
+        // is reverted and re-armed).
         public const string PausePointInteractionWarning =
-            "Hot reload transplant replaces the method body and discards other transpilers on "
+            "A hot-reload patch replaces the method body and discards other transpilers on "
             + "that method; a pause point on a hot-reloaded method will not fire until the patch "
             + "is reverted or a domain reload restores the original IL.";
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -42,11 +42,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // accesses into accessor delegates.
         public const string PatchKindDelegation = "delegation";
 
-        // The delegation patcher is not wired yet: delegation shims compile and load so the
-        // wiring change only needs to bind accessors and patch. Keep a single present-tense
-        // reason so that change can replace this constant and branch wholesale.
-        public const string DelegationPatchNotWiredSkipReason =
-            "Rewritten for delegation patching, which is not wired yet; method left unpatched.";
+        // Name of the parameterless public static binder the worker emits into delegation shim
+        // types. Wire contract with TransformWorker's EmitBindAccessorsMethod — the worker is a
+        // standalone source file that cannot reference this constant, so keep both in sync.
+        public const string ShimBindAccessorsMethodName = "__BindAccessors";
 
         /// <summary>
         /// Returns whether a ScriptAssemblies DLL is a project assembly that may be publicized.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -318,6 +318,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         internal static Dictionary<string, string> BindShimAccessors(Assembly shimAssembly)
         {
+            Debug.Assert(shimAssembly != null, "shimAssembly must not be null.");
+
             Dictionary<string, string> failureReasonByShimTypeName = new Dictionary<string, string>();
             foreach (Type shimType in shimAssembly.GetTypes())
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -313,8 +313,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// delegate) once, before any patch is applied, so no delegation shim can run with
         /// unbound accessor delegates. Returns bind failures keyed by shim type name; every
         /// delegation entry in a failed type becomes Failed instead of being patched.
+        /// Internal so tests can pin the failure contract directly — an end-to-end bind failure
+        /// cannot be fabricated once shim compilation has succeeded against the same assembly.
         /// </summary>
-        private static Dictionary<string, string> BindShimAccessors(Assembly shimAssembly)
+        internal static Dictionary<string, string> BindShimAccessors(Assembly shimAssembly)
         {
             Dictionary<string, string> failureReasonByShimTypeName = new Dictionary<string, string>();
             foreach (Type shimType in shimAssembly.GetTypes())

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -208,6 +208,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
+            Dictionary<string, string> bindFailureReasonByShimTypeName =
+                BindShimAccessors(compileResult.Assembly);
             int patchedCount = 0;
             foreach (TransformWorkerEntryDto entry in workerOutput.entries)
             {
@@ -215,6 +217,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     entry,
                     assemblyName,
                     compileResult.Assembly,
+                    bindFailureReasonByShimTypeName,
                     assemblyResolvePath,
                     warnings);
                 outcomes.Add(outcome);
@@ -231,18 +234,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TransformWorkerEntryDto entry,
             string assemblyName,
             Assembly shimAssembly,
+            IReadOnlyDictionary<string, string> bindFailureReasonByShimTypeName,
             string filePath,
             List<string> warnings)
         {
             string methodLabel = entry.typeMetadataName + "." + entry.methodName;
 
-            // Only "delegation" takes the skip branch; null/empty/anything else is transplant.
-            if (entry.patchKind == HotReloadConstants.PatchKindDelegation)
+            // Only "delegation" selects the forwarding patch; null/empty/anything else is transplant.
+            HotReloadPatchShape patchShape = entry.patchKind == HotReloadConstants.PatchKindDelegation
+                ? HotReloadPatchShape.Delegation
+                : HotReloadPatchShape.Transplant;
+
+            // Transplant entries never read accessor delegates, so a sibling bind failure in the
+            // same shim type must not take them down; only delegation entries depend on the bind.
+            if (patchShape == HotReloadPatchShape.Delegation
+                && bindFailureReasonByShimTypeName.TryGetValue(entry.shimTypeName ?? string.Empty, out string bindFailureReason))
             {
-                return HotReloadMethodOutcome.Skipped(
-                    methodLabel,
-                    HotReloadConstants.DelegationPatchNotWiredSkipReason,
-                    filePath);
+                return HotReloadMethodOutcome.Failed(methodLabel, bindFailureReason, filePath);
             }
 
             string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
@@ -286,7 +294,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     filePath);
             }
 
-            HotReloadPatchResult patchResult = HotReloadPatcher.Apply(matchResult.Method, shimMethod);
+            HotReloadPatchResult patchResult = HotReloadPatcher.Apply(matchResult.Method, shimMethod, patchShape);
             if (!patchResult.Success)
             {
                 return HotReloadMethodOutcome.Failed(methodLabel, patchResult.ErrorMessage, filePath);
@@ -298,6 +306,49 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return HotReloadMethodOutcome.Patched(methodLabel, filePath, patchResult.Warning);
+        }
+
+        /// <summary>
+        /// Invokes each shim type's binder (emitted when the type carries at least one accessor
+        /// delegate) once, before any patch is applied, so no delegation shim can run with
+        /// unbound accessor delegates. Returns bind failures keyed by shim type name; every
+        /// delegation entry in a failed type becomes Failed instead of being patched.
+        /// </summary>
+        private static Dictionary<string, string> BindShimAccessors(Assembly shimAssembly)
+        {
+            Dictionary<string, string> failureReasonByShimTypeName = new Dictionary<string, string>();
+            foreach (Type shimType in shimAssembly.GetTypes())
+            {
+                MethodInfo bindMethod = shimType.GetMethod(
+                    HotReloadConstants.ShimBindAccessorsMethodName,
+                    BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly,
+                    null,
+                    Type.EmptyTypes,
+                    null);
+                if (bindMethod == null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    bindMethod.Invoke(null, null);
+                }
+                catch (TargetInvocationException invocationException)
+                {
+                    // Approved deviation from the no-try-catch rule: a bind failure (the source
+                    // references a member the compiled assembly does not have yet) is an expected
+                    // per-type outcome that must fail that type's methods with a remediation hint,
+                    // not crash the whole hot-reload run. Nothing is swallowed — the cause becomes
+                    // the Failed reason for every affected method.
+                    Exception cause = invocationException.InnerException ?? invocationException;
+                    failureReasonByShimTypeName[shimType.Name] =
+                        "Accessor binding failed for shim type '" + shimType.Name + "': "
+                        + cause.Message + " Run 'uloop compile' and retry.";
+                }
+            }
+
+            return failureReasonByShimTypeName;
         }
 
         private static Type FindShimType(Assembly shimAssembly, string shimTypeName)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchShape.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchShape.cs
@@ -1,0 +1,16 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// How a hot-reload patch replaces the target method's body.
+    /// </summary>
+    internal enum HotReloadPatchShape
+    {
+        // The shim method's IL is copied into the target and runs inside Harmony's
+        // skip-visibility DynamicMethod.
+        Transplant,
+
+        // The target body becomes "forward all arguments to the shim and return". The shim
+        // JIT-compiles normally; its inaccessible accesses were rewritten to accessor delegates.
+        Delegation
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchShape.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchShape.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2751b42670d484e7d802cda29a487f44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -10,8 +10,10 @@ using UnityEngine;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Applies Harmony transplant patches that discard a target method's IL and emit a shim
-    /// method's IL instead, so the body runs inside Harmony's skip-visibility DynamicMethod.
+    /// Applies Harmony patches that replace a target method's body. Transplant copies a shim
+    /// method's IL so it runs inside Harmony's skip-visibility DynamicMethod; delegation
+    /// forwards every argument to a normally-JIT-compiled shim whose inaccessible accesses
+    /// were rewritten to accessor delegates.
     /// </summary>
     internal static class HotReloadPatcher
     {
@@ -20,22 +22,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             typeof(HotReloadPatcher).GetMethod(
                 nameof(ReplaceWithTransplantSourceTranspiler),
                 BindingFlags.NonPublic | BindingFlags.Static);
+        private static readonly MethodInfo DelegationTranspilerMethodInfo =
+            typeof(HotReloadPatcher).GetMethod(
+                nameof(ReplaceWithDelegationTranspiler),
+                BindingFlags.NonPublic | BindingFlags.Static);
 
-        // key = patched original method, value = transplant source shim.
-        private static readonly Dictionary<MethodBase, MethodInfo> ShimByMethod =
-            new Dictionary<MethodBase, MethodInfo>();
+        // Ledger: key = patched original method, value = the shim and how it was applied.
+        private static readonly Dictionary<MethodBase, PatchRecord> RecordByMethod =
+            new Dictionary<MethodBase, PatchRecord>();
 
-        // Harmony resolves transpilers as static methods, so the transplant source cannot be a
-        // parameter. Production looks up the target method in the ledger; the apply path also
-        // stashes the pending shim here so the first Patch call can read it before the ledger
-        // entry exists (Patch invokes the transpiler synchronously on the main thread).
-        private static MethodInfo _pendingTransplantSourceMethod;
+        // Harmony resolves transpilers as static methods, so the shim cannot be a parameter.
+        // Production looks up the target method in the ledger; the apply path also stashes the
+        // pending record here so the first Patch call can read it before the ledger entry
+        // exists (Patch invokes the transpiler synchronously on the main thread).
+        private static PatchRecord _pendingRecord;
 
         /// <summary>
-        /// Transplants <paramref name="shimMethodInfo"/>'s IL into <paramref name="method"/>.
-        /// Re-applying the same method Unpatches the previous transpiler first so patches do not stack.
+        /// Patches <paramref name="method"/> with <paramref name="shimMethodInfo"/> using
+        /// <paramref name="patchShape"/>. Re-applying the same method Unpatches the previous
+        /// transpiler first so patches do not stack.
         /// </summary>
-        public static HotReloadPatchResult Apply(MethodBase method, MethodInfo shimMethodInfo)
+        public static HotReloadPatchResult Apply(
+            MethodBase method,
+            MethodInfo shimMethodInfo,
+            HotReloadPatchShape patchShape)
         {
             if (method == null)
             {
@@ -57,27 +67,31 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return patchability;
             }
 
-            if (ShimByMethod.ContainsKey(method))
+            if (RecordByMethod.ContainsKey(method))
             {
-                // A second hot reload of the same method must replace the previous transplant;
+                // A second hot reload of the same method must replace the previous patch;
                 // leaving it in place would stack transpilers and run discarded IL chains.
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
-                ShimByMethod.Remove(method);
+                RecordByMethod.Remove(method);
             }
 
+            MethodInfo transpilerMethodInfo = patchShape == HotReloadPatchShape.Delegation
+                ? DelegationTranspilerMethodInfo
+                : TransplantTranspilerMethodInfo;
+
             // Ledger is updated after Patch succeeds. During Patch the transpiler reads the
-            // pending field because Harmony resolves transpilers statically (no MethodInfo arg).
-            _pendingTransplantSourceMethod = shimMethodInfo;
+            // pending record because Harmony resolves transpilers statically (no MethodInfo arg).
+            _pendingRecord = new PatchRecord(shimMethodInfo, patchShape);
             try
             {
                 HarmonyInstance.Patch(
                     method,
-                    transpiler: new HarmonyMethod(TransplantTranspilerMethodInfo));
-                ShimByMethod[method] = shimMethodInfo;
+                    transpiler: new HarmonyMethod(transpilerMethodInfo));
+                RecordByMethod[method] = new PatchRecord(shimMethodInfo, patchShape);
             }
             finally
             {
-                _pendingTransplantSourceMethod = null;
+                _pendingRecord = default;
             }
 
             string warning = IsLikelyJitInlined(method)
@@ -87,27 +101,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Removes every hot-reload transplant owned by this patcher and clears the ledger.
+        /// Removes every hot-reload patch owned by this patcher and clears the ledger.
         /// </summary>
         public static void RevertAll()
         {
             HarmonyInstance.UnpatchAll(HotReloadConstants.HarmonyId);
-            ShimByMethod.Clear();
-            _pendingTransplantSourceMethod = null;
+            RecordByMethod.Clear();
+            _pendingRecord = default;
         }
 
         /// <summary>
-        /// How many methods currently have an active transplant recorded in the ledger.
+        /// How many methods currently have an active patch recorded in the ledger.
         /// </summary>
-        public static int ActivePatchCount => ShimByMethod.Count;
+        public static int ActivePatchCount => RecordByMethod.Count;
 
         private static IEnumerable<CodeInstruction> ReplaceWithTransplantSourceTranspiler(
             IEnumerable<CodeInstruction> instructions,
             ILGenerator generator,
             MethodBase original)
         {
-            MethodInfo shimMethod = ResolveTransplantSource(original);
-            Debug.Assert(shimMethod != null, "Transplant source must be registered before Patch runs.");
+            MethodInfo shimMethod = ResolveShimMethod(original);
+            Debug.Assert(shimMethod != null, "Shim must be registered before Patch runs.");
             // Discard the original (and any prior transpiler) instructions entirely — the shim IL
             // is the whole replacement body.
             // Read shim IL without letting MethodBodyReader declare locals on a throwaway path, then
@@ -118,6 +132,125 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 new List<CodeInstruction>(PatchProcessor.GetOriginalInstructions(shimMethod));
             RebindShortFormLocals(shimMethod, generator, transplanted);
             return transplanted;
+        }
+
+        // Why discard the original instructions: the delegation body is a plain forward — load
+        // every argument slot (slot 0 is `this` for instance methods), call the shim, return its
+        // result. The shim was compiled without skip-visibility, so it JIT-compiles normally and
+        // its accessor delegates reach the members this assembly boundary would otherwise forbid.
+        private static IEnumerable<CodeInstruction> ReplaceWithDelegationTranspiler(
+            IEnumerable<CodeInstruction> instructions,
+            MethodBase original)
+        {
+            MethodInfo shimMethod = ResolveShimMethod(original);
+            Debug.Assert(shimMethod != null, "Shim must be registered before Patch runs.");
+
+            int argumentSlotCount = original.GetParameters().Length + (original.IsStatic ? 0 : 1);
+            Debug.Assert(
+                argumentSlotCount == shimMethod.GetParameters().Length,
+                "Shim parameter count must equal the original's argument slots (instance receiver included).");
+
+            List<CodeInstruction> forwarding = new List<CodeInstruction>(argumentSlotCount + 2);
+            for (int slot = 0; slot < argumentSlotCount; slot++)
+            {
+                forwarding.Add(CreateLoadArgumentInstruction(slot));
+            }
+
+            forwarding.Add(new CodeInstruction(OpCodes.Call, shimMethod));
+            forwarding.Add(new CodeInstruction(OpCodes.Ret));
+            return forwarding;
+        }
+
+        private static CodeInstruction CreateLoadArgumentInstruction(int slot)
+        {
+            Debug.Assert(
+                slot >= 0 && slot <= byte.MaxValue,
+                "Argument slot must fit Ldarg_S's byte operand.");
+
+            if (slot == 0)
+            {
+                return new CodeInstruction(OpCodes.Ldarg_0);
+            }
+
+            if (slot == 1)
+            {
+                return new CodeInstruction(OpCodes.Ldarg_1);
+            }
+
+            if (slot == 2)
+            {
+                return new CodeInstruction(OpCodes.Ldarg_2);
+            }
+
+            if (slot == 3)
+            {
+                return new CodeInstruction(OpCodes.Ldarg_3);
+            }
+
+            return new CodeInstruction(OpCodes.Ldarg_S, (byte)slot);
+        }
+
+        private static MethodInfo ResolveShimMethod(MethodBase original)
+        {
+            if (RecordByMethod.TryGetValue(original, out PatchRecord record))
+            {
+                return record.ShimMethod;
+            }
+
+            return _pendingRecord.ShimMethod;
+        }
+
+        private readonly struct PatchRecord
+        {
+            public MethodInfo ShimMethod { get; }
+            public HotReloadPatchShape Shape { get; }
+
+            public PatchRecord(MethodInfo shimMethod, HotReloadPatchShape shape)
+            {
+                ShimMethod = shimMethod;
+                Shape = shape;
+            }
+        }
+
+        private static HotReloadPatchResult CheckPatchable(MethodBase method)
+        {
+            if (method.IsAbstract)
+            {
+                return HotReloadPatchResult.Failure(
+                    HotReloadPatchFailureReason.UnpatchableAbstract,
+                    $"'{method}' is abstract and has no method body to patch.");
+            }
+
+            if (method.GetMethodBody() == null)
+            {
+                return HotReloadPatchResult.Failure(
+                    HotReloadPatchFailureReason.UnpatchableExtern,
+                    $"'{method}' has no IL method body (extern or an internal call) and cannot be patched.");
+            }
+
+            if (method.ContainsGenericParameters)
+            {
+                return HotReloadPatchResult.Failure(
+                    HotReloadPatchFailureReason.UnpatchableOpenGeneric,
+                    $"'{method}' is declared with unresolved generic type parameters and cannot be safely patched.");
+            }
+
+            if (HasBurstCompileAttribute(method) || HasBurstCompileAttribute(method.DeclaringType))
+            {
+                return HotReloadPatchResult.Failure(
+                    HotReloadPatchFailureReason.UnpatchableBurstCompiled,
+                    $"'{method}' (or its declaring type) is marked [BurstCompile] and cannot be patched.");
+            }
+
+            // Value-type instance transplant needs byref `this` semantics that v1 has not validated.
+            if (method.DeclaringType != null && method.DeclaringType.IsValueType)
+            {
+                return HotReloadPatchResult.Failure(
+                    HotReloadPatchFailureReason.UnpatchableValueType,
+                    $"'{method}' is declared on a value type; struct method transplant is out of scope for v1.");
+            }
+
+            return HotReloadPatchResult.SuccessResult();
         }
 
         private static void RebindShortFormLocals(
@@ -251,57 +384,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return -1;
-        }
-
-        private static MethodInfo ResolveTransplantSource(MethodBase original)
-        {
-            if (ShimByMethod.TryGetValue(original, out MethodInfo shimMethod))
-            {
-                return shimMethod;
-            }
-
-            return _pendingTransplantSourceMethod;
-        }
-
-        private static HotReloadPatchResult CheckPatchable(MethodBase method)
-        {
-            if (method.IsAbstract)
-            {
-                return HotReloadPatchResult.Failure(
-                    HotReloadPatchFailureReason.UnpatchableAbstract,
-                    $"'{method}' is abstract and has no method body to patch.");
-            }
-
-            if (method.GetMethodBody() == null)
-            {
-                return HotReloadPatchResult.Failure(
-                    HotReloadPatchFailureReason.UnpatchableExtern,
-                    $"'{method}' has no IL method body (extern or an internal call) and cannot be patched.");
-            }
-
-            if (method.ContainsGenericParameters)
-            {
-                return HotReloadPatchResult.Failure(
-                    HotReloadPatchFailureReason.UnpatchableOpenGeneric,
-                    $"'{method}' is declared with unresolved generic type parameters and cannot be safely patched.");
-            }
-
-            if (HasBurstCompileAttribute(method) || HasBurstCompileAttribute(method.DeclaringType))
-            {
-                return HotReloadPatchResult.Failure(
-                    HotReloadPatchFailureReason.UnpatchableBurstCompiled,
-                    $"'{method}' (or its declaring type) is marked [BurstCompile] and cannot be patched.");
-            }
-
-            // Value-type instance transplant needs byref `this` semantics that v1 has not validated.
-            if (method.DeclaringType != null && method.DeclaringType.IsValueType)
-            {
-                return HotReloadPatchResult.Failure(
-                    HotReloadPatchFailureReason.UnpatchableValueType,
-                    $"'{method}' is declared on a value type; struct method transplant is out of scope for v1.");
-            }
-
-            return HotReloadPatchResult.SuccessResult();
         }
 
         private static bool HasBurstCompileAttribute(MemberInfo member)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -27,15 +27,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 nameof(ReplaceWithDelegationTranspiler),
                 BindingFlags.NonPublic | BindingFlags.Static);
 
-        // Ledger: key = patched original method, value = the shim and how it was applied.
-        private static readonly Dictionary<MethodBase, PatchRecord> RecordByMethod =
-            new Dictionary<MethodBase, PatchRecord>();
+        // Ledger: key = patched original method, value = the shim whose call replaced it.
+        private static readonly Dictionary<MethodBase, MethodInfo> ShimByMethod =
+            new Dictionary<MethodBase, MethodInfo>();
 
         // Harmony resolves transpilers as static methods, so the shim cannot be a parameter.
         // Production looks up the target method in the ledger; the apply path also stashes the
-        // pending record here so the first Patch call can read it before the ledger entry
+        // pending shim here so the first Patch call can read it before the ledger entry
         // exists (Patch invokes the transpiler synchronously on the main thread).
-        private static PatchRecord _pendingRecord;
+        private static MethodInfo _pendingShimMethod;
 
         /// <summary>
         /// Patches <paramref name="method"/> with <paramref name="shimMethodInfo"/> using
@@ -67,12 +67,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return patchability;
             }
 
-            if (RecordByMethod.ContainsKey(method))
+            if (ShimByMethod.ContainsKey(method))
             {
                 // A second hot reload of the same method must replace the previous patch;
                 // leaving it in place would stack transpilers and run discarded IL chains.
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
-                RecordByMethod.Remove(method);
+                ShimByMethod.Remove(method);
             }
 
             MethodInfo transpilerMethodInfo = patchShape == HotReloadPatchShape.Delegation
@@ -80,18 +80,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 : TransplantTranspilerMethodInfo;
 
             // Ledger is updated after Patch succeeds. During Patch the transpiler reads the
-            // pending record because Harmony resolves transpilers statically (no MethodInfo arg).
-            _pendingRecord = new PatchRecord(shimMethodInfo, patchShape);
+            // pending shim because Harmony resolves transpilers statically (no MethodInfo arg).
+            _pendingShimMethod = shimMethodInfo;
             try
             {
                 HarmonyInstance.Patch(
                     method,
                     transpiler: new HarmonyMethod(transpilerMethodInfo));
-                RecordByMethod[method] = new PatchRecord(shimMethodInfo, patchShape);
+                ShimByMethod[method] = shimMethodInfo;
             }
             finally
             {
-                _pendingRecord = default;
+                _pendingShimMethod = null;
             }
 
             string warning = IsLikelyJitInlined(method)
@@ -106,14 +106,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static void RevertAll()
         {
             HarmonyInstance.UnpatchAll(HotReloadConstants.HarmonyId);
-            RecordByMethod.Clear();
-            _pendingRecord = default;
+            ShimByMethod.Clear();
+            _pendingShimMethod = null;
         }
 
         /// <summary>
         /// How many methods currently have an active patch recorded in the ledger.
         /// </summary>
-        public static int ActivePatchCount => RecordByMethod.Count;
+        public static int ActivePatchCount => ShimByMethod.Count;
 
         private static IEnumerable<CodeInstruction> ReplaceWithTransplantSourceTranspiler(
             IEnumerable<CodeInstruction> instructions,
@@ -192,24 +192,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static MethodInfo ResolveShimMethod(MethodBase original)
         {
-            if (RecordByMethod.TryGetValue(original, out PatchRecord record))
+            if (ShimByMethod.TryGetValue(original, out MethodInfo shimMethod))
             {
-                return record.ShimMethod;
+                return shimMethod;
             }
 
-            return _pendingRecord.ShimMethod;
-        }
-
-        private readonly struct PatchRecord
-        {
-            public MethodInfo ShimMethod { get; }
-            public HotReloadPatchShape Shape { get; }
-
-            public PatchRecord(MethodInfo shimMethod, HotReloadPatchShape shape)
-            {
-                ShimMethod = shimMethod;
-                Shape = shape;
-            }
+            return _pendingShimMethod;
         }
 
         private static HotReloadPatchResult CheckPatchable(MethodBase method)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -149,7 +149,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> warnings = new List<string>(result.Warnings);
             if (result.PatchedTotal > 0)
             {
-                // Always surface the pause-point interaction when any transplant was applied.
+                // Always surface the pause-point interaction when any patch was applied.
                 warnings.Add(HotReloadConstants.PausePointInteractionWarning);
             }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -86,10 +86,11 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 
 ## Pause point interaction
 
-A hot-reload transplant discards the original IL and any prior transpiler output on that
-method, so a source pause point on a hot-reloaded method stops firing until the patch is
-reverted (`--revert-all`) or a domain reload restores the original IL. Apply responses
-include this as a `Warnings` entry whenever any method was patched.
+Both patch shapes discard the original IL and any prior transpiler output on the patched
+method — delegation replaces the body with a forward to the shim — so a source pause point
+on a hot-reloaded method stops firing until the patch is reverted (`--revert-all`) or a
+domain reload restores the original IL. Apply responses include this as a `Warnings` entry
+whenever any method was patched.
 
 ## Output
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -34,14 +34,14 @@ consume exactly one value token.
 ## How it works
 
 1. Resolves each file to its compiled assembly via `CompilationPipeline`.
-2. Rewrites each editable method body into a static shim in an out-of-process Roslyn worker.
-3. Compiles the shims against publicized reference copies and loads the result into the Editor domain.
-4. Transplants each shim's IL into the original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`).
+2. Rewrites each editable method body into a static shim in an out-of-process Roslyn worker. When an async, iterator, lambda, local-function, or LINQ-query body touches private/internal members, those accesses are rewritten to accessor delegates so the body can compile and run from the shim assembly (the delegation shape below).
+3. Compiles the shims against publicized reference copies, loads the result into the Editor domain, and binds every shim type's accessor delegates (`__BindAccessors`) before any patch is applied.
+4. Patches each original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`) in one of two shapes: transplant copies the shim's IL into the original method, while delegation rewrites the original to forward its arguments to the shim, which runs as normally compiled code.
 
 Re-running on the same method replaces its previous patch; `ActivePatchTotal` tracks the
 ledger across runs.
 
-## Scope and limits (v1)
+## Scope and limits
 
 Only ordinary method declarations are scanned. Property and indexer accessors, constructors,
 finalizers, operators, and event accessors are never scanned: edits to them produce **no
@@ -54,7 +54,7 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Condition | Why |
 |-----------|-----|
 | Method on a `partial` type (including a type nested inside a partial outer type) | A single file cannot provide a complete semantic model |
-| Method on a struct (value type) | Value-type transplant is out of v1 scope |
+| Method on a struct (value type) | Value-type patching is out of scope |
 | Generic method, or method on a generic type | Harmony cannot safely patch open generics |
 | Explicit interface implementation | Dotted metadata names cannot be expressed as shim identifiers |
 | No body (`abstract` / `extern`) | Nothing to transplant |

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -9,8 +9,9 @@ description: "Apply method-body hot reload to edited C# sources in a running Uni
 Replaces method bodies in the running Editor (EditMode or PlayMode) directly from edited
 project source files — no domain reload, no attributes, no source markers. Private/internal
 member access, static methods, return values, async methods, and iterators all work within
-the v1 limits below. Methods that cannot be patched are reported per method as `Skipped` or
-`Failed`; one unpatchable method never aborts the rest of the run.
+the limits below — including private access inside async, iterator, lambda, local-function,
+and LINQ-query bodies. Methods that cannot be patched are reported per method as `Skipped`
+or `Failed`; one unpatchable method never aborts the rest of the run.
 
 ## Usage
 
@@ -28,7 +29,7 @@ consume exactly one value token.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
-| `--revert-all` | flag | - | Remove every active hot-reload transplant and clear the patch ledger. When set, `--files` is ignored |
+| `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 
 ## How it works
 
@@ -58,8 +59,8 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Explicit interface implementation | Dotted metadata names cannot be expressed as shim identifiers |
 | No body (`abstract` / `extern`) | Nothing to transplant |
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
-| Lambda, local function, or LINQ query in the body accesses private/internal members | Closure bodies run from the shim assembly, where that access fails runtime accessibility checks; only the named method's IL is transplanted |
-| `async` or iterator body accesses private/internal members | Same as above — the state machine's `MoveNext` runs from the shim assembly |
+| Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
+| An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`
 
@@ -71,6 +72,7 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
 | Patch rejected at apply time (e.g. `[BurstCompile]`) | Not patchable by Harmony transplant |
+| Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 
 ## Convergence and lifecycle
 

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -757,7 +757,7 @@
           },
           "RevertAll": {
             "type": "boolean",
-            "description": "Remove every active hot-reload transplant and clear the patch ledger. When set, --files is ignored"
+            "description": "Remove every active hot-reload patch and clear the patch ledger. When set, --files is ignored"
           }
         }
       }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "be4a33421c86ac76847440ec0ae0a71ffd0e4865"
+  "sharedInputsHash": "e4df659b90c264e6076a50d42d6a00f37d3e0ea0"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "82863563e5c0551929f1a636fb15fb5bbc7d0803"
+  "sharedInputsHash": "29f2a6233d6c747af0b22d4987e4657faf55b189"
 }

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -141,30 +141,39 @@ semantic model):
   same reason: their bodies compile into closure methods of the shim assembly, which
   JIT-compile normally when the delegate is invoked.
 
-### v2 (planned): accessor delegation for async, iterator, and closure bodies
+### v2: accessor delegation for async, iterator, and closure bodies
 
-Status: committed follow-up stage, not yet implemented. The async case is pinned by the S1
-spike tests (method-delegate accessor and delegation transpiler); iterator and closure bodies
-ride the same JIT-legality mechanism and must be verified by that stage's end-to-end tests
-before being documented as supported.
+Status: implemented. The worker rewrite path (PR-6) and the orchestrator bind + delegation
+patch path (PR-7) are wired; EditMode e2e covers async, iterator, lambda-capture, and private
+property round-trips, plus the internal-type skip.
 
 v2 lifts the two v1 boundaries above by rewriting the inaccessible accesses instead of
 transplanting the IL. For a method that v1 would skip only because its async/iterator/closure
 body touches inaccessible members, the worker rewrites each such access into a call through a
 generated accessor delegate field (`AccessTools.FieldRef` for fields; open-instance delegates
 for methods and property accessors). The rewritten shim is JIT-legal, so the original method
-is patched with the delegation transpiler instead of the transplant transpiler.
+is patched with the **delegation** transpiler: discard the original body and emit
+"load every argument slot → `Call` the shim → `Ret`". The shim itself JIT-compiles normally;
+its accessor delegates reach members the shim assembly boundary would otherwise forbid.
 
-- The shim self-binds: a generated `__BindAccessors()` method assigns the delegate fields via
-  Harmony's string-based `AccessTools` lookups, and the loader invokes it once after
-  `Assembly.Load`, before patching. The binding code only references public Harmony APIs,
-  `typeof` of accessible types, and string literals, so it JIT-compiles legally.
+Wire details:
+
+- Manifest `patchKind` is `"delegation"` when the worker applied accessor rewrite, otherwise
+  `"transplant"` (or absent — treated as transplant).
+- After `Assembly.Load` of the shim assembly and **before** any Harmony patch is applied, the
+  orchestrator reflects over each shim type and invokes `__BindAccessors()` once when present
+  (parameterless `public static`). Types with no accessor delegates simply have no binder.
+- Bind failure (for example the source names a member the compiled assembly does not have yet)
+  fails **only that shim type's delegation entries** with a remediation hint to run
+  `uloop compile`. Transplant entries that share the same shim type are not taken down —
+  they never read accessor delegates.
 - Scope constraint: the rewrite applies only when the containing type and every type
   appearing in an accessor signature (instance type, field type, parameter and return types)
   is accessible to a foreign assembly. Inaccessible member *names* are fine; inaccessible
   *types as types* (locals, casts, `new`, signatures) are not rewritable and keep the skip.
-- Still skipped in v2: bodies using internal types as types (above), private callees with
-  `ref`/`out` parameters, and event add/remove on inaccessible events.
+- Still skipped in v2: bodies using internal types as types (above), private accesses with no
+  accessor-delegate shape (conditional access, indexers, static field writes, and the other
+  condition-b cases in the skill), and event add/remove on inaccessible events.
 
 ## Convergence and Lifecycle
 


### PR DESCRIPTION
## Summary
- Hot reload can now apply edited async, iterator, lambda, and LINQ bodies that touch private/internal members, without a domain reload.
- Delegation shims bind their accessor delegates once after load, and bind failures surface as per-method `Failed` outcomes with a compile-and-retry hint.

## User Impact
- Before: private access inside async/iterator/closure bodies was left unpatched (`Skipped` / not wired).
- After: those methods patch through the delegation path when the worker can rewrite the accesses; remaining unsupported shapes and inaccessible type mentions still skip with explicit reasons.

## Changes
- Add a delegation Harmony patch shape that forwards every argument slot to the shim.
- Invoke `__BindAccessors` per shim type after load and before patching; only that type's delegation entries fail on bind errors.
- Cover patcher delegation apply/revert, mixed transplant+delegation, and five orchestrator e2e scenarios.
- Update skill tables, generated catalog copy, and the hot-reload design notes for the wired v2 path.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, 0/0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value 'HotReload' --project-path "$(git rev-parse --show-toplevel)"` → 53 Passed / 0 Failed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

