### PR TITLE
feat: warn when edited const values cannot take effect through hot reload

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -47,7 +47,7 @@ Only ordinary method declarations are scanned. Property and indexer accessors, c
 finalizers, operators, and event accessors are never scanned: edits to them produce **no
 per-method entry at all** and are silently not applied — use `uloop compile` for those.
 
-Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Use `uloop compile` for such edits.
+Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
 
 ### Skipped — reported per method, never flips `Success`
 

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -98,7 +98,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
-- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), and the pause-point interaction above
+- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -47,7 +47,7 @@ Only ordinary method declarations are scanned. Property and indexer accessors, c
 finalizers, operators, and event accessors are never scanned: edits to them produce **no
 per-method entry at all** and are silently not applied — use `uloop compile` for those.
 
-Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Use `uloop compile` for such edits.
+Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
 
 ### Skipped — reported per method, never flips `Success`
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -98,7 +98,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
-- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), and the pause-point interaction above
+- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -39,6 +39,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public class HotReloadE2EFixture : HotReloadE2EBase, IHotReloadE2EMarker
     {
         private int _secret = 10;
+        // Const drift e2e: the test template pairs this with an injectable declaration so a
+        // test can change only the value.
+        private const int TuningConst = 3;
         private Action _callback;
         private int? Score { get; set; }
         private int Value { get; set; }

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -32,6 +32,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 
     /// <summary>
+    /// Const drift e2e enum: the test template pairs this with an injectable declaration so a
+    /// test can change only a member value.
+    /// </summary>
+    public enum HotReloadE2EMode
+    {
+        Idle = 0,
+        Active = 1
+    }
+
+    /// <summary>
     /// Compiled fixture whose on-disk source path is passed as <c>files[]</c> to the
     /// orchestrator. Edited copies for worker input live under
     /// <c>Library/UloopHotReload/TestSources/</c> (never under Assets).

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -619,6 +619,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + string.Join("\n", result.Warnings));
         }
 
+        /// <summary>
+        /// What: partial declarations of one type in a single edited file produce exactly one
+        /// drift warning per const, not one per declaration.
+        /// </summary>
+        [Test]
+        public async Task Run_PartialTypeConst_WarnsOnce()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "PartialConstDrift.cs",
+                "namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload\n"
+                + "{\n"
+                + "    public partial class HotReloadE2EFixture\n"
+                + "    {\n"
+                + "        private const int TuningConst = 6;\n"
+                + "    }\n"
+                + "\n"
+                + "    public partial class HotReloadE2EFixture\n"
+                + "    {\n"
+                + "    }\n"
+                + "}\n");
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+
+            int driftCount = 0;
+            foreach (string warning in result.Warnings)
+            {
+                if (warning.Contains("TuningConst"))
+                {
+                    driftCount++;
+                }
+            }
+
+            Assert.That(
+                driftCount,
+                Is.EqualTo(1),
+                "Expected exactly one drift warning for TuningConst.\n"
+                + string.Join("\n", result.Warnings));
+        }
+
         private static void AssertNoFileLevelFailure(HotReloadOrchestratorResult result)
         {
             foreach (HotReloadMethodOutcome outcome in result.Methods)

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -494,7 +494,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             foreach (string warning in result.Warnings)
             {
                 if (warning.Contains("TuningConst")
-                    && warning.Contains("is 4 in the edited source but 3 in the compiled assembly"))
+                    && warning.Contains("is 4 in the edited source but 3 in the compiled assembly")
+                    && warning.Contains("uloop compile"))
                 {
                     foundDrift = true;
                 }
@@ -563,7 +564,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             foreach (string warning in result.Warnings)
             {
                 if (warning.Contains("HotReloadE2EMode.Active")
-                    && warning.Contains("is 2 in the edited source but 1 in the compiled assembly"))
+                    && warning.Contains("is 2 in the edited source but 1 in the compiled assembly")
+                    && warning.Contains("uloop compile"))
                 {
                     foundDrift = true;
                 }
@@ -606,7 +608,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             foreach (string warning in result.Warnings)
             {
                 if (warning.Contains("TuningConst")
-                    && warning.Contains("is 5 in the edited source but 3 in the compiled assembly"))
+                    && warning.Contains("is 5 in the edited source but 3 in the compiled assembly")
+                    && warning.Contains("uloop compile"))
                 {
                     foundDrift = true;
                 }

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -466,6 +466,76 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + FormatOutcomes(result));
         }
 
+        /// <summary>
+        /// What: editing a const value emits a drift warning naming both values while the run
+        /// itself stays successful (methods still patch).
+        /// </summary>
+        [Test]
+        public async Task Run_EditedConstValue_WarnsConstDrift()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "ConstDrift.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    tuningConstDeclaration:
+                    "private const int TuningConst = 4;"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            bool foundDrift = false;
+            foreach (string warning in result.Warnings)
+            {
+                if (warning.Contains("TuningConst")
+                    && warning.Contains("is 4 in the edited source but 3 in the compiled assembly"))
+                {
+                    foundDrift = true;
+                }
+            }
+
+            Assert.That(
+                foundDrift,
+                Is.True,
+                "Expected a const drift warning for TuningConst.\n"
+                + string.Join("\n", result.Warnings));
+        }
+
+        /// <summary>
+        /// What: an unchanged const produces no drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnchangedConst_HasNoDriftWarning()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "ConstUnchanged.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+
+            foreach (string warning in result.Warnings)
+            {
+                Assert.That(
+                    warning.Contains("TuningConst"),
+                    Is.False,
+                    "Unexpected drift warning: " + warning);
+            }
+        }
+
         private static void AssertNoFileLevelFailure(HotReloadOrchestratorResult result)
         {
             foreach (HotReloadMethodOutcome outcome in result.Methods)
@@ -536,7 +606,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string iteratePrivateMethod = null,
             string lambdaPrivateMethod = null,
             string propertyPrivateRoundTripMethod = null,
-            string asyncUsesInternalTypeMethod = null)
+            string asyncUsesInternalTypeMethod = null,
+            string tuningConstDeclaration = null)
         {
             string sumGrid = sumGridMethod ??
                 "public int SumGrid(int[,] grid)\n        {\n            return -1;\n        }";
@@ -570,6 +641,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "            HotReloadE2EInternalToken token = new HotReloadE2EInternalToken { N = 1 };\n"
                 + "            return token.N;\n"
                 + "        }";
+            string tuningConst = tuningConstDeclaration ??
+                "private const int TuningConst = 3;";
 
             return @"using System.Collections;
 using System.Collections.Generic;
@@ -599,6 +672,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public class HotReloadE2EFixture : HotReloadE2EBase, IHotReloadE2EMarker
     {
         private int _secret = 10;
+        " + tuningConst + @"
 
         public int SecretForAssert => _secret;
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -536,6 +536,89 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
         }
 
+        /// <summary>
+        /// What: editing an enum member value emits a drift warning naming both values; enum
+        /// members ride the same const drift detection as class consts.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedEnumMemberValue_WarnsConstDrift()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "EnumDrift.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    modeEnumDeclaration:
+                    "public enum HotReloadE2EMode\n    {\n        Idle = 0,\n        Active = 2\n    }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+
+            bool foundDrift = false;
+            foreach (string warning in result.Warnings)
+            {
+                if (warning.Contains("HotReloadE2EMode.Active")
+                    && warning.Contains("is 2 in the edited source but 1 in the compiled assembly"))
+                {
+                    foundDrift = true;
+                }
+            }
+
+            Assert.That(
+                foundDrift,
+                Is.True,
+                "Expected an enum member drift warning for HotReloadE2EMode.Active.\n"
+                + string.Join("\n", result.Warnings));
+        }
+
+        /// <summary>
+        /// What: a const-only edited source (no method bodies, so no shim and no entries) still
+        /// surfaces the drift warning through the empty-entries early return.
+        /// </summary>
+        [Test]
+        public async Task Run_ConstOnlyEditedSource_StillWarnsConstDrift()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "ConstOnlyDrift.cs",
+                "namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload\n"
+                + "{\n"
+                + "    public class HotReloadE2EFixture\n"
+                + "    {\n"
+                + "        private const int TuningConst = 5;\n"
+                + "    }\n"
+                + "}\n");
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            Assert.That(result.PatchedTotal, Is.EqualTo(0));
+
+            bool foundDrift = false;
+            foreach (string warning in result.Warnings)
+            {
+                if (warning.Contains("TuningConst")
+                    && warning.Contains("is 5 in the edited source but 3 in the compiled assembly"))
+                {
+                    foundDrift = true;
+                }
+            }
+
+            Assert.That(
+                foundDrift,
+                Is.True,
+                "Expected a const drift warning from the const-only early-return path.\n"
+                + string.Join("\n", result.Warnings));
+        }
+
         private static void AssertNoFileLevelFailure(HotReloadOrchestratorResult result)
         {
             foreach (HotReloadMethodOutcome outcome in result.Methods)
@@ -607,7 +690,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string lambdaPrivateMethod = null,
             string propertyPrivateRoundTripMethod = null,
             string asyncUsesInternalTypeMethod = null,
-            string tuningConstDeclaration = null)
+            string tuningConstDeclaration = null,
+            string modeEnumDeclaration = null)
         {
             string sumGrid = sumGridMethod ??
                 "public int SumGrid(int[,] grid)\n        {\n            return -1;\n        }";
@@ -643,6 +727,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "        }";
             string tuningConst = tuningConstDeclaration ??
                 "private const int TuningConst = 3;";
+            string modeEnum = modeEnumDeclaration ??
+                "public enum HotReloadE2EMode\n    {\n        Idle = 0,\n        Active = 1\n    }";
 
             return @"using System.Collections;
 using System.Collections.Generic;
@@ -651,6 +737,8 @@ using System.Threading.Tasks;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
+    " + modeEnum + @"
+
     public class HotReloadE2EBase
     {
         protected int BaseSeed()

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -176,6 +176,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
+            if (workerOutput.declarationDriftWarnings != null)
+            {
+                // Surfaced before the empty-entries early return so const drift still reaches
+                // the response when every method in the file is skipped or unchanged.
+                foreach (string driftWarning in workerOutput.declarationDriftWarnings)
+                {
+                    warnings.Add(driftWarning);
+                }
+            }
+
             if (string.IsNullOrEmpty(workerOutput.shimSource)
                 || workerOutput.entries == null
                 || workerOutput.entries.Length == 0)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -47,7 +47,7 @@ Only ordinary method declarations are scanned. Property and indexer accessors, c
 finalizers, operators, and event accessors are never scanned: edits to them produce **no
 per-method entry at all** and are silently not applied — use `uloop compile` for those.
 
-Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Use `uloop compile` for such edits.
+Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
 
 ### Skipped — reported per method, never flips `Success`
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -98,7 +98,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
-- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), and the pause-point interaction above
+- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -24,6 +24,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public TransformWorkerEntryDto[] entries;
         public TransformWorkerSkippedDto[] skipped;
         public string[] parseErrors;
+        public string[] declarationDriftWarnings;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Loader;
@@ -143,12 +144,27 @@ public static class TransformWorkerProgram
             }
         }
 
+        string targetTypesFullPath =
+            !string.IsNullOrEmpty(input.TargetTypesAssemblyPath) && File.Exists(input.TargetTypesAssemblyPath)
+                ? Path.GetFullPath(input.TargetTypesAssemblyPath)
+                : null;
+        MetadataReference targetTypesReference = null;
+
         List<MetadataReference> references = new List<MetadataReference>();
         foreach (string referencePath in input.ReferencePaths)
         {
             if (File.Exists(referencePath))
             {
-                references.Add(MetadataReference.CreateFromFile(referencePath));
+                MetadataReference reference = MetadataReference.CreateFromFile(referencePath);
+                references.Add(reference);
+                if (targetTypesFullPath != null
+                    && string.Equals(
+                        Path.GetFullPath(referencePath),
+                        targetTypesFullPath,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    targetTypesReference = reference;
+                }
             }
             else
             {
@@ -156,35 +172,33 @@ public static class TransformWorkerProgram
             }
         }
 
-        if (!string.IsNullOrEmpty(input.TargetTypesAssemblyPath) && File.Exists(input.TargetTypesAssemblyPath))
+        if (targetTypesFullPath != null && targetTypesReference == null)
         {
-            bool alreadyListed = false;
-            foreach (string referencePath in input.ReferencePaths)
-            {
-                if (string.Equals(
-                        Path.GetFullPath(referencePath),
-                        Path.GetFullPath(input.TargetTypesAssemblyPath),
-                        StringComparison.OrdinalIgnoreCase))
-                {
-                    alreadyListed = true;
-                    break;
-                }
-            }
-
-            if (!alreadyListed)
-            {
-                references.Add(MetadataReference.CreateFromFile(input.TargetTypesAssemblyPath));
-            }
+            targetTypesReference = MetadataReference.CreateFromFile(input.TargetTypesAssemblyPath);
+            references.Add(targetTypesReference);
         }
 
+        // MetadataImportOptions.All imports non-public members from metadata references; the
+        // default (Public) would hide private and internal consts in the compiled target
+        // assembly from the drift comparison. Shims compile against publicized references, so
+        // the wider view also matches what shim compilation sees.
         CSharpCompilation compilation = CSharpCompilation.Create(
             assemblyName: "UloopHotReloadTransformWorkerCompilation",
             syntaxTrees: new[] { syntaxTree },
             references: references,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithMetadataImportOptions(MetadataImportOptions.All));
 
         SemanticModel semanticModel = compilation.GetSemanticModel(syntaxTree, ignoreAccessibility: true);
         CompilationUnitSyntax root = syntaxTree.GetCompilationUnitRoot();
+
+        IAssemblySymbol targetTypesAssemblySymbol = targetTypesReference == null
+            ? null
+            : compilation.GetAssemblyOrModuleSymbol(targetTypesReference) as IAssemblySymbol;
+        List<string> declarationDriftWarnings = CollectConstDriftWarnings(
+            root,
+            semanticModel,
+            targetTypesAssemblySymbol);
 
         List<WorkerEntry> entries = new List<WorkerEntry>();
         List<WorkerSkipped> skipped = new List<WorkerSkipped>();
@@ -284,8 +298,123 @@ public static class TransformWorkerProgram
             ShimSource = shimSource,
             Entries = entries.ToArray(),
             Skipped = skipped.ToArray(),
+            DeclarationDriftWarnings = declarationDriftWarnings.ToArray(),
             ParseErrors = parseErrors.ToArray()
         };
+    }
+
+    /// <summary>
+    /// Detects const declarations (including enum members) in the edited source whose values
+    /// differ from the compiled target assembly. C# inlines const values at compile time and
+    /// shims compile against the already-compiled assembly, so such edits silently keep the old
+    /// value at runtime; each drift becomes a response warning instead of a silent no-op.
+    /// </summary>
+    private static List<string> CollectConstDriftWarnings(
+        CompilationUnitSyntax root,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetTypesAssemblySymbol)
+    {
+        List<string> warnings = new List<string>();
+        if (targetTypesAssemblySymbol == null)
+        {
+            return warnings;
+        }
+
+        foreach (BaseTypeDeclarationSyntax typeDeclaration
+            in root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>())
+        {
+            INamedTypeSymbol sourceType = semanticModel.GetDeclaredSymbol(typeDeclaration);
+            if (sourceType == null)
+            {
+                continue;
+            }
+
+            INamedTypeSymbol compiledType = targetTypesAssemblySymbol.GetTypeByMetadataName(
+                ToReflectionMetadataName(sourceType));
+            if (compiledType == null)
+            {
+                continue;
+            }
+
+            foreach (IFieldSymbol sourceField in sourceType.GetMembers().OfType<IFieldSymbol>())
+            {
+                if (!sourceField.HasConstantValue)
+                {
+                    continue;
+                }
+
+                IFieldSymbol compiledField = null;
+                foreach (ISymbol member in compiledType.GetMembers(sourceField.Name))
+                {
+                    if (member is IFieldSymbol candidate && candidate.HasConstantValue)
+                    {
+                        compiledField = candidate;
+                        break;
+                    }
+                }
+
+                if (compiledField == null)
+                {
+                    // A const missing from the compiled assembly is a new declaration, not a
+                    // drift; bodies reading it already fail shim compilation with their own
+                    // actionable error.
+                    continue;
+                }
+
+                if (Equals(sourceField.ConstantValue, compiledField.ConstantValue))
+                {
+                    continue;
+                }
+
+                warnings.Add(
+                    "const " + sourceType.ToDisplayString() + "." + sourceField.Name
+                    + " is " + FormatConstValue(sourceField.ConstantValue)
+                    + " in the edited source but " + FormatConstValue(compiledField.ConstantValue)
+                    + " in the compiled assembly; edits outside method bodies never take effect "
+                    + "through hot reload. Run 'uloop compile' to apply this change.");
+            }
+        }
+
+        return warnings;
+    }
+
+    /// <summary>
+    /// Builds the CLR reflection metadata name ('+' for nested types) that
+    /// IAssemblySymbol.GetTypeByMetadataName expects. CecilTypeNames.ToMetadataName cannot be
+    /// reused here because Cecil separates nested types with '/'.
+    /// </summary>
+    private static string ToReflectionMetadataName(INamedTypeSymbol typeSymbol)
+    {
+        if (typeSymbol.ContainingType != null)
+        {
+            return ToReflectionMetadataName(typeSymbol.ContainingType) + "+" + typeSymbol.MetadataName;
+        }
+
+        if (typeSymbol.ContainingNamespace == null || typeSymbol.ContainingNamespace.IsGlobalNamespace)
+        {
+            return typeSymbol.MetadataName;
+        }
+
+        return typeSymbol.ContainingNamespace.ToDisplayString() + "." + typeSymbol.MetadataName;
+    }
+
+    /// <summary>
+    /// Renders a const value for the drift warning: quoted for strings, "null" for null,
+    /// invariant-culture text otherwise.
+    /// </summary>
+    private static string FormatConstValue(object value)
+    {
+        if (value == null)
+        {
+            return "null";
+        }
+
+        if (value is string text)
+        {
+            return "\"" + text + "\"";
+        }
+
+        return Convert.ToString(value, CultureInfo.InvariantCulture);
     }
 
     private static IEnumerable<TypeDeclarationSyntax> EnumerateTypeDeclarations(CompilationUnitSyntax root)
@@ -2776,6 +2905,8 @@ internal sealed class WorkerOutput
     public WorkerEntry[] Entries { get; set; }
 
     public WorkerSkipped[] Skipped { get; set; }
+
+    public string[] DeclarationDriftWarnings { get; set; }
 
     public string[] ParseErrors { get; set; }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -325,6 +325,7 @@ public static class TransformWorkerProgram
             return warnings;
         }
 
+        HashSet<string> seenTypeMetadataNames = new HashSet<string>(StringComparer.Ordinal);
         foreach (BaseTypeDeclarationSyntax typeDeclaration
             in root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>())
         {
@@ -334,8 +335,16 @@ public static class TransformWorkerProgram
                 continue;
             }
 
+            // Partial declarations in one file resolve to the same merged type symbol, and
+            // comparing its members once per declaration would duplicate every warning.
+            string typeMetadataName = ToReflectionMetadataName(sourceType);
+            if (!seenTypeMetadataNames.Add(typeMetadataName))
+            {
+                continue;
+            }
+
             INamedTypeSymbol compiledType = targetTypesAssemblySymbol.GetTypeByMetadataName(
-                ToReflectionMetadataName(sourceType));
+                typeMetadataName);
             if (compiledType == null)
             {
                 continue;
@@ -404,8 +413,8 @@ public static class TransformWorkerProgram
     }
 
     /// <summary>
-    /// Renders a const value for the drift warning: quoted for strings, "null" for null,
-    /// invariant-culture text otherwise.
+    /// Renders a const value for the drift warning: quoted for strings and chars, "null" for
+    /// null, invariant-culture text otherwise.
     /// </summary>
     private static string FormatConstValue(object value)
     {
@@ -417,6 +426,13 @@ public static class TransformWorkerProgram
         if (value is string text)
         {
             return "\"" + text + "\"";
+        }
+
+        if (value is char character)
+        {
+            // A bare char (especially whitespace) is invisible inside the warning sentence;
+            // quote it the way C# source spells it.
+            return "'" + character + "'";
         }
 
         return Convert.ToString(value, CultureInfo.InvariantCulture);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -178,23 +178,28 @@ public static class TransformWorkerProgram
             references.Add(targetTypesReference);
         }
 
-        // MetadataImportOptions.All imports non-public members from metadata references; the
-        // default (Public) would hide private and internal consts in the compiled target
-        // assembly from the drift comparison. Shims compile against publicized references, so
-        // the wider view also matches what shim compilation sees.
         CSharpCompilation compilation = CSharpCompilation.Create(
             assemblyName: "UloopHotReloadTransformWorkerCompilation",
             syntaxTrees: new[] { syntaxTree },
             references: references,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-                .WithMetadataImportOptions(MetadataImportOptions.All));
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
         SemanticModel semanticModel = compilation.GetSemanticModel(syntaxTree, ignoreAccessibility: true);
         CompilationUnitSyntax root = syntaxTree.GetCompilationUnitRoot();
 
-        IAssemblySymbol targetTypesAssemblySymbol = targetTypesReference == null
-            ? null
-            : compilation.GetAssemblyOrModuleSymbol(targetTypesReference) as IAssemblySymbol;
+        // The drift comparison must see private and internal consts in the compiled target
+        // assembly, which the default MetadataImportOptions (Public) hides. Widening the main
+        // compilation would also widen what every classification query can bind to, so the
+        // wider import is confined to a throwaway compilation used only for this lookup.
+        IAssemblySymbol targetTypesAssemblySymbol = null;
+        if (targetTypesReference != null)
+        {
+            CSharpCompilation driftCompilation = compilation.WithOptions(
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                    .WithMetadataImportOptions(MetadataImportOptions.All));
+            targetTypesAssemblySymbol =
+                driftCompilation.GetAssemblyOrModuleSymbol(targetTypesReference) as IAssemblySymbol;
+        }
         List<string> declarationDriftWarnings = CollectConstDriftWarnings(
             root,
             semanticModel,

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -189,9 +189,11 @@ Wire details:
 
 ## Known Limits (documented, not worked around)
 
-- Adding fields, types, or methods; changing signatures; changing field initializers — all
-  require `uloop compile`. Shim compile errors caused by references to newly added members
-  are reported with that hint.
+- Adding fields, types, or methods; changing signatures; changing field initializers or
+  `const` values — all require `uloop compile`. Shim compile errors caused by references to
+  newly added members are reported with that hint, and changed `const` values (including
+  enum members) are compared against the compiled target assembly and reported as a
+  response warning; other outside-body edits stay silent.
 - In-flight async methods and coroutines keep running the old code until re-entered.
 - Callers whose call sites were JIT-inlined may not observe the detour (`IsLikelyJitInlined`
   heuristic produces a warning, as with pause points).


### PR DESCRIPTION
## Summary
- Hot reload now warns when an edited `const` (including enum members) cannot take effect, instead of reporting a silent Success.
- The run still succeeds and method patches still apply; only a `Warnings` entry is added so agents know to run `uloop compile`.

## User Impact
- Before: changing a `const` value looked successful while runtime kept the old inlined value.
- After: the response names the constant and both values, and points at `uloop compile` for outside-body edits. Other outside-body edits remain silent.

## Changes
- Transform worker compares const/enum values in the edited source against the compiled target assembly (with `MetadataImportOptions.All` so private/internal consts are visible).
- Orchestrator forwards those drift messages onto the existing per-file warnings path.
- EditMode e2e coverage for drifted and unchanged consts; skill and docs updated.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount=0 / WarningCount=0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value 'HotReload' --project-path "$(git rev-parse --show-toplevel)"` → 56 Passed / 0 Failed
- `scripts/sync-tool-docs.sh` → `default-tools.json` unchanged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

