### PR TITLE
fix: Windows-specific hot reload failures (worker references, stream encoding, fixture inlining)

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCoreFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCoreFixtures.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
@@ -24,23 +25,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return left + right + extra;
         }
 
+        // Why NoInlining on every patch target below: these fixtures verify detour mechanics,
+        // and without the attribute the x64 Mono JIT can inline the tiny original bodies into
+        // a test method that was JIT-compiled before the patch was applied, so the assertions
+        // would measure JIT inlining instead of patching.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static string StaticPing()
         {
             return "original";
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public void VoidBump()
         {
             VoidHits = -1;
         }
 
         // Sentinel return proves the original body ran before a transplant replaces it.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int ReplaceableCompute(int delta)
         {
             return -1 * delta;
         }
 
         // Delegation target: sentinel proves the original async body ran before forwarding.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public async Task<int> ReplaceableComputeAsync(int delta)
         {
             await Task.Yield();

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
@@ -80,8 +81,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return 2;
         }
 
+        // Why NoInlining on every patch target below: these fixtures verify detour mechanics,
+        // and without the attribute the x64 Mono JIT can inline the tiny original bodies into
+        // a test method that was JIT-compiled before the patch was applied, so the assertions
+        // would measure JIT inlining instead of patching.
+
         // Sentinel body: hot reload must replace this with a private-touching shim that returns
         // _secret + delta + 100.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int ComputeWithPrivate(int delta)
         {
             return _secret + delta;
@@ -108,6 +115,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         // Sync method + query syntax referencing a private field — worker emits a delegation
         // entry (accessor rewrite); orchestrator leaves it unpatched until the delegation pass.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int QueryPrivate()
         {
             int[] values = { 1, 2, 3 };
@@ -122,6 +130,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         // Multidimensional array parameter — exercises Cecil FullName `[0...,0...]` matching.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int SumGrid(int[,] grid)
         {
             return -1;
@@ -196,6 +205,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private int HiddenScore { get; set; } = 3;
 
         // v2 e2e (1): async body with private field write + private method call.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public async Task<int> AsyncPrivateFieldAndMethod(int delta)
         {
             await Task.Yield();
@@ -203,12 +213,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         // v2 e2e (2): iterator body with the same private accesses.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public IEnumerator IteratePrivate(int delta)
         {
             yield return _secret + delta;
         }
 
         // v2 e2e (3): lambda capture reading a private field.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int LambdaPrivate(int threshold)
         {
             Func<int, bool> pred = v => v < _secret;
@@ -216,6 +228,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         // v2 e2e (4): private property read/write round-trip.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int PropertyPrivateRoundTrip(int value)
         {
             HiddenScore = value;

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -781,6 +781,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return @"using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
@@ -823,6 +824,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             _secret += amount;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         " + computeWithPrivateMethod + @"
 
         public int CallsBase()
@@ -837,6 +839,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return _secret;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         " + queryPrivate + @"
 
         public async Task<int> AsyncReadPrivateIndexer()
@@ -845,6 +848,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return this[0];
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         " + sumGrid + @"
 
         public int CountEnumerator(List<int>.Enumerator enumerator)
@@ -852,12 +856,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return 0;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         " + asyncPrivate + @"
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         " + iteratePrivate + @"
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         " + lambdaPrivate + @"
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         " + propertyPrivate + @"
 
         " + asyncInternal + @"

--- a/Assets/Tests/Editor/HotReload/HotReloadProcessRunnerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadProcessRunnerTests.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+using System.Text;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Regression coverage for <see cref="HotReloadProcessRunner"/> stream decoding: worker
+    /// output must be decoded as UTF-8 so localized compiler diagnostics survive on systems
+    /// whose default code page is not UTF-8 (e.g. Japanese Windows).
+    /// </summary>
+    public class HotReloadProcessRunnerTests
+    {
+        /// <summary>
+        /// What: CreateStartInfo redirects both worker streams and decodes them as UTF-8,
+        /// matching the bundled .NET host's redirected console output encoding.
+        /// </summary>
+        [Test]
+        public void CreateStartInfo_DecodesRedirectedStreamsAsUtf8()
+        {
+            ProcessStartInfo startInfo = HotReloadProcessRunner.CreateStartInfo(
+                "worker-host", "worker-arguments", ".");
+
+            Assert.That(startInfo.StandardOutputEncoding, Is.EqualTo(Encoding.UTF8));
+            Assert.That(startInfo.StandardErrorEncoding, Is.EqualTo(Encoding.UTF8));
+            Assert.That(startInfo.RedirectStandardOutput, Is.True);
+            Assert.That(startInfo.RedirectStandardError, Is.True);
+            Assert.That(startInfo.UseShellExecute, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadProcessRunnerTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadProcessRunnerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d1078c7cdaa7ca45be8781e2051999b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS2WorkerBootstrapTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS2WorkerBootstrapTests.cs
@@ -159,6 +159,14 @@ public static class SpikeWorkerProgram
 
             foreach (string referencePath in Directory.GetFiles(paths.NetCoreRuntimeSharedDirectoryPath, "*.dll"))
             {
+                // Why: on Windows the bundled shared framework also ships native PE images
+                // (ucrtbase.dll, coreclr.dll, api-ms-win-crt-*.dll, ...); passing those to csc
+                // as references fails the worker build with CS0009.
+                if (!ManagedAssemblyDetector.IsManagedAssembly(referencePath))
+                {
+                    continue;
+                }
+
                 lines.Add($"-r:\"{referencePath}\"");
             }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS3PrefixDelegationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS3PrefixDelegationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using HarmonyLib;
 using NUnit.Framework;
@@ -26,27 +27,36 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
             public int Offset = 3;
             public List<string> CallLog = new();
 
+            // Why NoInlining on every patch target below: these tests verify detour mechanics,
+            // and without the attribute the x64 Mono JIT can inline the tiny original bodies
+            // into a test method that was JIT-compiled before the patch was applied, so the
+            // assertions would measure JIT inlining instead of patching.
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public void RecordGreeting()
             {
                 CallLog.Add("original");
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public int AddOffset(int value)
             {
                 return value + Offset;
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public static int StaticDouble(int value)
             {
                 return value * 2;
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public async Task<int> ComputeAsync()
             {
                 await Task.Yield();
                 return 1;
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public IEnumerable<int> EnumerateNumbers()
             {
                 yield return 1;
@@ -58,6 +68,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
                 return SecretNumber();
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             private int SecretNumber()
             {
                 return 5;

--- a/Assets/Tests/Editor/HotReload/ManagedAssemblyDetectorTests.cs
+++ b/Assets/Tests/Editor/HotReload/ManagedAssemblyDetectorTests.cs
@@ -30,7 +30,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             string filePath = WriteTempFile(
                 "managed-pe32plus.dll",
-                CreatePeImage(true, 0x2008u));
+                CreatePeImage(true, 0x2008u, 72u));
             Assert.That(ManagedAssemblyDetector.IsManagedAssembly(filePath), Is.True);
         }
 
@@ -43,7 +43,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             string filePath = WriteTempFile(
                 "managed-pe32.dll",
-                CreatePeImage(false, 0x2008u));
+                CreatePeImage(false, 0x2008u, 72u));
             Assert.That(ManagedAssemblyDetector.IsManagedAssembly(filePath), Is.True);
         }
 
@@ -56,7 +56,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             string filePath = WriteTempFile(
                 "native-pe32plus.dll",
-                CreatePeImage(true, 0u));
+                CreatePeImage(true, 0u, 0u));
+            Assert.That(ManagedAssemblyDetector.IsManagedAssembly(filePath), Is.False);
+        }
+
+        /// <summary>
+        /// What: a PE32+ image whose CLR runtime header directory has a non-zero RVA but a
+        /// zero size is rejected as malformed instead of being treated as managed.
+        /// </summary>
+        [Test]
+        public void IsManagedAssembly_ClrDirectoryWithZeroSize_ReturnsFalse()
+        {
+            string filePath = WriteTempFile(
+                "zero-size-clr-pe32plus.dll",
+                CreatePeImage(true, 0x2008u, 0u));
             Assert.That(ManagedAssemblyDetector.IsManagedAssembly(filePath), Is.False);
         }
 
@@ -90,7 +103,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         // Builds a minimal PE image: DOS header, PE signature, COFF header, and an optional
         // header with 16 data directories where only the CLR runtime header entry varies.
-        private static byte[] CreatePeImage(bool isPe32Plus, uint clrRuntimeHeaderRva)
+        private static byte[] CreatePeImage(
+            bool isPe32Plus,
+            uint clrRuntimeHeaderRva,
+            uint clrRuntimeHeaderSize)
         {
             ushort optionalHeaderMagic = isPe32Plus ? (ushort)0x20B : (ushort)0x10B;
             int rvaCountOffset = isPe32Plus ? 108 : 92;
@@ -117,7 +133,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             int clrDirectoryOffset =
                 OptionalHeaderStart + dataDirectoriesOffset + ClrRuntimeHeaderDirectoryIndex * 8;
             WriteInt32(image, clrDirectoryOffset, (int)clrRuntimeHeaderRva);
-            WriteInt32(image, clrDirectoryOffset + 4, clrRuntimeHeaderRva == 0 ? 0 : 72);
+            WriteInt32(image, clrDirectoryOffset + 4, (int)clrRuntimeHeaderSize);
 
             return image;
         }

--- a/Assets/Tests/Editor/HotReload/ManagedAssemblyDetectorTests.cs
+++ b/Assets/Tests/Editor/HotReload/ManagedAssemblyDetectorTests.cs
@@ -121,8 +121,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             image[DosHeaderSize] = 0x50;
             image[DosHeaderSize + 1] = 0x45;
 
-            // COFF header: machine (x64), one section, SizeOfOptionalHeader, characteristics.
-            WriteUInt16(image, CoffHeaderStart, 0x8664);
+            // COFF header: machine (AMD64 for PE32+, I386 for PE32), one section,
+            // SizeOfOptionalHeader, characteristics.
+            WriteUInt16(
+                image,
+                CoffHeaderStart,
+                isPe32Plus ? (ushort)0x8664 : (ushort)0x14C);
             WriteUInt16(image, CoffHeaderStart + 2, 1);
             WriteUInt16(image, CoffHeaderStart + 16, optionalHeaderSize);
             WriteUInt16(image, CoffHeaderStart + 18, 0x2022);

--- a/Assets/Tests/Editor/HotReload/ManagedAssemblyDetectorTests.cs
+++ b/Assets/Tests/Editor/HotReload/ManagedAssemblyDetectorTests.cs
@@ -1,0 +1,150 @@
+using System.IO;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Regression coverage for <see cref="ManagedAssemblyDetector"/>: the transform worker
+    /// reference set must keep native PE images (which share the .dll extension with managed
+    /// assemblies on Windows) out of the csc response file.
+    /// </summary>
+    public class ManagedAssemblyDetectorTests
+    {
+        private const int DosHeaderSize = 0x40;
+        private const int PeSignatureOffsetLocation = 0x3C;
+        private const int CoffHeaderStart = DosHeaderSize + 4;
+        private const int OptionalHeaderStart = CoffHeaderStart + 20;
+        private const int ClrRuntimeHeaderDirectoryIndex = 14;
+
+        /// <summary>
+        /// What: a PE32+ image whose CLR runtime header directory has a non-zero RVA is
+        /// recognized as a managed assembly.
+        /// </summary>
+        [Test]
+        public void IsManagedAssembly_Pe32PlusWithClrDirectory_ReturnsTrue()
+        {
+            string filePath = WriteTempFile(
+                "managed-pe32plus.dll",
+                CreatePeImage(true, 0x2008u));
+            Assert.That(ManagedAssemblyDetector.IsManagedAssembly(filePath), Is.True);
+        }
+
+        /// <summary>
+        /// What: a PE32 (32-bit optional header) image with a non-zero CLR runtime header RVA
+        /// is recognized as a managed assembly, covering the smaller data-directory layout.
+        /// </summary>
+        [Test]
+        public void IsManagedAssembly_Pe32WithClrDirectory_ReturnsTrue()
+        {
+            string filePath = WriteTempFile(
+                "managed-pe32.dll",
+                CreatePeImage(false, 0x2008u));
+            Assert.That(ManagedAssemblyDetector.IsManagedAssembly(filePath), Is.True);
+        }
+
+        /// <summary>
+        /// What: a PE32+ image whose CLR runtime header directory RVA is zero (the shape of
+        /// native DLLs such as ucrtbase.dll or coreclr.dll) is rejected as not managed.
+        /// </summary>
+        [Test]
+        public void IsManagedAssembly_Pe32PlusWithoutClrDirectory_ReturnsFalse()
+        {
+            string filePath = WriteTempFile(
+                "native-pe32plus.dll",
+                CreatePeImage(true, 0u));
+            Assert.That(ManagedAssemblyDetector.IsManagedAssembly(filePath), Is.False);
+        }
+
+        /// <summary>
+        /// What: a file that is large enough to hold a DOS header but does not start with the
+        /// 'MZ' magic is rejected as not managed instead of throwing.
+        /// </summary>
+        [Test]
+        public void IsManagedAssembly_NonPeContent_ReturnsFalse()
+        {
+            byte[] garbage = new byte[256];
+            for (int index = 0; index < garbage.Length; index++)
+            {
+                garbage[index] = (byte)(index % 251);
+            }
+
+            string filePath = WriteTempFile("garbage.dll", garbage);
+            Assert.That(ManagedAssemblyDetector.IsManagedAssembly(filePath), Is.False);
+        }
+
+        /// <summary>
+        /// What: a file shorter than a DOS header is rejected as not managed instead of
+        /// throwing on a truncated read.
+        /// </summary>
+        [Test]
+        public void IsManagedAssembly_FileShorterThanDosHeader_ReturnsFalse()
+        {
+            string filePath = WriteTempFile("truncated.dll", new byte[] { 0x4D, 0x5A, 0x00 });
+            Assert.That(ManagedAssemblyDetector.IsManagedAssembly(filePath), Is.False);
+        }
+
+        // Builds a minimal PE image: DOS header, PE signature, COFF header, and an optional
+        // header with 16 data directories where only the CLR runtime header entry varies.
+        private static byte[] CreatePeImage(bool isPe32Plus, uint clrRuntimeHeaderRva)
+        {
+            ushort optionalHeaderMagic = isPe32Plus ? (ushort)0x20B : (ushort)0x10B;
+            int rvaCountOffset = isPe32Plus ? 108 : 92;
+            int dataDirectoriesOffset = isPe32Plus ? 112 : 96;
+            ushort optionalHeaderSize = (ushort)(dataDirectoriesOffset + 16 * 8);
+
+            byte[] image = new byte[OptionalHeaderStart + optionalHeaderSize];
+            image[0] = 0x4D;
+            image[1] = 0x5A;
+            WriteInt32(image, PeSignatureOffsetLocation, DosHeaderSize);
+
+            image[DosHeaderSize] = 0x50;
+            image[DosHeaderSize + 1] = 0x45;
+
+            // COFF header: machine (x64), one section, SizeOfOptionalHeader, characteristics.
+            WriteUInt16(image, CoffHeaderStart, 0x8664);
+            WriteUInt16(image, CoffHeaderStart + 2, 1);
+            WriteUInt16(image, CoffHeaderStart + 16, optionalHeaderSize);
+            WriteUInt16(image, CoffHeaderStart + 18, 0x2022);
+
+            WriteUInt16(image, OptionalHeaderStart, optionalHeaderMagic);
+            WriteInt32(image, OptionalHeaderStart + rvaCountOffset, 16);
+
+            int clrDirectoryOffset =
+                OptionalHeaderStart + dataDirectoriesOffset + ClrRuntimeHeaderDirectoryIndex * 8;
+            WriteInt32(image, clrDirectoryOffset, (int)clrRuntimeHeaderRva);
+            WriteInt32(image, clrDirectoryOffset + 4, clrRuntimeHeaderRva == 0 ? 0 : 72);
+
+            return image;
+        }
+
+        private static void WriteUInt16(byte[] buffer, int offset, ushort value)
+        {
+            buffer[offset] = (byte)(value & 0xFF);
+            buffer[offset + 1] = (byte)(value >> 8);
+        }
+
+        private static void WriteInt32(byte[] buffer, int offset, int value)
+        {
+            buffer[offset] = (byte)(value & 0xFF);
+            buffer[offset + 1] = (byte)((value >> 8) & 0xFF);
+            buffer[offset + 2] = (byte)((value >> 16) & 0xFF);
+            buffer[offset + 3] = (byte)((value >> 24) & 0xFF);
+        }
+
+        private static string WriteTempFile(string fileName, byte[] content)
+        {
+            string projectRootPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string workRootPath = Path.Combine(
+                projectRootPath, "Library", "UloopHotReloadTests", "ManagedAssemblyDetector");
+            Directory.CreateDirectory(workRootPath);
+            string filePath = Path.Combine(workRootPath, fileName);
+            File.WriteAllBytes(filePath, content);
+            return filePath;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/ManagedAssemblyDetectorTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/ManagedAssemblyDetectorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0b8e46b9d0ab574fbc6bfed14040548
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/SpikeAccessFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/SpikeAccessFixtures.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
@@ -17,8 +18,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
             _counter++;
         }
 
+        // Why NoInlining on both patch targets below: these tests verify detour mechanics,
+        // and without the attribute the x64 Mono JIT can inline the tiny original bodies into
+        // a test method that was JIT-compiled before the patch was applied, so the assertions
+        // would measure JIT inlining instead of patching.
+
         // Transplant target for S1: a Harmony transpiler replaces this body with the IL of a
         // snippet method compiled outside Unity; -1 is a sentinel proving the original body ran.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int ReplaceableCompute(int delta)
         {
             return -1 * delta;
@@ -26,6 +33,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
 
         // Delegation target for the S1 async pin: a Harmony transpiler replaces this body with
         // a call to an accessor-rewritten async shim; -1 is a sentinel proving the original ran.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public async Task<int> ReplaceableComputeAsync(int delta)
         {
             await Task.Yield();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadProcessRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadProcessRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,16 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(!string.IsNullOrEmpty(fileName), "fileName must not be empty.");
 
-            ProcessStartInfo startInfo = new ProcessStartInfo
-            {
-                FileName = fileName,
-                Arguments = arguments,
-                WorkingDirectory = workingDirectoryPath,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true
-            };
+            ProcessStartInfo startInfo = CreateStartInfo(fileName, arguments, workingDirectoryPath);
 
             using Process process = Process.Start(startInfo);
             Debug.Assert(process != null, "Failed to start process: " + fileName);
@@ -68,6 +60,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string standardOutput = await stdoutTask.ConfigureAwait(false);
             string standardError = await stderrTask.ConfigureAwait(false);
             return (process.ExitCode, standardOutput, standardError);
+        }
+
+        // Why: both worker processes (csc and the transform worker) run on the bundled .NET
+        // host, which writes redirected console output as UTF-8, so both streams are decoded
+        // as UTF-8 instead of the platform default, which mojibakes non-ASCII output such as
+        // localized compiler diagnostics on Windows.
+        internal static ProcessStartInfo CreateStartInfo(
+            string fileName,
+            string arguments,
+            string workingDirectoryPath)
+        {
+            return new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = workingDirectoryPath,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+                CreateNoWindow = true
+            };
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/ManagedAssemblyDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/ManagedAssemblyDetector.cs
@@ -34,34 +34,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             using FileStream stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
             using BinaryReader reader = new BinaryReader(stream);
 
-            if (stream.Length < DosHeaderSize)
+            long coffHeaderStart = ReadCoffHeaderStart(stream, reader);
+            if (coffHeaderStart < 0)
             {
                 return false;
             }
 
-            // DOS header magic 'M','Z'.
-            if (reader.ReadByte() != 0x4D || reader.ReadByte() != 0x5A)
-            {
-                return false;
-            }
-
-            stream.Position = PeSignatureOffsetLocation;
-            int peSignatureOffset = reader.ReadInt32();
-            if (peSignatureOffset < DosHeaderSize
-                || peSignatureOffset > stream.Length - PeSignatureSize - CoffHeaderSize)
-            {
-                return false;
-            }
-
-            // PE signature 'P','E','\0','\0'.
-            stream.Position = peSignatureOffset;
-            if (reader.ReadByte() != 0x50 || reader.ReadByte() != 0x45
-                || reader.ReadByte() != 0 || reader.ReadByte() != 0)
-            {
-                return false;
-            }
-
-            long coffHeaderStart = peSignatureOffset + PeSignatureSize;
             stream.Position = coffHeaderStart + SizeOfOptionalHeaderOffsetInCoff;
             ushort optionalHeaderSize = reader.ReadUInt16();
             long optionalHeaderStart = coffHeaderStart + CoffHeaderSize;
@@ -73,19 +51,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             stream.Position = optionalHeaderStart;
             ushort optionalHeaderMagic = reader.ReadUInt16();
-            int rvaCountOffset;
-            int dataDirectoriesOffset;
-            if (optionalHeaderMagic == Pe32Magic)
-            {
-                rvaCountOffset = Pe32RvaCountOffset;
-                dataDirectoriesOffset = Pe32DataDirectoriesOffset;
-            }
-            else if (optionalHeaderMagic == Pe32PlusMagic)
-            {
-                rvaCountOffset = Pe32PlusRvaCountOffset;
-                dataDirectoriesOffset = Pe32PlusDataDirectoriesOffset;
-            }
-            else
+            int rvaCountOffset = ResolveRvaCountOffset(optionalHeaderMagic);
+            int dataDirectoriesOffset = ResolveDataDirectoriesOffset(optionalHeaderMagic);
+            if (rvaCountOffset < 0 || dataDirectoriesOffset < 0)
             {
                 return false;
             }
@@ -106,7 +74,76 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             stream.Position = optionalHeaderStart + clrDirectoryOffset;
             uint clrRuntimeHeaderRva = reader.ReadUInt32();
-            return clrRuntimeHeaderRva != 0;
+            uint clrRuntimeHeaderSize = reader.ReadUInt32();
+            // A non-zero RVA paired with a zero size is a malformed image (real compilers emit
+            // size 72), so it is rejected per the malformed-returns-false policy.
+            return clrRuntimeHeaderRva != 0 && clrRuntimeHeaderSize != 0;
+        }
+
+        // Validates the DOS header, PE signature offset, and PE signature, and returns the
+        // COFF header start offset; -1 means the preamble is not a well-formed PE image.
+        private static long ReadCoffHeaderStart(FileStream stream, BinaryReader reader)
+        {
+            if (stream.Length < DosHeaderSize)
+            {
+                return -1;
+            }
+
+            // DOS header magic 'M','Z'.
+            if (reader.ReadByte() != 0x4D || reader.ReadByte() != 0x5A)
+            {
+                return -1;
+            }
+
+            stream.Position = PeSignatureOffsetLocation;
+            int peSignatureOffset = reader.ReadInt32();
+            if (peSignatureOffset < DosHeaderSize
+                || peSignatureOffset > stream.Length - PeSignatureSize - CoffHeaderSize)
+            {
+                return -1;
+            }
+
+            // PE signature 'P','E','\0','\0'.
+            stream.Position = peSignatureOffset;
+            if (reader.ReadByte() != 0x50 || reader.ReadByte() != 0x45
+                || reader.ReadByte() != 0 || reader.ReadByte() != 0)
+            {
+                return -1;
+            }
+
+            return peSignatureOffset + PeSignatureSize;
+        }
+
+        // -1 means the optional-header magic is neither PE32 nor PE32+.
+        private static int ResolveRvaCountOffset(ushort optionalHeaderMagic)
+        {
+            if (optionalHeaderMagic == Pe32Magic)
+            {
+                return Pe32RvaCountOffset;
+            }
+
+            if (optionalHeaderMagic == Pe32PlusMagic)
+            {
+                return Pe32PlusRvaCountOffset;
+            }
+
+            return -1;
+        }
+
+        // -1 means the optional-header magic is neither PE32 nor PE32+.
+        private static int ResolveDataDirectoriesOffset(ushort optionalHeaderMagic)
+        {
+            if (optionalHeaderMagic == Pe32Magic)
+            {
+                return Pe32DataDirectoriesOffset;
+            }
+
+            if (optionalHeaderMagic == Pe32PlusMagic)
+            {
+                return Pe32PlusDataDirectoriesOffset;
+            }
+
+            return -1;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/ManagedAssemblyDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/ManagedAssemblyDetector.cs
@@ -1,0 +1,112 @@
+using System.IO;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Detects whether a PE file carries managed (CLR) metadata by reading its headers.
+    /// Why: on Windows the bundled shared-framework directory mixes native PE images and
+    /// managed assemblies under the same .dll extension, so reference-set builders need a
+    /// cheap managed-or-native check that does not load the file as an assembly.
+    /// </summary>
+    internal static class ManagedAssemblyDetector
+    {
+        private const int DosHeaderSize = 0x40;
+        private const int PeSignatureOffsetLocation = 0x3C;
+        private const int PeSignatureSize = 4;
+        private const int CoffHeaderSize = 20;
+        private const int SizeOfOptionalHeaderOffsetInCoff = 16;
+        private const ushort Pe32Magic = 0x10B;
+        private const ushort Pe32PlusMagic = 0x20B;
+        private const int Pe32RvaCountOffset = 92;
+        private const int Pe32DataDirectoriesOffset = 96;
+        private const int Pe32PlusRvaCountOffset = 108;
+        private const int Pe32PlusDataDirectoriesOffset = 112;
+        private const int ClrRuntimeHeaderDirectoryIndex = 14;
+        private const int DataDirectoryEntrySize = 8;
+
+        /// <summary>
+        /// Returns true when the file is a PE image whose optional header declares a CLR
+        /// runtime header (data directory 14), i.e. a managed assembly. Malformed and native
+        /// images return false; genuinely unreadable files throw (Fail Fast).
+        /// </summary>
+        public static bool IsManagedAssembly(string filePath)
+        {
+            using FileStream stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using BinaryReader reader = new BinaryReader(stream);
+
+            if (stream.Length < DosHeaderSize)
+            {
+                return false;
+            }
+
+            // DOS header magic 'M','Z'.
+            if (reader.ReadByte() != 0x4D || reader.ReadByte() != 0x5A)
+            {
+                return false;
+            }
+
+            stream.Position = PeSignatureOffsetLocation;
+            int peSignatureOffset = reader.ReadInt32();
+            if (peSignatureOffset < DosHeaderSize
+                || peSignatureOffset > stream.Length - PeSignatureSize - CoffHeaderSize)
+            {
+                return false;
+            }
+
+            // PE signature 'P','E','\0','\0'.
+            stream.Position = peSignatureOffset;
+            if (reader.ReadByte() != 0x50 || reader.ReadByte() != 0x45
+                || reader.ReadByte() != 0 || reader.ReadByte() != 0)
+            {
+                return false;
+            }
+
+            long coffHeaderStart = peSignatureOffset + PeSignatureSize;
+            stream.Position = coffHeaderStart + SizeOfOptionalHeaderOffsetInCoff;
+            ushort optionalHeaderSize = reader.ReadUInt16();
+            long optionalHeaderStart = coffHeaderStart + CoffHeaderSize;
+            if (optionalHeaderSize < sizeof(ushort)
+                || optionalHeaderStart + optionalHeaderSize > stream.Length)
+            {
+                return false;
+            }
+
+            stream.Position = optionalHeaderStart;
+            ushort optionalHeaderMagic = reader.ReadUInt16();
+            int rvaCountOffset;
+            int dataDirectoriesOffset;
+            if (optionalHeaderMagic == Pe32Magic)
+            {
+                rvaCountOffset = Pe32RvaCountOffset;
+                dataDirectoriesOffset = Pe32DataDirectoriesOffset;
+            }
+            else if (optionalHeaderMagic == Pe32PlusMagic)
+            {
+                rvaCountOffset = Pe32PlusRvaCountOffset;
+                dataDirectoriesOffset = Pe32PlusDataDirectoriesOffset;
+            }
+            else
+            {
+                return false;
+            }
+
+            int clrDirectoryOffset =
+                dataDirectoriesOffset + ClrRuntimeHeaderDirectoryIndex * DataDirectoryEntrySize;
+            if (optionalHeaderSize < clrDirectoryOffset + DataDirectoryEntrySize)
+            {
+                return false;
+            }
+
+            stream.Position = optionalHeaderStart + rvaCountOffset;
+            uint rvaCount = reader.ReadUInt32();
+            if (rvaCount <= ClrRuntimeHeaderDirectoryIndex)
+            {
+                return false;
+            }
+
+            stream.Position = optionalHeaderStart + clrDirectoryOffset;
+            uint clrRuntimeHeaderRva = reader.ReadUInt32();
+            return clrRuntimeHeaderRva != 0;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/ManagedAssemblyDetector.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/ManagedAssemblyDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 620b60ef707c83242ae873ae2bff1da8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
@@ -142,6 +142,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             foreach (string referencePath in Directory.GetFiles(paths.NetCoreRuntimeSharedDirectoryPath, "*.dll"))
             {
+                // Why: on Windows the bundled shared framework also ships native PE images
+                // (ucrtbase.dll, coreclr.dll, api-ms-win-crt-*.dll, ...); passing those to csc
+                // as references fails the worker build with CS0009.
+                if (!ManagedAssemblyDetector.IsManagedAssembly(referencePath))
+                {
+                    continue;
+                }
+
                 lines.Add("-r:\"" + referencePath + "\"");
             }
 

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -92,7 +92,9 @@ Test file: `HotReloadSpikeS2WorkerBootstrapTests.cs`.
 
 - The Unity-bundled csc (`csc.dll` on the bundled .NET host) compiles a standalone worker
   executable against the bundled shared framework (`-nostdlib+ -target:exe`, references =
-  every dll in `NetCoreRuntimeSharedDirectoryPath` + the two bundled Roslyn assemblies).
+  every managed assembly in `NetCoreRuntimeSharedDirectoryPath` + the two bundled Roslyn
+  assemblies; on Windows that directory also ships native PE images, which are filtered out
+  because csc rejects them with CS0009).
 - The worker resolves `Microsoft.CodeAnalysis*` at runtime from the compiler directory via
   an `AssemblyLoadContext.Default.Resolving` hook registered in `Main` before any Roslyn
   type is touched (Roslyn usage lives in a separate method so `Main`'s JIT does not trigger


### PR DESCRIPTION
## Summary

Manual Windows verification of `feature/hot-reload` (at 8dd9d952) failed: the EditMode HotReload suite was 32/59 and the PlayMode regression harness failed. All failures trace to three independent Windows-specific root causes, fixed here.

## Root cause analysis

### 1. Transform worker rsp referenced native PE images (20 test failures + harness failure)

`TransformWorkerBootstrap.WriteWorkerResponseFile` (and the spike S2 test's copy) built the csc `-r:` set by globbing `Directory.GetFiles(sharedFrameworkDir, "*.dll")`. On Windows, Unity's bundled `Microsoft.NETCore.App` shared-framework directory also ships native PE images under the same `.dll` extension (`ucrtbase.dll`, `coreclr.dll`, `clrjit.dll`, `hostpolicy.dll`, `api-ms-win-crt-*.dll`, ...). csc rejects every one of them with CS0009, so the worker build fails and everything downstream (orchestrator tests, tool tests, the harness `hot-reload --files` call) fails with it. macOS/Linux never hit this because their native runtime libraries are `.dylib`/`.so` and escape the glob — which is why ubuntu CI stayed green.

Fix: new `ManagedAssemblyDetector.IsManagedAssembly` reads the PE headers (DOS → PE signature → optional header → CLR runtime header data directory 14) and both glob sites now skip non-managed images. No assembly loading, no exception-driven control flow. Regression tests craft minimal PE32/PE32+ images (managed, native, garbage, truncated) so the check is exercised on every platform.

### 2. Worker output decoded with the platform ANSI code page

`HotReloadProcessRunner` redirected the worker's stdout/stderr without setting `StandardOutputEncoding`/`StandardErrorEncoding`, so output was decoded with the OS default code page. The bundled .NET host writes redirected console output as UTF-8, so localized compiler diagnostics mojibake on any non-UTF-8 system locale. Fix: the start info now pins both stream encodings to UTF-8 (same pattern as `NativeCliSetupCommandRunner`), with a regression test on the extracted `CreateStartInfo`.

### 3. Detour tests measured x64 Mono JIT inlining instead of patching (7 test failures)

Seven tests asserted patched behavior through direct calls to tiny fixture methods (2–13 bytes of IL). The x64 Mono JIT inlines those bodies into the test method when it is first JIT-compiled — before `HotReloadPatcher.Apply` runs mid-body — so the call sites keep executing the old body. Verified empirically on Windows x64: after `Apply`, both a reflection `Invoke` and a freshly JIT-compiled `DynamicMethod` call site do hit the patched body, and `RevertAll` restores the original — the detour mechanism itself is sound; only already-inlined call sites miss it, exactly what `Apply`'s `SmallMethodInliningRiskWarning` predicts. arm64 Mono on macOS makes different inlining decisions, which is why the suite was green there. Fix: `[MethodImpl(MethodImplOptions.NoInlining)]` on every patch-target fixture method so the tests verify detour mechanics deterministically on both platforms. No production behavior change.

## Windows verification (2022.3.62f3, x64)

- `uloop compile`: 0 errors / 0 warnings
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value HotReload`: **65/65 passed** (59 existing + 6 new regression tests), single run
- `scripts/regression-harness-hot-reload.sh`: `PASS: hot-reload changed PlayMode logs and revert-all restored the previous body.` — working tree clean afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

