### PR TITLE
fix: rebind transplant branch labels and contain patch apply failures

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -71,8 +71,19 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
-| Patch rejected at apply time (e.g. `[BurstCompile]`) | Not patchable by Harmony transplant |
+| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
+
+## When a patch reports `Patched` but behavior does not change
+
+`Patched` means the method body was replaced, not that the method ran. Before suspecting
+the patch, confirm the method is actually reached: arm
+`uloop enable-pause-point --mode trace` on the method's first line (and, when an early
+return is plausible, a second marker on the line whose effect you expect), then drive the
+game and compare hit counts — zero hits means the calling path never reached the method,
+which no patch can fix. Arm such markers after the hot-reload run, not before (see the
+pause point interaction below). The other known cause is JIT inlining of tiny methods,
+which the response already flags with a per-method warning.
 
 ## Convergence and lifecycle
 
@@ -87,10 +98,20 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 ## Pause point interaction
 
 Both patch shapes discard the original IL and any prior transpiler output on the patched
-method — delegation replaces the body with a forward to the shim — so a source pause point
-on a hot-reloaded method stops firing until the patch is reverted (`--revert-all`) or a
-domain reload restores the original IL. Apply responses include this as a `Warnings` entry
-whenever any method was patched.
+method — delegation replaces the body with a forward to the shim. The interaction with
+source pause points is therefore order-dependent:
+
+- A pause point armed **before** a hot reload of the same method silently stops firing —
+  its instrumentation was part of the discarded IL. `pause-point-status` still reports
+  `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
+  whenever any method was patched.
+- A pause point armed (or re-armed) **after** the hot reload fires normally on the
+  patched method.
+- `--revert-all` (or a domain reload) restores the original IL, and previously armed
+  pause points fire again.
+
+So hot reload and pause points do compose: after each `uloop hot-reload` run, re-arm any
+pause point that targets a patched method.
 
 ## Output
 

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -80,8 +80,11 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 the patch, confirm the method is actually reached: arm
 `uloop enable-pause-point --mode trace` on the method's first line, then drive the game
 and check the hit count — zero hits means the calling path never reached the method,
-which no patch can fix. Arm the marker after the hot-reload run, not before, and keep it
-on the first line: on a currently patched method, deeper lines and local capture resolve
+which no patch can fix. Arm the marker after the hot-reload run, not before — and if the
+same marker already existed, clear it and enable it again, because re-enabling an
+existing marker re-arms its hit counter without re-injecting the discarded
+instrumentation. Keep it on the first line: on a currently patched method, deeper lines
+and local capture resolve
 against the pre-patch compiled body and are not reliable (see the pause point interaction
 below). To chase an early return inside the method, revert or `uloop compile` first. The
 other known cause is JIT inlining of tiny methods, which the response already flags with
@@ -107,17 +110,20 @@ source pause points is therefore order-dependent:
   its instrumentation was part of the discarded IL. `pause-point-status` still reports
   `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
   whenever any method was patched.
-- A pause point armed (or re-armed) **after** the hot reload fires on the method's
-  first line and captures parameters and `this` fields normally. Markers on deeper
-  lines — and captured method locals — resolve against the pre-patch compiled body,
-  so they may land on the wrong instruction or read stale slots; treat them as
+- A pause point enabled fresh **after** the hot reload fires on the method's first
+  line and captures parameters and `this` fields normally. Re-enabling a marker that
+  was already armed before the hot reload does not recover it: the patcher treats a
+  known marker id as a no-op, re-arming the hit counter without re-injecting the
+  discarded instrumentation — clear the marker, then enable it again. Markers on
+  deeper lines — and captured method locals — resolve against the pre-patch compiled
+  body, so they may land on the wrong instruction or read stale slots; treat them as
   unreliable until the patch is reverted or compiled for real.
 - `--revert-all` (or a domain reload) restores the original IL, and previously armed
   pause points fire again.
 
 So hot reload and pause points do compose for reachability checks: after each
-`uloop hot-reload` run, re-arm first-line markers on patched methods, and defer
-deeper markers until `--revert-all` or a real `uloop compile`.
+`uloop hot-reload` run, clear and re-enable first-line markers on patched methods,
+and defer deeper markers until `--revert-all` or a real `uloop compile`.
 
 ## Output
 

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -71,19 +71,21 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
-| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the underlying engine error; other methods in the run still apply |
+| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 
 ## When a patch reports `Patched` but behavior does not change
 
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
 the patch, confirm the method is actually reached: arm
-`uloop enable-pause-point --mode trace` on the method's first line (and, when an early
-return is plausible, a second marker on the line whose effect you expect), then drive the
-game and compare hit counts — zero hits means the calling path never reached the method,
-which no patch can fix. Arm such markers after the hot-reload run, not before (see the
-pause point interaction below). The other known cause is JIT inlining of tiny methods,
-which the response already flags with a per-method warning.
+`uloop enable-pause-point --mode trace` on the method's first line, then drive the game
+and check the hit count — zero hits means the calling path never reached the method,
+which no patch can fix. Arm the marker after the hot-reload run, not before, and keep it
+on the first line: on a currently patched method, deeper lines and local capture resolve
+against the pre-patch compiled body and are not reliable (see the pause point interaction
+below). To chase an early return inside the method, revert or `uloop compile` first. The
+other known cause is JIT inlining of tiny methods, which the response already flags with
+a per-method warning.
 
 ## Convergence and lifecycle
 
@@ -105,13 +107,17 @@ source pause points is therefore order-dependent:
   its instrumentation was part of the discarded IL. `pause-point-status` still reports
   `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
   whenever any method was patched.
-- A pause point armed (or re-armed) **after** the hot reload fires normally on the
-  patched method.
+- A pause point armed (or re-armed) **after** the hot reload fires on the method's
+  first line and captures parameters and `this` fields normally. Markers on deeper
+  lines — and captured method locals — resolve against the pre-patch compiled body,
+  so they may land on the wrong instruction or read stale slots; treat them as
+  unreliable until the patch is reverted or compiled for real.
 - `--revert-all` (or a domain reload) restores the original IL, and previously armed
   pause points fire again.
 
-So hot reload and pause points do compose: after each `uloop hot-reload` run, re-arm any
-pause point that targets a patched method.
+So hot reload and pause points do compose for reachability checks: after each
+`uloop hot-reload` run, re-arm first-line markers on patched methods, and defer
+deeper markers until `--revert-all` or a real `uloop compile`.
 
 ## Output
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -71,8 +71,19 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
-| Patch rejected at apply time (e.g. `[BurstCompile]`) | Not patchable by Harmony transplant |
+| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
+
+## When a patch reports `Patched` but behavior does not change
+
+`Patched` means the method body was replaced, not that the method ran. Before suspecting
+the patch, confirm the method is actually reached: arm
+`uloop enable-pause-point --mode trace` on the method's first line (and, when an early
+return is plausible, a second marker on the line whose effect you expect), then drive the
+game and compare hit counts — zero hits means the calling path never reached the method,
+which no patch can fix. Arm such markers after the hot-reload run, not before (see the
+pause point interaction below). The other known cause is JIT inlining of tiny methods,
+which the response already flags with a per-method warning.
 
 ## Convergence and lifecycle
 
@@ -87,10 +98,20 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 ## Pause point interaction
 
 Both patch shapes discard the original IL and any prior transpiler output on the patched
-method — delegation replaces the body with a forward to the shim — so a source pause point
-on a hot-reloaded method stops firing until the patch is reverted (`--revert-all`) or a
-domain reload restores the original IL. Apply responses include this as a `Warnings` entry
-whenever any method was patched.
+method — delegation replaces the body with a forward to the shim. The interaction with
+source pause points is therefore order-dependent:
+
+- A pause point armed **before** a hot reload of the same method silently stops firing —
+  its instrumentation was part of the discarded IL. `pause-point-status` still reports
+  `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
+  whenever any method was patched.
+- A pause point armed (or re-armed) **after** the hot reload fires normally on the
+  patched method.
+- `--revert-all` (or a domain reload) restores the original IL, and previously armed
+  pause points fire again.
+
+So hot reload and pause points do compose: after each `uloop hot-reload` run, re-arm any
+pause point that targets a patched method.
 
 ## Output
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -80,8 +80,11 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 the patch, confirm the method is actually reached: arm
 `uloop enable-pause-point --mode trace` on the method's first line, then drive the game
 and check the hit count — zero hits means the calling path never reached the method,
-which no patch can fix. Arm the marker after the hot-reload run, not before, and keep it
-on the first line: on a currently patched method, deeper lines and local capture resolve
+which no patch can fix. Arm the marker after the hot-reload run, not before — and if the
+same marker already existed, clear it and enable it again, because re-enabling an
+existing marker re-arms its hit counter without re-injecting the discarded
+instrumentation. Keep it on the first line: on a currently patched method, deeper lines
+and local capture resolve
 against the pre-patch compiled body and are not reliable (see the pause point interaction
 below). To chase an early return inside the method, revert or `uloop compile` first. The
 other known cause is JIT inlining of tiny methods, which the response already flags with
@@ -107,17 +110,20 @@ source pause points is therefore order-dependent:
   its instrumentation was part of the discarded IL. `pause-point-status` still reports
   `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
   whenever any method was patched.
-- A pause point armed (or re-armed) **after** the hot reload fires on the method's
-  first line and captures parameters and `this` fields normally. Markers on deeper
-  lines — and captured method locals — resolve against the pre-patch compiled body,
-  so they may land on the wrong instruction or read stale slots; treat them as
+- A pause point enabled fresh **after** the hot reload fires on the method's first
+  line and captures parameters and `this` fields normally. Re-enabling a marker that
+  was already armed before the hot reload does not recover it: the patcher treats a
+  known marker id as a no-op, re-arming the hit counter without re-injecting the
+  discarded instrumentation — clear the marker, then enable it again. Markers on
+  deeper lines — and captured method locals — resolve against the pre-patch compiled
+  body, so they may land on the wrong instruction or read stale slots; treat them as
   unreliable until the patch is reverted or compiled for real.
 - `--revert-all` (or a domain reload) restores the original IL, and previously armed
   pause points fire again.
 
 So hot reload and pause points do compose for reachability checks: after each
-`uloop hot-reload` run, re-arm first-line markers on patched methods, and defer
-deeper markers until `--revert-all` or a real `uloop compile`.
+`uloop hot-reload` run, clear and re-enable first-line markers on patched methods,
+and defer deeper markers until `--revert-all` or a real `uloop compile`.
 
 ## Output
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -71,19 +71,21 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
-| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the underlying engine error; other methods in the run still apply |
+| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 
 ## When a patch reports `Patched` but behavior does not change
 
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
 the patch, confirm the method is actually reached: arm
-`uloop enable-pause-point --mode trace` on the method's first line (and, when an early
-return is plausible, a second marker on the line whose effect you expect), then drive the
-game and compare hit counts — zero hits means the calling path never reached the method,
-which no patch can fix. Arm such markers after the hot-reload run, not before (see the
-pause point interaction below). The other known cause is JIT inlining of tiny methods,
-which the response already flags with a per-method warning.
+`uloop enable-pause-point --mode trace` on the method's first line, then drive the game
+and check the hit count — zero hits means the calling path never reached the method,
+which no patch can fix. Arm the marker after the hot-reload run, not before, and keep it
+on the first line: on a currently patched method, deeper lines and local capture resolve
+against the pre-patch compiled body and are not reliable (see the pause point interaction
+below). To chase an early return inside the method, revert or `uloop compile` first. The
+other known cause is JIT inlining of tiny methods, which the response already flags with
+a per-method warning.
 
 ## Convergence and lifecycle
 
@@ -105,13 +107,17 @@ source pause points is therefore order-dependent:
   its instrumentation was part of the discarded IL. `pause-point-status` still reports
   `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
   whenever any method was patched.
-- A pause point armed (or re-armed) **after** the hot reload fires normally on the
-  patched method.
+- A pause point armed (or re-armed) **after** the hot reload fires on the method's
+  first line and captures parameters and `this` fields normally. Markers on deeper
+  lines — and captured method locals — resolve against the pre-patch compiled body,
+  so they may land on the wrong instruction or read stale slots; treat them as
+  unreliable until the patch is reverted or compiled for real.
 - `--revert-all` (or a domain reload) restores the original IL, and previously armed
   pause points fire again.
 
-So hot reload and pause points do compose: after each `uloop hot-reload` run, re-arm any
-pause point that targets a patched method.
+So hot reload and pause points do compose for reachability checks: after each
+`uloop hot-reload` run, re-arm first-line markers on patched methods, and defer
+deeper markers until `--revert-all` or a real `uloop compile`.
 
 ## Output
 

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
+using UnityEngine;
+
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
     /// <summary>
@@ -134,6 +136,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public int SumGrid(int[,] grid)
         {
             return -1;
+        }
+
+        // Patch target for the struct-return control-flow e2e (foreign-label regression).
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public Vector3 CenterOfCell(Vector3Int cell)
+        {
+            return Vector3.zero;
         }
 
         // Nested constructed generic parameter — worker manifest must emit Cecil's FullName shape.

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -170,6 +170,46 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a struct-returning method with a loop transplants through the full pipeline
+        /// (edit → worker → shim compile → transplant) and computes the edited value.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedStructReturnLoopMethod_PatchesBehavior()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "CenterOfCell.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    centerOfCellMethod:
+                    "[MethodImpl(MethodImplOptions.NoInlining)]\n"
+                    + "        public Vector3 CenterOfCell(Vector3Int cell)\n"
+                    + "        {\n"
+                    + "            Vector3 center = Vector3.zero;\n"
+                    + "            for (int i = 0; i < 1; i++)\n"
+                    + "            {\n"
+                    + "                center = new Vector3(cell.x + 0.5f, cell.y + 0.5f, cell.z + 0.5f);\n"
+                    + "            }\n"
+                    + "\n"
+                    + "            return center;\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.CenterOfCell));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(
+                fixture.CenterOfCell(new Vector3Int(1, 2, 3)),
+                Is.EqualTo(new Vector3(1.5f, 2.5f, 3.5f)));
+        }
+
+        /// <summary>
         /// What: a method containing base. is reported as Skipped with an explanatory reason.
         /// </summary>
         [Test]
@@ -739,7 +779,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string propertyPrivateRoundTripMethod = null,
             string asyncUsesInternalTypeMethod = null,
             string tuningConstDeclaration = null,
-            string modeEnumDeclaration = null)
+            string modeEnumDeclaration = null,
+            string centerOfCellMethod = null)
         {
             string sumGrid = sumGridMethod ??
                 "public int SumGrid(int[,] grid)\n        {\n            return -1;\n        }";
@@ -777,12 +818,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "private const int TuningConst = 3;";
             string modeEnum = modeEnumDeclaration ??
                 "public enum HotReloadE2EMode\n    {\n        Idle = 0,\n        Active = 1\n    }";
+            string centerOfCell = centerOfCellMethod ??
+                "[MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public Vector3 CenterOfCell(Vector3Int cell)\n"
+                + "        {\n"
+                + "            return Vector3.zero;\n"
+                + "        }";
 
             return @"using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
@@ -850,6 +898,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         " + sumGrid + @"
+
+        " + centerOfCell + @"
 
         public int CountEnumerator(List<int>.Enumerator enumerator)
         {

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -179,6 +179,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(0));
             Assert.That(await fixture.ReplaceableComputeAsync(5), Is.EqualTo(-5));
         }
+
+        [System.Runtime.InteropServices.DllImport("__Internal")]
+        private static extern int ExternShimStub(int value);
+
+        /// <summary>
+        /// What: an apply-time engine failure (here: a body-less extern shim whose
+        /// transplant JIT-compiles to invalid IL) returns a per-method Failure instead
+        /// of throwing, and leaves no ledger entry or active patch behind.
+        /// </summary>
+        [Test]
+        public void Apply_UnreadableShim_ReturnsFailureAndKeepsLedgerClean()
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadPatcherTests), nameof(ExternShimStub));
+
+            HotReloadPatchResult result = HotReloadPatcher.Apply(
+                original, shim, HotReloadPatchShape.Transplant);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.FailureReason, Is.EqualTo(HotReloadPatchFailureReason.ApplyFailed));
+            Assert.That(result.ErrorMessage, Does.Contain("ReplaceableCompute"));
+            Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(0));
+
+            HotReloadCoreFixture fixture = new HotReloadCoreFixture();
+            Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(-5), "Original body must survive.");
+        }
     }
 
     /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 using HarmonyLib;
@@ -180,7 +181,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(await fixture.ReplaceableComputeAsync(5), Is.EqualTo(-5));
         }
 
-        [System.Runtime.InteropServices.DllImport("__Internal")]
+        [DllImport("__Internal")]
         private static extern int ExternShimStub(int value);
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
@@ -87,6 +87,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return center;
         }
 
+        public static Vector3 ShimToCenterTryFinally(Vector3Int position)
+        {
+            Vector3 center = Vector3.zero;
+            try
+            {
+                center.x = position.x + 0.5f;
+                center.y = position.y + 0.5f;
+            }
+            finally
+            {
+                center.z = position.z + 0.5f;
+            }
+
+            return center;
+        }
+
         private static Vector3 ApplyAndInvoke(string shimName)
         {
             MethodInfo original = AccessTools.Method(
@@ -126,8 +142,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a single forward branch (debug-build return jump) lands on the correct
-        /// target — pins against silent mis-branching when label indices happen to collide.
+        /// What: a single forward branch (debug-build return jump) still lands on the correct
+        /// target after rebinding — the shape that passed only by label-index collision before
+        /// the fix.
         /// </summary>
         [Test]
         public void Apply_StructCtorReassignShim_TransplantsAndComputes()
@@ -146,6 +163,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             Assert.That(
                 ApplyAndInvoke(nameof(ShimToCenterSwitch)),
+                Is.EqualTo(new Vector3(1.5f, 2.5f, 3.5f)));
+        }
+
+        /// <summary>
+        /// What: a shim containing try/finally transplants — exception-block marks survive
+        /// the label rebind and the leave target still lands on the correct instruction.
+        /// </summary>
+        [Test]
+        public void Apply_StructTryFinallyShim_TransplantsAndComputes()
+        {
+            Assert.That(
+                ApplyAndInvoke(nameof(ShimToCenterTryFinally)),
                 Is.EqualTo(new Vector3(1.5f, 2.5f, 3.5f)));
         }
     }

--- a/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -103,6 +104,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return center;
         }
 
+        // Written by the finally block of ShimToCenterThrowInTry so the exceptional-path
+        // test can observe that the finally actually ran after the propagated throw.
+        private static int _finallySideEffect;
+
+        public static Vector3 ShimToCenterThrowInTry(Vector3Int position)
+        {
+            Vector3 center = Vector3.zero;
+            try
+            {
+                center.x = position.x + 0.5f;
+                if (position.x > 0)
+                {
+                    throw new InvalidOperationException(
+                        "Exceptional exit through the transplanted try body.");
+                }
+                center.y = position.y + 0.5f;
+            }
+            finally
+            {
+                _finallySideEffect = position.z;
+            }
+
+            return center;
+        }
+
         private static Vector3 ApplyAndInvoke(string shimName)
         {
             MethodInfo original = AccessTools.Method(
@@ -176,6 +202,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 ApplyAndInvoke(nameof(ShimToCenterTryFinally)),
                 Is.EqualTo(new Vector3(1.5f, 2.5f, 3.5f)));
+        }
+
+        /// <summary>
+        /// What: an exception thrown inside a transplanted try body still runs the finally
+        /// and propagates to the caller — the handler region survives the transplant
+        /// semantically, not just structurally.
+        /// </summary>
+        [Test]
+        public void Apply_StructThrowInTryShim_RunsFinallyAndPropagates()
+        {
+            _finallySideEffect = 0;
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadTransplantControlFlowTests), nameof(OriginalToCenter));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadTransplantControlFlowTests), nameof(ShimToCenterThrowInTry));
+
+            HotReloadPatchResult result = HotReloadPatcher.Apply(
+                original, shim, HotReloadPatchShape.Transplant);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            Assert.Throws<InvalidOperationException>(
+                () => OriginalToCenter(new Vector3Int(1, 2, 3)));
+            Assert.That(_finallySideEffect, Is.EqualTo(3));
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
@@ -1,0 +1,152 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using HarmonyLib;
+using NUnit.Framework;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Regression coverage for transplanting shim bodies whose IL carries branch labels
+    /// and struct locals. Labels read from the shim without the patch ILGenerator are
+    /// foreign to it and must be rebound, exactly like short-form locals.
+    /// </summary>
+    public class HotReloadTransplantControlFlowTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadPatcher.RevertAll();
+        }
+
+        // Why NoInlining: repo convention for patch-target fixtures — without it the
+        // x64 Mono JIT can inline this tiny body into ApplyAndInvoke, so the assertions
+        // would measure JIT inlining instead of patching.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static Vector3 OriginalToCenter(Vector3Int position)
+        {
+            return Vector3.zero;
+        }
+
+        public static Vector3 ShimToCenterLoop(Vector3Int position)
+        {
+            Vector3 center = Vector3.zero;
+            for (int i = 0; i < 1; i++)
+            {
+                center = new Vector3(position.x + 0.5f, position.y + 0.5f, position.z + 0.5f);
+            }
+
+            return center;
+        }
+
+        public static Vector3 ShimToCenterFieldWrites(Vector3Int position)
+        {
+            Vector3 center = Vector3.zero;
+            for (int i = 0; i < 1; i++)
+            {
+                center.x = position.x + 0.5f;
+                center.y = position.y + 0.5f;
+                center.z = position.z + 0.5f;
+            }
+
+            return center;
+        }
+
+        public static Vector3 ShimToCenterReassign(Vector3Int position)
+        {
+            Vector3 center = Vector3.zero;
+            center = new Vector3(position.x + 0.5f, position.y + 0.5f, position.z + 0.5f);
+            return center;
+        }
+
+        public static Vector3 ShimToCenterSwitch(Vector3Int position)
+        {
+            Vector3 center = Vector3.zero;
+            switch (position.x)
+            {
+                case 1:
+                    center = new Vector3(position.x + 0.5f, position.y + 0.5f, position.z + 0.5f);
+                    break;
+                case 2:
+                    center = Vector3.one;
+                    break;
+                case 3:
+                    center = Vector3.up;
+                    break;
+                case 4:
+                    center = Vector3.down;
+                    break;
+                default:
+                    center = Vector3.left;
+                    break;
+            }
+
+            return center;
+        }
+
+        private static Vector3 ApplyAndInvoke(string shimName)
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadTransplantControlFlowTests), nameof(OriginalToCenter));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadTransplantControlFlowTests), shimName);
+
+            HotReloadPatchResult result = HotReloadPatcher.Apply(
+                original, shim, HotReloadPatchShape.Transplant);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            return OriginalToCenter(new Vector3Int(1, 2, 3));
+        }
+
+        /// <summary>
+        /// What: a struct-returning shim with a loop (backward branch) transplants and
+        /// computes the edited value — the field-reported crash shape.
+        /// </summary>
+        [Test]
+        public void Apply_StructReturnShimWithLoop_TransplantsAndComputes()
+        {
+            Assert.That(
+                ApplyAndInvoke(nameof(ShimToCenterLoop)),
+                Is.EqualTo(new Vector3(1.5f, 2.5f, 3.5f)));
+        }
+
+        /// <summary>
+        /// What: control flow plus struct-local field writes (no ctor call) transplants —
+        /// isolates the branch labels from the ctor-call IL shape.
+        /// </summary>
+        [Test]
+        public void Apply_StructFieldWritesShimWithLoop_TransplantsAndComputes()
+        {
+            Assert.That(
+                ApplyAndInvoke(nameof(ShimToCenterFieldWrites)),
+                Is.EqualTo(new Vector3(1.5f, 2.5f, 3.5f)));
+        }
+
+        /// <summary>
+        /// What: a single forward branch (debug-build return jump) lands on the correct
+        /// target — pins against silent mis-branching when label indices happen to collide.
+        /// </summary>
+        [Test]
+        public void Apply_StructCtorReassignShim_TransplantsAndComputes()
+        {
+            Assert.That(
+                ApplyAndInvoke(nameof(ShimToCenterReassign)),
+                Is.EqualTo(new Vector3(1.5f, 2.5f, 3.5f)));
+        }
+
+        /// <summary>
+        /// What: a dense switch body transplants and picks the right arm — the shape
+        /// Roslyn compiles to the multi-target switch opcode (Label[] operand).
+        /// </summary>
+        [Test]
+        public void Apply_StructSwitchShim_TransplantsAndComputes()
+        {
+            Assert.That(
+                ApplyAndInvoke(nameof(ShimToCenterSwitch)),
+                Is.EqualTo(new Vector3(1.5f, 2.5f, 3.5f)));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 131b608c2c3e5487e8665e407c226ad1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchFailureReason.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchFailureReason.cs
@@ -13,5 +13,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         UnpatchableValueType,
         NullMethod,
         NullShimMethod,
+        ApplyFailed,
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -89,6 +89,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     transpiler: new HarmonyMethod(transpilerMethodInfo));
                 ShimByMethod[method] = shimMethodInfo;
             }
+            catch (Exception exception)
+            {
+                // User-approved exception to the no-try-catch policy: Harmony emit/JIT
+                // failures cannot be pre-validated (the IL shape is only known inside
+                // Harmony), and an escaping exception would abort the whole run while
+                // silently leaving previously patched methods active. Contain it as this
+                // method's Failed outcome so the per-method contract holds. Unpatch scrubs
+                // the transpiler Harmony may have registered before the wrapper update
+                // failed (a no-op when nothing was registered).
+                HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
+                return HotReloadPatchResult.Failure(
+                    HotReloadPatchFailureReason.ApplyFailed,
+                    $"Applying the patch to '{method}' failed: " +
+                    $"{exception.GetType().Name}: {exception.Message} " +
+                    "Other methods in this run are unaffected.");
+            }
             finally
             {
                 _pendingShimMethod = null;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -41,6 +41,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Patches <paramref name="method"/> with <paramref name="shimMethodInfo"/> using
         /// <paramref name="patchShape"/>. Re-applying the same method Unpatches the previous
         /// transpiler first so patches do not stack.
+        /// Engine failures during apply never throw; they are contained as an
+        /// <see cref="HotReloadPatchFailureReason.ApplyFailed"/> result for that method only.
         /// </summary>
         public static HotReloadPatchResult Apply(
             MethodBase method,
@@ -95,14 +97,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // failures cannot be pre-validated (the IL shape is only known inside
                 // Harmony), and an escaping exception would abort the whole run while
                 // silently leaving previously patched methods active. Contain it as this
-                // method's Failed outcome so the per-method contract holds. Unpatch scrubs
-                // the transpiler Harmony may have registered before the wrapper update
-                // failed (a no-op when nothing was registered).
+                // method's Failed outcome so the per-method contract holds. Unpatch removes
+                // the transpiler this call registered before failing and rebuilds the
+                // wrapper, restoring the original body (verified by the extern-shim test).
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
+                Exception rootCause = exception;
+                while (rootCause.InnerException != null)
+                {
+                    rootCause = rootCause.InnerException;
+                }
+
+                string rootCauseSuffix = ReferenceEquals(rootCause, exception)
+                    ? string.Empty
+                    : $" (root cause: {rootCause.GetType().Name}: {rootCause.Message})";
                 return HotReloadPatchResult.Failure(
                     HotReloadPatchFailureReason.ApplyFailed,
                     $"Applying the patch to '{method}' failed: " +
-                    $"{exception.GetType().Name}: {exception.Message} " +
+                    $"{exception.GetType().Name}: {exception.Message}{rootCauseSuffix} " +
                     "Other methods in this run are unaffected.");
             }
             finally
@@ -314,6 +325,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // collide with labels it did define.
         private static void RebindLabels(ILGenerator generator, List<CodeInstruction> instructions)
         {
+            Debug.Assert(generator != null, "RebindLabels requires the patch method ILGenerator.");
+            Debug.Assert(instructions != null, "RebindLabels requires the transplanted instructions.");
+
             Dictionary<Label, Label> ownedLabelByForeign = new Dictionary<Label, Label>();
 
             for (int instructionIndex = 0; instructionIndex < instructions.Count; instructionIndex++)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -128,9 +128,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // declare locals on THIS patch ILGenerator and rebind short-form ldloc/stloc onto those
             // LocalBuilders. Numeric short-forms left as-is produce InvalidProgramException after
             // transplant when the shim body has locals (typical for object-initializer locals).
+            // Labels need the same treatment: see RebindLabels below.
             List<CodeInstruction> transplanted =
                 new List<CodeInstruction>(PatchProcessor.GetOriginalInstructions(shimMethod));
             RebindShortFormLocals(shimMethod, generator, transplanted);
+            RebindLabels(generator, transplanted);
             return transplanted;
         }
 
@@ -287,6 +289,57 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     blocks = instruction.blocks
                 };
             }
+        }
+
+        // Labels read from the shim without this patch's ILGenerator belong to a throwaway
+        // generator (same failure family as the LocalBuilder rebinding above): the real
+        // CecilILGenerator resolves Label structs against its own table, so a foreign label
+        // NREs at emit — or silently branches to the wrong target when indices happen to
+        // collide with labels it did define.
+        private static void RebindLabels(ILGenerator generator, List<CodeInstruction> instructions)
+        {
+            Dictionary<Label, Label> ownedLabelByForeign = new Dictionary<Label, Label>();
+
+            for (int instructionIndex = 0; instructionIndex < instructions.Count; instructionIndex++)
+            {
+                CodeInstruction instruction = instructions[instructionIndex];
+                if (instruction.operand is Label foreignTarget)
+                {
+                    instruction.operand = RemapLabel(generator, ownedLabelByForeign, foreignTarget);
+                }
+                else if (instruction.operand is Label[] foreignTargets)
+                {
+                    Label[] ownedTargets = new Label[foreignTargets.Length];
+                    for (int targetIndex = 0; targetIndex < foreignTargets.Length; targetIndex++)
+                    {
+                        ownedTargets[targetIndex] =
+                            RemapLabel(generator, ownedLabelByForeign, foreignTargets[targetIndex]);
+                    }
+
+                    instruction.operand = ownedTargets;
+                }
+
+                for (int labelIndex = 0; labelIndex < instruction.labels.Count; labelIndex++)
+                {
+                    instruction.labels[labelIndex] =
+                        RemapLabel(generator, ownedLabelByForeign, instruction.labels[labelIndex]);
+                }
+            }
+        }
+
+        private static Label RemapLabel(
+            ILGenerator generator,
+            Dictionary<Label, Label> ownedLabelByForeign,
+            Label foreignLabel)
+        {
+            if (ownedLabelByForeign.TryGetValue(foreignLabel, out Label ownedLabel))
+            {
+                return ownedLabel;
+            }
+
+            ownedLabel = generator.DefineLabel();
+            ownedLabelByForeign[foreignLabel] = ownedLabel;
+            return ownedLabel;
         }
 
         private static bool TryGetLocalOpcodeShape(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -71,8 +71,19 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
-| Patch rejected at apply time (e.g. `[BurstCompile]`) | Not patchable by Harmony transplant |
+| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
+
+## When a patch reports `Patched` but behavior does not change
+
+`Patched` means the method body was replaced, not that the method ran. Before suspecting
+the patch, confirm the method is actually reached: arm
+`uloop enable-pause-point --mode trace` on the method's first line (and, when an early
+return is plausible, a second marker on the line whose effect you expect), then drive the
+game and compare hit counts — zero hits means the calling path never reached the method,
+which no patch can fix. Arm such markers after the hot-reload run, not before (see the
+pause point interaction below). The other known cause is JIT inlining of tiny methods,
+which the response already flags with a per-method warning.
 
 ## Convergence and lifecycle
 
@@ -87,10 +98,20 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 ## Pause point interaction
 
 Both patch shapes discard the original IL and any prior transpiler output on the patched
-method — delegation replaces the body with a forward to the shim — so a source pause point
-on a hot-reloaded method stops firing until the patch is reverted (`--revert-all`) or a
-domain reload restores the original IL. Apply responses include this as a `Warnings` entry
-whenever any method was patched.
+method — delegation replaces the body with a forward to the shim. The interaction with
+source pause points is therefore order-dependent:
+
+- A pause point armed **before** a hot reload of the same method silently stops firing —
+  its instrumentation was part of the discarded IL. `pause-point-status` still reports
+  `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
+  whenever any method was patched.
+- A pause point armed (or re-armed) **after** the hot reload fires normally on the
+  patched method.
+- `--revert-all` (or a domain reload) restores the original IL, and previously armed
+  pause points fire again.
+
+So hot reload and pause points do compose: after each `uloop hot-reload` run, re-arm any
+pause point that targets a patched method.
 
 ## Output
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -80,8 +80,11 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 the patch, confirm the method is actually reached: arm
 `uloop enable-pause-point --mode trace` on the method's first line, then drive the game
 and check the hit count — zero hits means the calling path never reached the method,
-which no patch can fix. Arm the marker after the hot-reload run, not before, and keep it
-on the first line: on a currently patched method, deeper lines and local capture resolve
+which no patch can fix. Arm the marker after the hot-reload run, not before — and if the
+same marker already existed, clear it and enable it again, because re-enabling an
+existing marker re-arms its hit counter without re-injecting the discarded
+instrumentation. Keep it on the first line: on a currently patched method, deeper lines
+and local capture resolve
 against the pre-patch compiled body and are not reliable (see the pause point interaction
 below). To chase an early return inside the method, revert or `uloop compile` first. The
 other known cause is JIT inlining of tiny methods, which the response already flags with
@@ -107,17 +110,20 @@ source pause points is therefore order-dependent:
   its instrumentation was part of the discarded IL. `pause-point-status` still reports
   `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
   whenever any method was patched.
-- A pause point armed (or re-armed) **after** the hot reload fires on the method's
-  first line and captures parameters and `this` fields normally. Markers on deeper
-  lines — and captured method locals — resolve against the pre-patch compiled body,
-  so they may land on the wrong instruction or read stale slots; treat them as
+- A pause point enabled fresh **after** the hot reload fires on the method's first
+  line and captures parameters and `this` fields normally. Re-enabling a marker that
+  was already armed before the hot reload does not recover it: the patcher treats a
+  known marker id as a no-op, re-arming the hit counter without re-injecting the
+  discarded instrumentation — clear the marker, then enable it again. Markers on
+  deeper lines — and captured method locals — resolve against the pre-patch compiled
+  body, so they may land on the wrong instruction or read stale slots; treat them as
   unreliable until the patch is reverted or compiled for real.
 - `--revert-all` (or a domain reload) restores the original IL, and previously armed
   pause points fire again.
 
 So hot reload and pause points do compose for reachability checks: after each
-`uloop hot-reload` run, re-arm first-line markers on patched methods, and defer
-deeper markers until `--revert-all` or a real `uloop compile`.
+`uloop hot-reload` run, clear and re-enable first-line markers on patched methods,
+and defer deeper markers until `--revert-all` or a real `uloop compile`.
 
 ## Output
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -71,19 +71,21 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
-| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the underlying engine error; other methods in the run still apply |
+| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 
 ## When a patch reports `Patched` but behavior does not change
 
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
 the patch, confirm the method is actually reached: arm
-`uloop enable-pause-point --mode trace` on the method's first line (and, when an early
-return is plausible, a second marker on the line whose effect you expect), then drive the
-game and compare hit counts — zero hits means the calling path never reached the method,
-which no patch can fix. Arm such markers after the hot-reload run, not before (see the
-pause point interaction below). The other known cause is JIT inlining of tiny methods,
-which the response already flags with a per-method warning.
+`uloop enable-pause-point --mode trace` on the method's first line, then drive the game
+and check the hit count — zero hits means the calling path never reached the method,
+which no patch can fix. Arm the marker after the hot-reload run, not before, and keep it
+on the first line: on a currently patched method, deeper lines and local capture resolve
+against the pre-patch compiled body and are not reliable (see the pause point interaction
+below). To chase an early return inside the method, revert or `uloop compile` first. The
+other known cause is JIT inlining of tiny methods, which the response already flags with
+a per-method warning.
 
 ## Convergence and lifecycle
 
@@ -105,13 +107,17 @@ source pause points is therefore order-dependent:
   its instrumentation was part of the discarded IL. `pause-point-status` still reports
   `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
   whenever any method was patched.
-- A pause point armed (or re-armed) **after** the hot reload fires normally on the
-  patched method.
+- A pause point armed (or re-armed) **after** the hot reload fires on the method's
+  first line and captures parameters and `this` fields normally. Markers on deeper
+  lines — and captured method locals — resolve against the pre-patch compiled body,
+  so they may land on the wrong instruction or read stale slots; treat them as
+  unreliable until the patch is reverted or compiled for real.
 - `--revert-all` (or a domain reload) restores the original IL, and previously armed
   pause points fire again.
 
-So hot reload and pause points do compose: after each `uloop hot-reload` run, re-arm any
-pause point that targets a patched method.
+So hot reload and pause points do compose for reachability checks: after each
+`uloop hot-reload` run, re-arm first-line markers on patched methods, and defer
+deeper markers until `--revert-all` or a real `uloop compile`.
 
 ## Output
 

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -120,6 +120,13 @@ of a prefix).
 **Transplant-primary.** Stage (5) applies a Harmony transpiler per patched method that
 replaces the original instructions with the shim method's instructions.
 
+The transpiler reads the shim body without the patch `ILGenerator`, so both `LocalBuilder`
+operands and branch `Label`s arrive owned by a throwaway generator; the patcher re-declares
+the locals and re-defines the labels on the real generator and rebinds every reference
+(including `switch` target arrays and instruction label marks) before emitting. A foreign
+label otherwise NREs at emit, or silently branches to the wrong target when indices happen
+to collide.
+
 Why transplant over the accessor rewrite:
 
 - The worker-side transform stays exactly the qualification rewrite stage (2) already needs


### PR DESCRIPTION
## Summary

- **Foreign-label transplant crash (H-1):** shim IL read without the patch `ILGenerator` carries foreign `Label`s. `CecilILGenerator` then NREs at emit (struct + loop field reports) or silently mis-branches when indices collide. Rebind every `Label` / `Label[]` operand and instruction mark onto the real generator, same family as the existing short-form local rebind.
- **Partial-patch leak on apply failure (H-2):** Harmony emit/JIT exceptions escaped `Apply`, aborted the whole run with `UNITY_RPC_ERROR` and no `Methods` array, and left earlier patches in the same run active — violating the skill contract that one unpatchable method never aborts the rest. Contain those failures as per-method `ApplyFailed`, Unpatch any half-registered transpiler, and keep the rest of the run going.
- **Skill / docs:** document that `Patched` does not prove the method ran, that pause-point interaction is order-dependent, and that Label rebinding is part of the transplant mechanism.

## Test plan

- [x] `uloop compile` → 0 errors / 0 warnings
- [x] EditMode HotReload suite → 72 passed / 0 failed
- [x] H-1 Red: Loop + FieldWrites (+ Switch) NRE via DynEmit; Reassign passed by label collision
- [x] H-2 Red: `InvalidProgramException` from `UpdateWrapper` → `Harmony.Patch` → `Apply`
- [x] `scripts/regression-harness-hot-reload.sh` → `PASS: hot-reload changed PlayMode logs and revert-all restored the previous body.`
- [x] Complexity: `HotReloadPatcher` not in CA1502 findings (pre-existing HotReload Orchestrator/TransformWorker findings unchanged)
- [x] `scripts/sync-tool-docs.sh --check` matches


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

